### PR TITLE
fix(widget): remove Learn More from WI widget

### DIFF
--- a/src/app/home/work-item-widget/work-item-widget.component.html
+++ b/src/app/home/work-item-widget/work-item-widget.component.html
@@ -25,12 +25,6 @@
         </div>
         <p>Work items reflect the work to be done within a space.</p>
         <p>Once you create a space or join a space, your work items will begin displaying here.</p>
-        <p>Learn how to get started
-          <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift.io/1/html-single/user_guide"
-             target="_blank">
-            in the documentation
-          </a>
-        </p>
       </div>
     </ng-template>
     <ng-template #showWorkItems>


### PR DESCRIPTION
remove the Learn More link from the WI widget on the Home dashboard

closes https://github.com/fabric8-ui/fabric8-ux/issues/527

