### PR TITLE
Fixed update profile navigation

### DIFF
--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -69,8 +69,6 @@
                     [charsMaxLimit]="255"
                     [charsRemainingElement]="remainingCountElement"
                     [charsRemainingWarning]="5"
-                    (onOverCharsMaxLimit)="handleOverCharsMaxLimit($event, 'example1')"
-                    (onUnderCharsMaxLimit)="handleUnderCharsMaxLimit($event, 'example1')"
                     [(ngModel)]="bio"
                     pfng-remaining-chars-count>
           </textarea>

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -359,13 +359,17 @@ export class UpdateComponent implements AfterViewInit, OnInit {
    * @param user
    */
   private setUserProperties(user: User): void {
-    this.bio = user.attributes.bio;
-    this.company = user.attributes.company;
-    this.email = user.attributes.email;
-    this.fullName = user.attributes.fullName;
-    this.imageUrl = user.attributes.imageURL;
-    this.url = user.attributes.url;
-    this.username = user.attributes.username;
+    if (user.attributes === undefined) {
+      return;
+    }
+
+    this.bio = (user.attributes.bio !== undefined) ? user.attributes.bio : '';
+    this.company = (user.attributes.company !== undefined) ? user.attributes.company : '';
+    this.email = (user.attributes.email !== undefined) ? user.attributes.email : '';
+    this.fullName = (user.attributes.fullName !== undefined) ? user.attributes.fullName : '';
+    this.imageUrl = (user.attributes.imageURL !== undefined) ? user.attributes.imageURL : '';
+    this.url = (user.attributes.url !== undefined) ? user.attributes.url : '';
+    this.username = (user.attributes.username !== undefined) ? user.attributes.username : '';
 
     let contextInformation = user.attributes["contextInformation"];
     if (contextInformation && contextInformation.experimentalFeatures ) {


### PR DESCRIPTION
There were two issues.

1. There was an undefined user attribute property -- best seen when selecting "Log Out".
2. There were unused component events (tag attributes) copied from an example.

Fixes #1737