### PR TITLE
Fix specificity of .combobox selector override

### DIFF
--- a/src/app/home/work-item-widget/work-item-widget.component.html
+++ b/src/app/home/work-item-widget/work-item-widget.component.html
@@ -3,7 +3,7 @@
     <div class="card-pf-heading f8-card-heading">
       <h2 class="card-pf-title">My work items
       <span *ngIf="spaces.length !== 0">
-        <select class="col-xs-3 col-sm-6 combobox form-control"
+        <select class="col-xs-3 col-sm-6 form-control work-item-combobox combobox"
             [disabled]="spaces.length === 0"
             [(ngModel)]="currentSpaceId"
             (ngModelChange)="fetchWorkItems()">

--- a/src/app/home/work-item-widget/work-item-widget.component.less
+++ b/src/app/home/work-item-widget/work-item-widget.component.less
@@ -1,9 +1,12 @@
 @import (reference) '../../../assets/stylesheets/shared/osio.less';
-.combobox {
-  position: absolute;
-  top: 15px;
-  right: 25px;
-  width: 50%;
+// Setting the specificity of .combobox so it won't effect the codebases page
+.work-item-combobox {
+  &.combobox {
+    position: absolute;
+    top: 15px;
+    right: 25px;
+    width: 50%;
+  }
 }
 .work-item-title {
   position: absolute;


### PR DESCRIPTION
Fixes https://github.com/fabric8-ui/fabric8-ui/issues/1758.

The combobox selector was recently overridden for work-item-widget. This uses the ‘top’ property to position the select element absolutely. As a result, the select element used on the codebases page is incorrectly positioned at the top of its container. 

The codebases select element should appear in each row of the list component, not in the header.

