### PR TITLE
feat(cleanup): add support for tenant reset/cleanup

### DIFF
--- a/src/app/profile/cleanup/cleanup-routing.module.ts
+++ b/src/app/profile/cleanup/cleanup-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule }  from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { CleanupComponent } from './cleanup.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: CleanupComponent
+  }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class CleanupRoutingModule {}

--- a/src/app/profile/cleanup/cleanup.component.html
+++ b/src/app/profile/cleanup/cleanup.component.html
@@ -1,0 +1,114 @@
+<div id="overview" class="container-fluid content padding-top-15">
+  <div class="row">
+    <div class="col-xs-8 col-sm-8 col-sm-offset-1">
+      <div *ngIf="showNotification" class="alert {{notificationClass}}">
+        <span class="pficon {{notificationIcon}}"></span>
+        <strong>{{notificationTitle}}</strong> {{notificationText}}
+      </div>
+      <p *ngIf="cleanupStatus === 'notstarted'"><strong>You are about to erase all of your OpenShift.io spaces</strong>, reverting your OpenShift.io environment to it's default state.
+        This action will not affect your Github account or repositories associated with OpenShift.io.</p>
+      <p *ngIf="cleanupStatus === 'notstarted'">The following spaces will be removed and your account will be reset.</p>
+      <p *ngIf="cleanupStatus !== 'notstarted'">Results</p>
+      <div class="cleanup-list-results">
+        <div class="row cleanup-row">
+          <p class="cleanup-row-header"><b>Your Account</b></p>
+          <div class="list-group list-view-pf list-view-pf-view">
+            <div class="list-group-item">
+              <div class="list-group-item-header">
+                <!-- todo - conditionally show expansion if there are errors -->
+                <div class="list-view-pf-expand" *ngIf="tenantError">
+                  <span class="fa fa-angle-right" (click)="toggleTenantError()"
+                        [ngClass]="{'fa-angle-down': tenantErrorExpanded}"></span>
+                </div>
+                <div class="list-view-pf-main-info">
+                  <div class="list-view-pf-left">
+                    <div class="{{tenantIcon}} list-view-pf-icon-sm"></div>
+                  </div>
+                  <div class="list-view-pf-body">
+                    <div class="list-view-pf-description">
+                      <div class="list-group-item-heading">
+                        {{contextUserName}}
+                      </div>
+                      <div class="pull-right">{{tenantResult}}</div>
+                    </div>
+                  </div>
+                </div>
+                <div class="list-pf-expansion collapse in"
+                     *ngIf="tenantErrorExpanded">
+                  <div class="list-pf-container" tabindex="0">
+                    <div class="list-pf-content">
+                      {{tenantError}}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row cleanup-row">
+          <p class="cleanup-row-header"><b>Spaces</b></p>
+          <pfng-list
+            [config]="listConfig"
+            [itemTemplate]="itemTemplate"
+            [items]="spaces" >
+            <template #itemTemplate let-item="item" let-index="index">
+              <div class="list-pf-content-wrapper">
+                <div class="list-pf-main-content">
+                  <span class="cleanup-status-icon {{item.statusIcon}}"></span>
+                  <div class="list-pf-title">{{item.attributes.name}}</div>
+                  <div class="pull-right">{{item.progress}}</div>
+                </div>
+              </div>
+            </template>
+          </pfng-list>
+        </div>
+      </div>
+      <div>
+        <p class="cleanup-action-confirm" *ngIf="cleanupStatus !== 'completedwitherrors' && cleanupStatus !== 'completed'">
+          By clicking on 'Erase my OpenShift.io environment', you are telling us that you no longer wish to use your current environment, and that you wish to start all over again.  There is no going back - we cannot save what is lost.
+        </p>
+        <p class="cleanup-action-confirm" *ngIf="cleanupStatus === 'completedwitherrors'">
+          There was an error erasing some of your spaces from OpenShift.io.  You can either erase these manually, or try again using the button below.
+        </p>
+        <p class="cleanup-action-confirm" *ngIf="cleanupStatus === 'completed'">
+          You have successfully erased your OpenShift.io environment.  You can now return to your user dashboard.
+        </p>
+
+        <button class="btn btn-danger btn-lg" (click)="confirmErase()" *ngIf="cleanupStatus !== 'completed'">Erase My OpenShift.io Environment</button>
+        <div *ngIf="cleanupStatus === 'completedwitherrors' || cleanupStatus === 'completed'" class="cleanup-home-action">
+          <button class="btn btn-default btn-lg" (click)="goHome()">Take me to my Dashboard</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<modal #confirmCleanup title="Are you sure?">
+  <modal-content>
+    <section>
+      <p class="clean-modal-warning">Erasing your OpenShift.io environment is an action that CANNOT be undone.</p>
+      <p>This will permanently erase all spaces, codebase links, applications, environments and pipelines.</p>
+      <p>Please verify this action by typing in your OpenShift.io username.</p>
+      <div class="form">
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label class="col-md-4 control-label">OpenShift.io Username</label>
+            <div class="col-md-8">
+              <input
+                #username
+                class="form-control"
+                name="username"
+                [(ngModel)]="userName" />
+            </div>
+          </div>
+        </form>
+      </div>
+    </section>
+    <footer>
+      <div class="col-md-offset-4 col-md-8">
+        <button class="btn" [ngClass]="{ 'btn-danger': userNameMatches() }" type="button" (click)="confirm()" [disabled]="!userNameMatches()" type="submit"> I understand my actions - erase my environment</button>
+      </div>
+    </footer>
+  </modal-content>
+</modal>

