### PR TITLE
fix(wizard): fix alignment of dropdown and input

### DIFF
--- a/src/app/space-wizard/components/app-generator-single-selection-dropdown/app-generator-single-selection-dropdown.component.less
+++ b/src/app/space-wizard/components/app-generator-single-selection-dropdown/app-generator-single-selection-dropdown.component.less
@@ -5,6 +5,8 @@
   .combobox-container {
     input[type='text'] {
       &.combobox {
+        top: 0;
+        left: 0;
         background-color: @color-pf-white;
         color: inherit;
       }


### PR DESCRIPTION
fix the alignment of the dropdown and input boxes after style updates

**Updated Views**
<img width="918" alt="screen shot 2017-07-10 at 9 15 42 am" src="https://user-images.githubusercontent.com/4032718/28019875-6e60e430-6550-11e7-8814-80af51ccbdb5.png">

<img width="905" alt="screen shot 2017-07-10 at 9 15 53 am" src="https://user-images.githubusercontent.com/4032718/28019883-71572122-6550-11e7-8a8a-62a58135742c.png">
