### PR TITLE
Set longer timeout for Che start

### DIFF
--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -14,7 +14,7 @@
         <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="!workspaceBusy"
            (click)="createAndOpenWorkspace()">Create workspace</a>
         <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="workspaceBusy"
-           tooltip="Please wait..." disabled>Create workspace</a>
+           tooltip="Waiting for Che..." disabled>Create workspace</a>
       </li>
       <li class="disabled">
         <a href="javascript:void(0)" class="dropdown-item secondary-action"

--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -9,9 +9,12 @@
       <span class="fa fa-ellipsis-v"></span>
     </button>
     <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
-      <li [attr.role]="menuitem">
-        <a href="javascript:void(0)" class="dropdown-item secondary-action"
+      <li [ngClass]="{'disabled': workspaceBusy}"
+          [attr.role]="menuitem">
+        <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="!workspaceBusy"
            (click)="createAndOpenWorkspace()">Create workspace</a>
+        <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="workspaceBusy"
+           tooltip="Please wait..." disabled>Create workspace</a>
       </li>
       <li class="disabled">
         <a href="javascript:void(0)" class="dropdown-item secondary-action"

--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -17,6 +17,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   @Input() index: number = -1;
 
   subscriptions: Subscription[] = [];
+  workspaceBusy: boolean = false;
 
   constructor(
       private broadcaster: Broadcaster,
@@ -40,8 +41,10 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
    * Create workspace and open in editor
    */
   createAndOpenWorkspace(): void {
+    this.workspaceBusy = true;
     this.subscriptions.push(this.workspacesService.createWorkspace(this.codebase.id)
       .subscribe(workspaceLinks => {
+        this.workspaceBusy = false;
         if (workspaceLinks != null) {
           let name = this.getWorkspaceName(workspaceLinks.links.open);
           this.windowService.open(workspaceLinks.links.open, name);
@@ -58,6 +61,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
           });
         }
       }, error => {
+        this.workspaceBusy = false;
         this.handleError("Failed to create workspace", NotificationType.DANGER);
       }));
   }

--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.module.ts
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown'
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { WindowService } from '../services/window.service';
 import { WorkspacesService } from '../services/workspaces.service';
@@ -13,11 +14,12 @@ import { CodebasesItemActionsComponent } from './codebases-item-actions.componen
   imports: [
     BsDropdownModule.forRoot(),
     CommonModule,
-    FormsModule
+    FormsModule,
+    TooltipModule.forRoot()
   ],
   declarations: [ CodebasesItemActionsComponent ],
   exports: [ CodebasesItemActionsComponent ],
-  providers: [ BsDropdownConfig, WindowService, WorkspacesService ]
+  providers: [ BsDropdownConfig, TooltipConfig, WindowService, WorkspacesService ]
 })
 export class CodebasesItemActionsModule {
   constructor(http: Http) {}

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
@@ -16,7 +16,7 @@
 <ng-template #showCreateWorkspace>
   <a href="javascript:void(0)" (click)="createAndOpenWorkspace()" *ngIf="!workspaceBusy">
     <i class="pficon pficon-add-circle-o margin-right-10"></i>Create workspace</a>
-  <a href="javascript:void(0)" *ngIf="workspaceBusy"
+  <a class="workspace-busy disabled" href="javascript:void(0)" *ngIf="workspaceBusy"
      tooltip="Waiting for Che..." disabled>
     <i class="pficon pficon-add-circle-o margin-right-10"></i>Create workspace</a>
 </ng-template>

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
@@ -14,7 +14,10 @@
           (click)="openWorkspace()">Open</button>
 </ng-template>
 <ng-template #showCreateWorkspace>
-  <a href="javascript:void(0)" (click)="createAndOpenWorkspace()">
+  <a href="javascript:void(0)" (click)="createAndOpenWorkspace()" *ngIf="!workspaceBusy">
+    <i class="pficon pficon-add-circle-o margin-right-10"></i>Create workspace</a>
+  <a href="javascript:void(0)" *ngIf="workspaceBusy"
+     tooltip="Waiting for Che..." disabled>
     <i class="pficon pficon-add-circle-o margin-right-10"></i>Create workspace</a>
 </ng-template>
 <div class="busy-indicator" *ngIf="workspaceBusy">

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.less
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.less
@@ -15,5 +15,5 @@
   height: 32px;
   margin-right: 5px;
   width: 200px;
-  display: inline-block;
+  display: initial;
 }

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.less
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.less
@@ -11,6 +11,13 @@
     padding: 0;
   }
 }
+.workspace-busy {
+  &.disabled {
+    &:hover {
+      color: @color-pf-black-500;
+    }
+  }
+}
 .workspace-select {
   height: 32px;
   margin-right: 5px;

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.module.ts
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { WindowService } from '../services/window.service';
 import { WorkspacesService } from '../services/workspaces.service';
@@ -13,11 +14,12 @@ import { CodebasesItemWorkspacesComponent } from './codebases-item-workspaces.co
   imports: [
     BsDropdownModule.forRoot(),
     CommonModule,
-    FormsModule
+    FormsModule,
+    TooltipModule.forRoot()
   ],
   declarations: [ CodebasesItemWorkspacesComponent ],
   exports: [ CodebasesItemWorkspacesComponent ],
-  providers: [ BsDropdownConfig, WindowService, WorkspacesService ]
+  providers: [ BsDropdownConfig, TooltipConfig, WindowService, WorkspacesService ]
 })
 export class CodebasesItemWorkspacesModule {
   constructor(http: Http) {}

--- a/src/app/create/codebases/services/workspaces.service.ts
+++ b/src/app/create/codebases/services/workspaces.service.ts
@@ -35,6 +35,7 @@ export class WorkspacesService {
     let url = `${this.workspacesUrl}/${codebaseId}/create`;
     return this.http
       .post(url, null, { headers: this.headers })
+      .timeout(60000) // 30 sec is not enough for che-server to start
       .map(response => {
         return response.json() as WorkspaceLinks;
       })
@@ -70,6 +71,7 @@ export class WorkspacesService {
   openWorkspace(url: string): Observable<WorkspaceLinks> {
     return this.http
       .post(url, null, { headers: this.headers })
+      .timeout(60000) // 30 sec is not enough for che-server to start
       .map(response => {
         return response.json() as WorkspaceLinks;
       })


### PR DESCRIPTION
Fixes https://github.com/fabric8-ui/fabric8-ui/issues/1745

Since the expected Che starting time is up to 3 minutes, I've set a longer timeout (5 min) for the create/open Che workspace request. This seems to work fine and no longer see the "failed to create workspace" notification -- will retest when Che goes idle again.

Note there are two controls in the codebases page that can create/open a workspace; a "Create workspace" link and a kebab menu option. These controls already become disabled while waiting for Che; however, I added a tooltip to the kebab menu option. Buttons and combo boxes do not show tooltips when disabled. A progress spinner is already shown for the "Create workspace" link while waiting for Che.