### PR TITLE
fix(bug): fix the undefined print on analytics dashboard timestamp, increase the version of fabric8-stack-analysis-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "core-js": "2.4.1",
     "fabric8-planner": "0.26.1",
     "fabric8-runtime-console": "0.18.9",
-    "fabric8-stack-analysis-ui": "0.1.48",
+    "fabric8-stack-analysis-ui": "0.1.49",
     "http-server": "0.9.0",
     "ie-shim": "0.1.0",
     "js-yaml": "3.8.2",

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.ts
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.ts
@@ -161,7 +161,7 @@ export class AnalyticalReportWidgetComponent implements OnInit, OnDestroy {
               this.stackAnalysisInformation['recommendations'] = recommendations;
               // Restrict the recommendations to a particular limit as specified in UX
               this.stackAnalysisInformation['recommendations'].splice(this.stackAnalysisInformation['recommendationsLimit']);
-              let finishedTime: string = result.finishedTime;
+              let finishedTime: string = result && result[0] ? result[0].finishedTime : 'NA';
               if (finishedTime) {
                 let date = null;
                 try {


### PR DESCRIPTION
1. Change the version of fabric8-stack-analysis-ui package from 0.1.48 to 0.1.49
2. A codefix for reading timestamp properly as the change has been made in npm.