### PR TITLE
Clean up .combobox selector

### DIFF
--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="workspacesAvailable; then showOpenWorkspace else showCreateWorkspace"></div>
 <ng-template #showOpenWorkspace>
-  <select class="combobox form-control workspace-select"
+  <select class="form-control workspace-select"
           [disabled]="!workspacesAvailable || workspaceBusy"
           [(ngModel)]="workspaceUrl"
           (ngModelChange)="setWorkspaceSelected()">

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
@@ -4,7 +4,7 @@
       Stack Report Recommendations
       <div *ngIf="(buildConfigsCount | async) > 0" class="pull-right">
         <select id="spacehome-analytical-report-combobox" name="pipeSelect" [(ngModel)]="currentPipeline" (change)="selectedPipeline()"
-          class="combobox form-control">
+          class="form-control">
           <option value="default">Select a pipeline...</option>
           <option *ngFor="let build of pipelines | filter; let i = index;" [ngValue]="build.id">{{ build.name }}</option>
         </select>

--- a/src/app/home/work-item-widget/work-item-widget.component.html
+++ b/src/app/home/work-item-widget/work-item-widget.component.html
@@ -3,7 +3,7 @@
     <div class="card-pf-heading f8-card-heading">
       <h2 class="card-pf-title">My work items
       <span *ngIf="spaces.length !== 0">
-        <select class="col-xs-3 col-sm-6 form-control work-item-combobox combobox"
+        <select class="col-xs-3 col-sm-6 form-control work-item-combobox"
             [disabled]="spaces.length === 0"
             [(ngModel)]="currentSpaceId"
             (ngModelChange)="fetchWorkItems()">

--- a/src/app/home/work-item-widget/work-item-widget.component.less
+++ b/src/app/home/work-item-widget/work-item-widget.component.less
@@ -1,12 +1,9 @@
 @import (reference) '../../../assets/stylesheets/shared/osio.less';
-// Setting the specificity of .combobox so it won't effect the codebases page
 .work-item-combobox {
-  &.combobox {
-    position: absolute;
-    top: 15px;
-    right: 25px;
-    width: 50%;
-  }
+  position: absolute;
+  top: 15px;
+  right: 25px;
+  width: 50%;
 }
 .work-item-title {
   position: absolute;

--- a/src/app/profile/overview/work-items/work-items.component.html
+++ b/src/app/profile/overview/work-items/work-items.component.html
@@ -1,5 +1,5 @@
 <div class="col-sm-6 margin-top-25" *ngIf="spaces.length !== 0">
-  <select class="combobox form-control"
+  <select class="form-control"
           [(ngModel)]="currentSpaceId"
           (ngModelChange)="fetchWorkItems()">
     <option value="default">Select a space to work with...</option>


### PR DESCRIPTION
This PR cleans up the misuse of the .combobox selector. This is used only for Bootstrap comboxes and is not needed for select elements. It adds nothing unless you're using an input element.