--- a/src/app/profile/cleanup/cleanup.component.less
+++ b/src/app/profile/cleanup/cleanup.component.less
@@ -1,0 +1,41 @@
+@import (reference) '../../../assets/stylesheets/shared/osio.less';
+
+.cleanup-list-results {
+  background-color: @color-pf-black-200;
+  padding: 30px;
+}
+
+.cleanup-action-confirm {
+  padding-top: 30px;
+}
+
+.cleanup-row {
+  .list-view-pf-view {
+    margin-top: 5px;
+  }
+  background-color: white;
+  margin-bottom: 30px;
+  &-header {
+    padding-top: 5px;
+    padding-left: 10px;
+  }
+
+  &-account-icon {
+    font-size: 1.5em;
+    border-color: @color-pf-black-200 !important;
+    background-color: @color-pf-black-200;
+  }
+}
+
+.cleanup-home-action {
+  margin-top: 20px;
+}
+
+.clean-modal-warning {
+  margin: 0;
+}
+
+.cleanup-status-icon {
+  font-size: 1.5em;
+  color: @color-pf-black-400;
+}

--- a/src/app/profile/cleanup/cleanup.component.ts
+++ b/src/app/profile/cleanup/cleanup.component.ts
@@ -1,0 +1,169 @@
+import { AfterViewInit, Component, ElementRef, OnInit, OnDestroy, ViewChild, ViewEncapsulation } from '@angular/core';
+import { NgForm } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Subscription, Observable } from 'rxjs';
+
+import { Contexts, Space, SpaceService } from 'ngx-fabric8-wit';
+import { IModalHost } from '../../space/wizard/models/modal-host';
+import { TenentService } from '../services/tenent.service';
+import { ListConfig } from 'patternfly-ng';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'fabric8-cleanup',
+  templateUrl: 'cleanup.component.html',
+  styleUrls: ['./cleanup.component.less'],
+  providers: [ TenentService ]
+})
+export class CleanupComponent implements OnInit, OnDestroy {
+  spaces: Space[] = [];
+  contextSubscription: Subscription;
+  userName: string;
+  contextUserName: string;
+  tenantResult: string;
+  listConfig: ListConfig;
+  showNotification: boolean = true;
+  notificationClass: string;
+  notificationIcon: string;
+  notificationText: string;
+  notificationTitle: string;
+  tenantIcon: string;
+  tenantError: string;
+  tenantErrorExpanded: boolean = false;
+
+  cleanupStatus: string = "notstarted";
+
+  @ViewChild('confirmCleanup') confirmCleanup: IModalHost;
+
+  constructor( private contexts: Contexts, private spaceService: SpaceService, private tenantService: TenentService, private router: Router ) {
+  }
+
+  ngOnInit() {
+    this.notificationClass = "alert-danger";
+    this.notificationIcon = "pficon-error-circle-o";
+    this.notificationTitle = "Warning!";
+    this.notificationText = "This action is not reversible!";
+    this.tenantIcon = "fa fa-circle-o cleanup-row-account-icon";
+
+    this.listConfig = {
+      dblClick: false,
+      dragEnabled: false,
+      multiSelect: false,
+      selectItems: false,
+      showCheckbox: false,
+      useExpandItems: false
+    } as ListConfig;
+
+    this.userName = '';
+    this.contextSubscription = this.contexts.current.subscribe(val => {
+      this.contextUserName = val.user.attributes.username;
+      this.spaceService
+        .getSpacesByUser(val.user.attributes.username, 100)
+        .subscribe(spaces => {
+          this.spaces = spaces;
+          this.spaces.forEach((space) => {
+            space['statusIcon'] = "fa fa-2x fa-circle-o";
+          });
+        });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.contextSubscription.unsubscribe();
+  }
+
+  confirmErase(): void{
+    this.confirmCleanup.open();
+  }
+  confirm(): void {
+    this.confirmCleanup.close();
+    this.tenantError = "";
+    this.cleanupStatus = "running";
+    this.showNotification = false;
+    let observableArray: Observable<any>[] = [];
+    let tenantCleanError: boolean = false;
+
+    this.tenantIcon = "spinner spinner-lg";
+
+    this.spaces.forEach((space) => {
+      // only try to erase spaces if they are still around after a failed attempt
+      if (!space['erased']) {
+        space['progress'] = "Erasing space";
+        space['statusIcon'] = "spinner spinner-lg";
+        let spaceObservable = this.spaceService.deleteSpace(space).map((result) => {
+          space['erased'] = true;
+          space['progress'] = "Space successfully erased!";
+          space['statusIcon'] = "pficon pficon-ok ";
+        }).catch((error) => {
+          space['progress'] = "Error: Unable to erase.";
+          space['statusIcon'] = "pficon pficon-warning-triangle-o";
+          this.showWarningNotification();
+          return Observable.of(error);
+        });
+        observableArray.push(spaceObservable);
+      }
+    });
+
+    this.tenantResult = "Cleaning up tenant.";
+    let tenantServiceCleanup = this.tenantService.cleanupTenant()
+      .catch((error) => {
+        tenantCleanError = true;
+        this.tenantResult = "Tenant cleanup failed.";
+        this.tenantError = error;
+        this.tenantIcon = "pficon pficon-warning-triangle-o cleanup-row-account-icon";
+        return Observable.of(error);
+    });
+
+    observableArray.push(tenantServiceCleanup);
+
+    //join all space delete observables and wait for completion before running tenant cleanup
+    Observable.forkJoin(...observableArray).subscribe((result) => {
+      if(!tenantCleanError) {
+        this.tenantService.updateTenent().subscribe(() => {
+          this.showSuccessNotification();
+          this.tenantIcon = "pficon pficon-ok cleanup-row-account-icon";
+          this.tenantResult = "Tenant reset successful";
+        }, (error) => {
+          this.tenantIcon = "pficon pficon-warning-triangle-o cleanup-row-account-icon";
+          this.tenantResult = "Tenant update failed.";
+          this.tenantError = error;
+          this.showWarningNotification();
+        });
+      } else {
+        this.showWarningNotification();
+      }
+    }, (error) => {
+      this.showWarningNotification();
+    });
+  }
+
+  userNameMatches(): boolean {
+    return (this.contextUserName === this.userName);
+  }
+
+  showSuccessNotification(): void {
+    this.showNotification = true;
+    this.notificationClass = "alert-success";
+    this.notificationIcon = "pficon-ok";
+    this.notificationTitle = "Success!";
+    this.notificationText = "Your OpenShift.io environment has been erased!";
+    this.cleanupStatus = "completed";
+  }
+
+  showWarningNotification(): void {
+    this.showNotification = true;
+    this.notificationClass = "alert-warning";
+    this.notificationIcon = "pficon-warning-triangle-o";
+    this.notificationTitle = "Alert!";
+    this.notificationText = "We were unable to reset your account or erase some of your spaces.";
+    this.cleanupStatus = "completedwitherrors";
+  }
+
+  toggleTenantError(): void {
+    this.tenantErrorExpanded = !this.tenantErrorExpanded;
+  }
+
+  goHome(): void {
+    this.router.navigate(['/', '_home']);
+  }
+}

--- a/src/app/profile/cleanup/cleanup.module.ts
+++ b/src/app/profile/cleanup/cleanup.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, Http } from '@angular/http';
+
+import { ModalModule } from 'ngx-modal';
+import { ListModule } from 'patternfly-ng';
+import { CleanupComponent } from './cleanup.component';
+import { CleanupRoutingModule } from './cleanup-routing.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    HttpModule,
+    ModalModule,
+    ListModule,
+    CleanupRoutingModule
+  ],
+  declarations: [ CleanupComponent ],
+})
+export class CleanupModule {
+  constructor(http: Http) {}
+}

