### PR TITLE
fix(title): remove duplicate title in wizard

### DIFF
--- a/src/app/profile/overview/spaces/spaces.component.html
+++ b/src/app/profile/overview/spaces/spaces.component.html
@@ -11,7 +11,7 @@
            target="_blank">in the documentation</a>
       </p>
       <div class="blank-slate-pf-main-action">
-        <button class="btn btn-primary btn-lg" (click)="createSpace.open()">Create a Space</button>
+        <button class="btn btn-primary btn-lg" (click)="createSpace.open()">Create</button>
       </div>
     </div>
   </div>
@@ -47,7 +47,7 @@
 </ng-template>
 
 <!-- Create Space modal -->
-<modal #createSpace title="Create new space">
+<modal #createSpace>
   <modal-content>
     <space-wizard [host]="createSpace"></space-wizard>
   </modal-content>

--- a/src/app/space-wizard/components/space-creator/space-creator.component.html
+++ b/src/app/space-wizard/components/space-creator/space-creator.component.html
@@ -68,7 +68,7 @@
   <footer class="container-fluid padding-top-standard-offset padding-bottom-standard-offset">
     <div class="row">
       <div class="col-sm-12 wizard-step-tool-bar button-right">
-        <button id="createSpaceButton" class="btn btn-primary" [disabled]="!spaceForm.form.valid" type="submit">Create Space</button>
+        <button id="createSpaceButton" class="btn btn-primary" [disabled]="!spaceForm.form.valid" type="submit">Create</button>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
remove the duplicate 'Create Space' title from the Space Wizard when creating a new Space from a user's profile. As the Space Creator component contains the title, it does not need to be passed by the page to the modal itself.

fixes https://github.com/fabric8-ui/fabric8-ui/issues/1627

