### PR TITLE
fix(codebase-sort): fixing codebase sorting issue

### DIFF
--- a/src/app/create/codebases/codebases.component.ts
+++ b/src/app/create/codebases/codebases.component.ts
@@ -153,6 +153,13 @@ export class CodebasesComponent implements OnDestroy, OnInit {
 
   compare(codebase1: Codebase, codebase2: Codebase): number {
     var compValue = 0;
+
+    // this is necessary because the first item in the codebases array
+    // is an empty object that is needed to create the headers of the table
+    if (!Object.keys(codebase1).length || !Object.keys(codebase2).length) {
+      return compValue;
+    }
+
     if (this.currentSortField.id === 'name') {
       compValue = codebase1.name.localeCompare(codebase2.name);
     } else if (this.currentSortField.id === 'createdAt') {


### PR DESCRIPTION
After the codebases are fetched, an empty object is added to the beginning of the codebases array
for table header display purposes. When sorting happens, the sort function is trying compare
properties on the object and the empty object added at the beginning obviously does not have any
properties. So if the object is empty, skip it and return 0

fixes #1456

