### PR TITLE
fix(user-menu): remove Help from user menu

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -115,11 +115,6 @@
                   Profile
                 </a>
               </li>
-              <li id="header_loggedinHelp">
-                <a href="https://fabric8.io/guide/getStarted/index.html">
-                  Help
-                </a>
-              </li>
               <li id="header_loggedinAbout">
                 <a (click)="aboutModal.open()" class="pointer">
                   About


### PR DESCRIPTION
remove the Help section from the user menu, as it does not direct to OpenShift.io documentation

