### PR TITLE
Replaced codebases request timeout with retry

### DIFF
--- a/src/app/create/codebases/services/workspaces.service.ts
+++ b/src/app/create/codebases/services/workspaces.service.ts
@@ -35,7 +35,7 @@ export class WorkspacesService {
     let url = `${this.workspacesUrl}/${codebaseId}/create`;
     return this.http
       .post(url, null, { headers: this.headers })
-      .timeout(60000) // 30 sec is not enough for che-server to start
+      .retry(8) // che-starter timeout is 3 min -- 30 sec default request timeout is not enough
       .map(response => {
         return response.json() as WorkspaceLinks;
       })
@@ -71,7 +71,7 @@ export class WorkspacesService {
   openWorkspace(url: string): Observable<WorkspaceLinks> {
     return this.http
       .post(url, null, { headers: this.headers })
-      .timeout(60000) // 30 sec is not enough for che-server to start
+      .retry(8) // che-starter timeout is 3 min -- 30 sec default request timeout is not enough
       .map(response => {
         return response.json() as WorkspaceLinks;
       })


### PR DESCRIPTION
I replaced the timeout in the codebases service with a retry(8) statement. The UI will now error after 4 min. The default request timeout is 30 sec, while the che-starter timeout is 3 min. The previous timeout does not seem to override the router.

For testing purposes, I manually idled Che. Now that I'm able to monitor the Che console, I can see that UI opens the new tab after Che has started -- typically within 4-5 re-tries.

The UI will still show a "Failed to create workspace" notification; for example, if the retries are exhausted.