### PR TITLE
Omit the disabled ‘Remove codebase' option

### DIFF
--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -16,10 +16,12 @@
         <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="workspaceBusy"
            tooltip="Waiting for Che..." disabled>Create workspace</a>
       </li>
+      <!-- Remove until API is available
       <li class="disabled">
         <a href="javascript:void(0)" class="dropdown-item secondary-action"
            (click)="deleteCodebase()" disabled>Remove codebase</a>
       </li>
+      -->
     </ul>
   </span>
 </ng-template>


### PR DESCRIPTION
Omit the disabled ‘Remove codebase' option from the kebab on the codebases page until an API is available for this functionality.

This resolves issue # https://github.com/fabric8-ui/fabric8-ui/issues/552

