### PR TITLE
NotificationService: replace ngx-widgets import with patternfly-ng

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,7 +56,7 @@ import {
   UserService
 }                             from 'ngx-login-client';
 import { WidgetsModule }      from 'ngx-widgets';
-
+import { PatternFlyNgModule } from 'patternfly-ng';
 
 /*
  * Platform and Environment providers/directives/pipes
@@ -156,6 +156,7 @@ export type StoreType = {
     SpaceWizardModule,
     StackDetailsModule,
     WidgetsModule,
+    PatternFlyNgModule,
     StatusListModule,
     // AppRoutingModule must appear last
     AppRoutingModule

--- a/src/app/shared/notifications.service.ts
+++ b/src/app/shared/notifications.service.ts
@@ -1,4 +1,4 @@
-import { NotificationService } from 'ngx-widgets';
+import { NotificationService } from 'patternfly-ng';
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { Notifications, Notification, NotificationAction } from 'ngx-base';


### PR DESCRIPTION
NotificationService is using an old import from ngx-widgets and needs to use patternfly-ng.