### PR TITLE
fix(landing): set size of logo on landing page

### DIFF
--- a/src/app/getting-started/getting-started.component.less
+++ b/src/app/getting-started/getting-started.component.less
@@ -38,3 +38,4 @@ h2 {
   border-top-color: @color-pf-black-400;
 }
 .success-title { font-weight: 400; }
+.home-logo { width: 100%; }


### PR DESCRIPTION
set the size of the logo on the landing page to be 100% of the column that it resides in, rather than left at it's native size

fixes https://github.com/fabric8-ui/fabric8-ui/issues/1765