--- a/src/app/profile/profile-routing.module.ts
+++ b/src/app/profile/profile-routing.module.ts
@@ -23,6 +23,13 @@ const routes: Routes = [
         data: {
           title: 'Profile'
         }
+      },
+      {
+        path: '_cleanup',
+        loadChildren: './cleanup/cleanup.module#CleanupModule',
+        data: {
+          title: 'Cleanup'
+        }
       }
     ]
   }

--- a/src/app/profile/profile.module.ts
+++ b/src/app/profile/profile.module.ts
@@ -6,10 +6,11 @@ import { ProfileComponent }     from './profile.component';
 import { ProfileRoutingModule } from './profile-routing.module';
 
 import { OverviewModule } from './overview/overview.module';
+import { CleanupModule } from './cleanup/cleanup.module';
 
 
 @NgModule({
-  imports:      [ CommonModule, OverviewModule, ProfileRoutingModule ],
+  imports:      [ CommonModule, OverviewModule, ProfileRoutingModule, CleanupModule ],
   declarations: [ ProfileComponent ],
 })
 export class ProfileModule {

--- a/src/app/profile/services/tenent.service.ts
+++ b/src/app/profile/services/tenent.service.ts
@@ -42,6 +42,22 @@ export class TenentService {
       });
   }
 
