### PR TITLE
fix(wizard): to display exception when thrown by Forge backend

### DIFF
--- a/src/app/space-wizard/services/fabric8-app-generator.service.mock.ts
+++ b/src/app/space-wizard/services/fabric8-app-generator.service.mock.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-export let errorForExecuteForgeCommandError = {
+export const errorForExecuteForgeCommandError = {
   "origin": "Fabric8ForgeService",
   "name": "ForgeApiClientExceptionError",
   "message": "An unexpected error occurred while consuming the http response returned from the server",
@@ -20,7 +20,7 @@ export let errorForExecuteForgeCommandError = {
   }
 };
 
-export let expectedErr = {
+export const expectedForgeError = {
   "origin": "Fabric8AppGeneratorService",
   "name": "ExecuteForgeCommandError",
   "message": "The forge-quick-start :: begin :: 0 command failed or only partially succeeded",
@@ -30,7 +30,7 @@ export let expectedErr = {
   }
 };
 
-export let mockService = {
+export const mockServiceForError = {
   executeCommand(options) {
     return Observable.create(observer => {
       observer.error(errorForExecuteForgeCommandError);
@@ -38,3 +38,57 @@ export let mockService = {
     })
   }
 }
+
+export const errorForForgeException = {
+  "origin": "Fabric8ForgeService",
+  "name": "ForgeApiClientExceptionError",
+  "message": "An unexpected error occurred while consuming the http response returned from the server",
+  "inner": {
+    "_body": "{\"type\":\"org.javassist.tmp.java.lang.RuntimeException_$$_javassist_60aecd8a-a516-4262-8fd3-0aaf82659a25\",\"message\":\"Failed to find Jenkins URL in namespaces ckrych-jenkins and ckrych-jenkins: \",\"localizedMessage\":\"Failed to find Jenkins URL in namespaces ckrych-jenkins and ckrych-jenkins: \",\"forgeVersion\":\"3.6.1.Final\",\"stackTrace\":[{\"line\":303,\"class\":\"io.fabric8.forge.generator.kubernetes.CreateBuildConfigStep\",\"file\":\"CreateBuildConfigStep.java\",\"method\":\"execute\"},{\"line\":-2,\"class\":\"sun.reflect.NativeMethodAccessorImpl\",\"file\":\"NativeMethodAccessorImpl.java\",\"method\":\"invoke0\"}]}",
+    "status": 500,
+    "ok": false,
+    "statusText": "Internal Server Error",
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "type": 2,
+    "url": "http://localhost:8080/forge/commands/fabric8-new-project/execute",
+    "inner": {}
+  }
+};
+
+export const mockServiceForgeException = {
+  executeCommand(options) {
+    return Observable.create(observer => {
+      observer.error(errorForForgeException);
+      observer.complete();
+    })
+  }
+}
+export const expectedForException = {
+  "origin": "Fabric8AppGeneratorService",
+  "name": "ExecuteForgeCommandError",
+  "message": "The forge-quick-start :: begin :: 0 command failed or only partially succeeded",
+  "inner": {
+    "type": "org.javassist.tmp.java.lang.RuntimeException_$$_javassist_60aecd8a-a516-4262-8fd3-0aaf82659a25",
+    "message": "Failed to find Jenkins URL in namespaces ckrych-jenkins and ckrych-jenkins: ",
+    "localizedMessage": "Failed to find Jenkins URL in namespaces ckrych-jenkins and ckrych-jenkins: ",
+    "forgeVersion": "3.6.1.Final",
+    "stackTrace": [
+      {
+        "line": 303,
+        "class": "io.fabric8.forge.generator.kubernetes.CreateBuildConfigStep",
+        "file": "CreateBuildConfigStep.java",
+        "method": "execute"
+      },
+      {
+        "line": -2,
+        "class": "sun.reflect.NativeMethodAccessorImpl",
+        "file": "NativeMethodAccessorImpl.java",
+        "method": "invoke0"
+      }
+    ]
+  }
+};

--- a/src/app/space-wizard/services/fabric8-app-generator.service.spec.ts
+++ b/src/app/space-wizard/services/fabric8-app-generator.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Logger } from 'ngx-base';
 import { Fabric8AppGeneratorService } from './fabric8-app-generator.service';
-import { errorForExecuteForgeCommandError, expectedErr, mockService } from './fabric8-app-generator.service.mock'
+import { expectedForgeError, mockServiceForError, mockServiceForgeException, expectedForException } from './fabric8-app-generator.service.mock'
 
 describe('Fabric8AppGeneratorService:', () => {
   let mockAppGeneratorService: any;
@@ -20,7 +20,7 @@ describe('Fabric8AppGeneratorService:', () => {
     };
   });
 
-  it('Execute returns with a Forge error', () => {
+  it('Execute returns with a Forge returning an error', () => {
     // given
     mockLog.createLoggerDelegate.and.returnValue(() => { });
     let request = {
@@ -28,13 +28,34 @@ describe('Fabric8AppGeneratorService:', () => {
         "name": "forge-quick-start"
       }
     };
-    fabric8AppGeneratorService = new Fabric8AppGeneratorService(mockService, mockLog, mockAppGeneratorConfigurationService, mockApiLocator);
+    fabric8AppGeneratorService = new Fabric8AppGeneratorService(mockServiceForError, mockLog, mockAppGeneratorConfigurationService, mockApiLocator);
 
     // when
     fabric8AppGeneratorService.executeForgeCommand(request).subscribe(() => {
+      fail("Execute returns with a Forge trowing an exception");
     }, err => {
       // then
-      expect(err).toEqual(expectedErr);
+      expect(err).toEqual(expectedForgeError);
+    })
+  });
+
+
+  it('Execute returns with a Forge returning an error', () => {
+    // given
+    mockLog.createLoggerDelegate.and.returnValue(() => { });
+    let request = {
+      "command": {
+        "name": "forge-quick-start"
+      }
+    };
+    fabric8AppGeneratorService = new Fabric8AppGeneratorService(mockServiceForgeException, mockLog, mockAppGeneratorConfigurationService, mockApiLocator);
+
+    // when
+    fabric8AppGeneratorService.executeForgeCommand(request).subscribe(() => {
+      fail("Execute returns with a Forge trowing an exception");
+    }, err => {
+      // then
+      expect(err).toEqual(expectedForException);
     })
   });
 

--- a/src/app/space-wizard/services/fabric8-app-generator.service.ts
+++ b/src/app/space-wizard/services/fabric8-app-generator.service.ts
@@ -148,13 +148,15 @@ export class Fabric8AppGeneratorService extends AppGeneratorService {
            inner: err
          };
         // Find Forge root cause
-        if (err.inner._body) {
+        if (err && err.inner && err.inner._body) {
           const body = JSON.parse(err.inner._body);
-          if (body && body.results) {
+          if (body && body.results) { // Forge returns an error with Results.fail
             const result = body.results.filter(result => result.status === "FAILED");
             if (result && result.length > 0) {
               error.inner = result[0];
             }
+          } else { // Forge returns an Exception with throw RuntimeException
+            error.inner = body
           }
         }
         if (err.message == "io.fabric8.forge.generator.keycloak.KeyCloakFailureException") {


### PR DESCRIPTION
Fixes https://github.com/fabric8-ui/fabric8-ui/issues/1742
Similar to previous PR https://github.com/fabric8-ui/fabric8-ui/pull/1749 but here Forge Add-on API does not return a Results.fail but throw an exception.
Now the UI code can deal with either a Results.fail or throw exception.