### PR TITLE
fix(button): fix context button event handling

### DIFF
--- a/src/app/shared/experimental-feature.resolver.ts
+++ b/src/app/shared/experimental-feature.resolver.ts
@@ -14,37 +14,38 @@ import { FeatureFlagConfig } from '../models/feature-flag-config';
 @Injectable()
 export class ExperimentalFeatureResolver implements Resolve<FeatureFlagConfig> {
 
-  private _loggedInUser: User;
-
   constructor(private router: Router, private userService: UserService, private authService: AuthenticationService) {
-    if(authService.isLoggedIn()) {
-      userService.loggedInUser.subscribe((user) => {
-        this._loggedInUser = user;
-      });
-    }
   }
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureFlagConfig> {
-    // Resolve the context
     let featureName = route.data["featureName"];
-    let experimentalFeaturesEnabled = false;
-    if (this._loggedInUser && this._loggedInUser.attributes) {
-      let contextInformation = this._loggedInUser.attributes["contextInformation"];
-      if (contextInformation && contextInformation.experimentalFeatures ) {
-        experimentalFeaturesEnabled =  contextInformation.experimentalFeatures["enabled"];
-      }
-    }
-
-    if (!this.authService.isLoggedIn()) {
+    let experimentalFeaturesEnabled = true;
+    if(this.authService.isLoggedIn()) {
+      return this.userService.loggedInUser.map((user) => {
+        let loggedInUser = user;
+        // Resolve the context
+        let experimentalFeaturesEnabled = false;
+        if (loggedInUser && loggedInUser.attributes) {
+          let contextInformation = loggedInUser.attributes["contextInformation"];
+          if (contextInformation && contextInformation.experimentalFeatures ) {
+            experimentalFeaturesEnabled =  contextInformation.experimentalFeatures["enabled"];
+          }
+        }
+        return {
+          name: featureName,
+          showBanner: true,
+          enabled: experimentalFeaturesEnabled
+        } as FeatureFlagConfig;
+      }).take(1);
+    } else  {
       // enable experimental features for all non-logged in users
       experimentalFeaturesEnabled = true;
+      return Observable.of({
+        name: featureName,
+        showBanner: true,
+        enabled: experimentalFeaturesEnabled
+      } as FeatureFlagConfig);
     }
-
-    return Observable.of({
-      name: featureName,
-      showBanner: true,
-      enabled: experimentalFeaturesEnabled
-    } as FeatureFlagConfig);
   }
 
 }


### PR DESCRIPTION
We need to make sure the user's profile is successfully reloaded after this setting is changed within the context.  Had to reorder events in the resolver to ensure this happens.

Tested in planner - enabling in profile and in planner and also when not logged in.