+  /**
+   * Cleanup tenant
+   * @returns {Observable<T>}
+   */
+  cleanupTenant(): Observable<any> {
+    let url = `${this.userUrl}/services`;
+    return this.http
+      .delete(url, { headers: this.headers })
+      .map(response => {
+        return response;
+      })
+      .catch((error) => {
+        return this.handleError(error);
+      });
+  }
+
   // Private
 
   private handleError(error: any) {

--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -124,6 +124,9 @@
         <div class="form-group">
           <button class="btn btn-lg btn-default"
                   (click)="updateTenent()">Update tenant</button>
+
+          <button class="btn btn-lg btn-default"
+                  (click)="cleanupTenant()">Clean tenant</button>
         </div>
       </form>
     </div>

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -245,6 +245,13 @@ export class UpdateComponent implements AfterViewInit, OnInit {
   }
 
   /**
+   * Cleanup tenant
+   */
+  cleanupTenant(): void {
+    this.router.navigate(['/', this.context.user.attributes.username, '_cleanup']);
+  }
+
+  /**
    * Validate email
    */
   validateEmail(): void {


### PR DESCRIPTION
Add a new cleanup component (linked to from the user profile page).  This shows all spaces, deletes them after sufficient warning for the user and calls the new tenant cleanup API (which deletes all openshift objects).  

Upon success, the tenant reset API is called which adds back Jenkins and Che support.