### PR TITLE
fix(kubernetes): fixed k8s getting started

### DIFF
--- a/environments/local-kubernetes.sh
+++ b/environments/local-kubernetes.sh
@@ -22,11 +22,12 @@ export OAUTH_LOGOUT_URI=""
 export K8S_API_SERVER="localhost:3000"
 export PROXIED_K8S_API_SERVER="localhost:3000"
 #export WS_K8S_API_SERVER=${PROXIED_K8S_API_SERVER}
-export WS_K8S_API_SERVER="localhost:3000"
-
 export K8S_API_SERVER_BASE_PATH="/_p/oso"
-export WS_K8S_API_SERVER_BASE_PATH="/_p/oso"
 export K8S_API_SERVER_PROTOCOL="http"
+
+export WS_K8S_API_SERVER="${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+export WS_K8S_API_SERVER_BASE_PATH=""
+export WS_K8S_API_SERVER_PROTOCOL="wss"
 
 export OAUTH_ISSUER=""
 export OAUTH_SCOPE="user:full"
@@ -42,13 +43,15 @@ echo "Configured to connect to kubernetes cluster at https://${PROXIED_K8S_API_S
 
 export FABRIC8_SSO_API_URL="http://sso.fabric8.${VM_IP}.nip.io/"
 export FABRIC8_WIT_API_URL="http://wit.fabric8.${VM_IP}.nip.io/api/"
-export FABRIC8_FORGE_API_URL="http://forge.fabric8.${VM_IP}.nip.io//"
+export FABRIC8_FORGE_API_URL="http://forge.fabric8.${VM_IP}.nip.io/"
+export FABRIC8_TENANT_API_URL="http://f8tenant.fabric8.${VM_IP}.nip.io/"
 
 
 echo ""
 echo "WS_K8S_API_SERVER:             ${WS_K8S_API_SERVER}"
 echo "WS_K8S_API_SERVER_BASE_PATH:   ${WS_K8S_API_SERVER_BASE_PATH}"
 echo ""
+echo "K8S_API_SERVER:                ${K8S_API_SERVER}"
 echo "K8S_API_SERVER_PROTOCOL:       ${K8S_API_SERVER_PROTOCOL}"
 echo "K8S_API_SERVER_BASE_PATH:      ${K8S_API_SERVER_BASE_PATH}"
 echo "OAUTH_ISSUER:                  ${OAUTH_ISSUER}"
@@ -60,5 +63,6 @@ echo "FABRIC8_PIPELINES_NAMESPACE    ${FABRIC8_PIPELINES_NAMESPACE}"
 echo "FABRIC8_SSO_API_URL            ${FABRIC8_SSO_API_URL}"
 echo "FABRIC8_WIT_API_URL            ${FABRIC8_WIT_API_URL}"
 echo "FABRIC8_FORGE_API_URL          ${FABRIC8_FORGE_API_URL}"
+echo "FABRIC8_TENANT_API_URL         ${FABRIC8_TENANT_API_URL}"
 echo "FABRIC8_REALM                  ${FABRIC8_REALM}"
 echo ""

--- a/src/app/getting-started/getting-started.component.html
+++ b/src/app/getting-started/getting-started.component.html
@@ -1,13 +1,19 @@
 <div id="overview" class="container content margin-top-80" *ngIf="showGettingStarted">
   <div class="row">
-    <div class="col-md-8 padding-left-none">
+    <div class="col-md-8 padding-left-none" *ngIf="!kubeMode">
       <h1 class="getting-started-title">Getting started in OpenShift.io</h1>
       <p class="getting-started-subtitle">
         Welcome to OpenShift.io! To get started you will need to connect
-        your GitHub and OpenShift.com accounts.
+        your GitHub and OpenShift accounts.
       </p>
       <p class="padding-bottom-15 padding-top-15">
         The fields marked with <span class="required-pf">*</span> are required.
+      </p>
+    </div>
+    <div class="col-md-8 padding-left-none" *ngIf="kubeMode">
+      <h1 class="getting-started-title">Getting started in OpenShift.io</h1>
+      <p class="getting-started-subtitle">
+        Welcome to OpenShift.io!
       </p>
     </div>
     <div class="col-md-4">
@@ -60,7 +66,7 @@
         </div>
       </div>
 -->
-      <div class="row">
+      <div class="row" *ngIf="!kubeMode">
         <div class="col-md-1">
           <h2 class="circle">1</h2>
         </div>
@@ -115,6 +121,20 @@
                     [disabled]="isConnectAccountsDisabled"
                     (click)="connectAccounts()">Connect accounts</button>
           </div>
+        </div>
+      </div>
+
+      <div class="row" *ngIf="kubeMode">
+        <div class="col-md-1">
+          <h2 class="circle">1</h2>
+        </div>
+        <div class="col-md-11 padding-left-0" *ngIf="!openShiftLinked">
+          <h2>Waiting for your tenant services to startup</h2>
+
+          <p>{{kubePollMessage}}</p>
+        </div>
+        <div class="col-md-11 padding-left-0" *ngIf="openShiftLinked">
+          <h2>You tenant services are running!</h2>
         </div>
       </div>
       <div class="row" *ngIf="isSuccess">

--- a/src/app/shared/config/fabric8-ui-config.ts
+++ b/src/app/shared/config/fabric8-ui-config.ts
@@ -9,6 +9,7 @@ export class Fabric8UIConfig {
   ssoApiUrl: string;
   statusApiUrl: string;
   witApiUrl: string;
+  tenantApiUrl: string;
   kubernetesMode: string;
 
 }

--- a/src/config/fabric8-ui.env.js
+++ b/src/config/fabric8-ui.env.js
@@ -9,5 +9,6 @@ window.Fabric8UIEnv = {
   "recommenderApiUrl": "{{ .Env.FABRIC8_RECOMMENDER_API_URL }}",
   "ssoApiUrl": "{{ .Env.FABRIC8_SSO_API_URL }}",
   "statusApiUrl": "{{ .Env.FABRIC8_STATUS_API_URL }}",
-  "witApiUrl": "{{ .Env.FABRIC8_WIT_API_URL }}"
+  "witApiUrl": "{{ .Env.FABRIC8_WIT_API_URL }}",
+  "tenantApiUrl": "{{ .Env.FABRIC8_TENANT_API_URL }}"
 };


### PR DESCRIPTION
lets poll the fabric8-tenant service until the kubernetes tenant is connected
as the creation of the jenkins external URL is lazy and only then can we register it into KC
so that the user can login to jenkins via KC