### PR TITLE
fix(testing): add a tenant config UI

### DIFF
--- a/environments/local-kubernetes.sh
+++ b/environments/local-kubernetes.sh
@@ -41,10 +41,11 @@ export KUBERNETES_MODE=true
 
 echo "Configured to connect to kubernetes cluster at https://${PROXIED_K8S_API_SERVER}/ with namespace ${NAMESPACE}"
 
-export FABRIC8_SSO_API_URL="http://sso.fabric8.${VM_IP}.nip.io/"
 export FABRIC8_WIT_API_URL="http://wit.fabric8.${VM_IP}.nip.io/api/"
 export FABRIC8_FORGE_API_URL="http://forge.fabric8.${VM_IP}.nip.io/"
 export FABRIC8_TENANT_API_URL="http://f8tenant.fabric8.${VM_IP}.nip.io/"
+#export FABRIC8_SSO_API_URL="http://sso.fabric8.${VM_IP}.nip.io/"
+export FABRIC8_SSO_API_URL="${FABRIC8_TENANT_API_URL}"
 
 
 echo ""

--- a/src/app/profile/profile-routing.module.ts
+++ b/src/app/profile/profile-routing.module.ts
@@ -30,6 +30,13 @@ const routes: Routes = [
         data: {
           title: 'Cleanup'
         }
+      },
+      {
+        path: '_tenant',
+        loadChildren: './tenant/tenant.module#TenantModule',
+        data: {
+          title: 'Tenant'
+        }
       }
     ]
   }

--- a/src/app/profile/tenant/tenant-routing.module.ts
+++ b/src/app/profile/tenant/tenant-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule }  from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { TenantComponent } from './tenant.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TenantComponent
+  }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class TenantRoutingModule {}

--- a/src/app/profile/tenant/tenant.component.html
+++ b/src/app/profile/tenant/tenant.component.html
@@ -1,0 +1,81 @@
+<div id="overview" class="container-fluid content padding-top-15">
+  <div class="row profile-edit">
+    <form role="form" #tenantForm="ngForm">
+      <!-- left column -->
+      <div class="col-xs-12 col-sm-5 col-sm-offset-1">
+        <h1>Edit Booster Catalog</h1>
+        <div class="form-group">
+          <label for="boosterGitRef" class="control-label">Booster ref</label>
+          <div [ngClass]="{'has-error': boosterGitRefInvalid}">
+            <input type="text" class="form-control" id="boosterGitRef" name="boosterGitRef"
+                   placeholder="Booster catalog git ref"
+                   [(ngModel)]="boosterGitRef">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="boosterGitRepo" class="control-label">Booster repo</label>
+          <div [ngClass]="{'has-error': boosterGitRepoInvalid}">
+            <input type="url" class="form-control" id="boosterGitRepo" name="boosterGitRepo"
+                   placeholder="Booster catalog git repository URL"
+                   [(ngModel)]="boosterGitRepo"
+                   (change)="boosterGitRepoValidate()">
+          </div>
+        </div>
+      </div>
+      <!-- right column -->
+      <div class="col-xs-12 col-sm-4 col-sm-offset-1">
+        <h1>Edit Tenant Version</h1>
+        <div class="form-group">
+          <label for="jenkinsVersion" class="control-label">Jenkins version</label>
+          <div [ngClass]="{'has-error': jenkinsVersionInvalid}">
+            <input type="text" class="form-control" id="jenkinsVersion" name="jenkinsVersion"
+                   placeholder="Jenkins version"
+                   [(ngModel)]="jenkinsVersion">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="cheVersion" class="control-label">Che version</label>
+          <div [ngClass]="{'has-error': cheVersionInvalid}">
+            <input type="text" class="form-control" id="cheVersion" name="cheVersion"
+                   placeholder="Che version"
+                   [(ngModel)]="cheVersion">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="mavenRepo" class="control-label">Maven Repo</label>
+          <div [ngClass]="{'has-error': mavenRepoInvalid}">
+            <input type="url" class="form-control" id="mavenRepo" name="mavenRepo"
+                   placeholder="Maven Repository URL"
+                   [(ngModel)]="mavenRepo"
+                   (change)="mavenRepoValidate()">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="updateTenant" class="control-label">Update Tenant?</label>
+          <div>
+            <input type="checkbox" class="form-control" id="updateTenant" name="updateTenant"
+                   [(ngModel)]="updateTenant">
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="profile-bar">
+    <div class="profile-bar-buttons col-sm-12">
+      <div class="center-block">
+          <button
+            class="btn btn-primary btn-update btn-lg col-auto ml-auto"
+            [disabled]="isUpdateProfileDisabled"
+            (click)="updateProfile()">Update Profile
+          </button>
+          <button
+            class="btn btn-default btn-update btn-lg col-auto md-auto"
+            (click)="resetProfile()">Clear Values
+          </button>
+          <button class="btn btn-default btn-lg col-auto mr-auto"
+                  (click)="routeToProfile()">Cancel
+          </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/profile/tenant/tenant.component.less
+++ b/src/app/profile/tenant/tenant.component.less
@@ -1,0 +1,84 @@
+@import (reference) '../../../assets/stylesheets/shared/osio.less';
+.checkbox input[type='checkbox'] {
+  margin-left: 0;
+  margin-right: 5px;
+  position: relative;
+}
+.getting-started { padding-bottom: 20px; }
+.margin-top-40 { margin-top: 40px; }
+.padding-top-30 { padding-top: 30px; }
+.padding-top-40 { padding-top: 40px; }
+.preview-cont { margin-bottom: 15px; }
+.preview-btn {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  max-height: 29px;
+  white-space: normal;
+}
+.profile-wrapper {
+  &-email,
+  &-url,
+  &-bio,
+  &-username {
+    padding-left: 5px;
+  }
+}
+.preview-field {
+  position: absolute;
+  bottom: 0;
+  padding-left: 0;
+}
+.profile-img-none,
+.preview-img-none {
+  border-bottom: solid 1px;
+  border-bottom-color: @color-pf-black-300;
+  border-left: solid 2px;
+  border-left-color: @color-pf-black-300;
+  border-top: solid 2px;
+  border-top-color: @color-pf-black-300;
+  border-right: solid 1px;
+  border-right-color: @color-pf-black-300;
+}
+textarea {
+  resize: none;
+}
+.token-body { word-wrap: break-word; }
+.token-heading {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.token-heading-cont { display: flex; }
+.btn {
+  &-cancel {
+    margin-left: 14px;
+  }
+}
+.feature-toggle-text {
+  &-body {
+    margin-top: 25px;
+    margin-bottom: 25px;
+    font-style: italic;
+    color: @color-pf-black-500;
+  }
+}
+.profile {
+  &-edit {
+    margin-bottom: 75px;
+  }
+  &-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 50px;
+    border-top: 1px solid;
+    border-top-color: @color-pf-black-300;
+    background-color: @color-pf-black-200;
+  }
+  &-bar-buttons {
+    margin-top: 9px;
+    text-align: center;
+  }
+}

--- a/src/app/profile/tenant/tenant.component.ts
+++ b/src/app/profile/tenant/tenant.component.ts
@@ -1,0 +1,293 @@
+import {AfterViewInit, Component, ElementRef, OnInit, ViewChild, ViewEncapsulation} from '@angular/core';
+import {NgForm} from '@angular/forms';
+import {Router} from '@angular/router';
+import {Subscription} from 'rxjs';
+
+import {Notification, Notifications, NotificationType} from 'ngx-base';
+import {Context, Contexts} from 'ngx-fabric8-wit';
+import {AuthenticationService, User, UserService} from 'ngx-login-client';
+
+import {CopyService} from '../services/copy.service';
+import {ExtProfile, GettingStartedService} from '../../getting-started/services/getting-started.service';
+import {GitHubService} from "../../space/create/codebases/services/github.service";
+import {ProviderService} from '../../getting-started/services/provider.service';
+import {TenentService} from '../services/tenent.service';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'alm-update',
+  templateUrl: 'tenant.component.html',
+  styleUrls: ['./tenant.component.less'],
+  providers: [CopyService, GettingStartedService, GitHubService, ProviderService, TenentService]
+})
+export class TenantComponent implements AfterViewInit, OnInit {
+  @ViewChild('_jenkinsVersion') jenkinsVersionElement: HTMLElement;
+  @ViewChild('_cheVersion') cheVersionElement: HTMLElement;
+  @ViewChild('_mavenRepo') mavenRepoElement: ElementRef;
+  @ViewChild('_boosterGitRef') boosterGitRefElement: HTMLElement;
+  @ViewChild('_boosterGitRepo') boosterGitRepoElement: HTMLElement;
+
+  @ViewChild('tenantForm') profileForm: NgForm;
+
+  jenkinsVersion: string;
+  cheVersion: string;
+  mavenRepo: string;
+  updateTenant: boolean = true;
+
+  boosterGitRef: string;
+  boosterGitRepo: string;
+
+  context: Context;
+
+  jenkinsVersionInvalid: boolean = false;
+  cheVersionInvalid: boolean = false;
+  mavenRepoInvalid: boolean = false;
+
+  boosterGitRefInvalid: boolean = false;
+  boosterGitRepoInvalid: boolean = false;
+
+  loadedFormEmpty: boolean;
+
+  gitHubLinked: boolean = false;
+  imageUrl: string;
+  loggedInUser: User;
+  fullName: string;
+  openShiftLinked: boolean = false;
+  registrationCompleted: boolean = true;
+  subscriptions: Subscription[] = [];
+  token: string;
+  username: string;
+  url: string;
+
+  constructor(
+      private auth: AuthenticationService,
+      private gettingStartedService: GettingStartedService,
+      private contexts: Contexts,
+      private notifications: Notifications,
+      private router: Router,
+      private userService: UserService) {
+    this.subscriptions.push(contexts.current.subscribe(val => this.context = val));
+    this.subscriptions.push(userService.loggedInUser.subscribe(user => {
+      this.loggedInUser = user;
+      this.setUserProperties(user);
+    }));
+    this.subscriptions.push(auth.gitHubToken.subscribe(token => {
+      this.gitHubLinked = (token !== undefined && token.length !== 0);
+    }));
+    this.subscriptions.push(auth.openShiftToken.subscribe(token => {
+      this.openShiftLinked = (token !== undefined && token.length !== 0);
+    }));
+  }
+
+  ngAfterViewInit(): void {
+    // Set focus
+    if (this.getRequestParam('jenkinsVersion') !== null) {
+      this.setElementFocus(null, this.jenkinsVersionElement);
+    } else if (this.getRequestParam('boosterGitRef') !== null) {
+      this.setElementFocus(null, this.boosterGitRefElement);
+    }
+  }
+
+  ngOnInit() {
+    this.token = this.auth.getToken();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => {
+      sub.unsubscribe();
+    });
+  }
+
+
+  get isUpdateProfileDisabled(): boolean {
+    return ((!this.profileForm.dirty && !(!this.loadedFormEmpty && this.formValuesEmpty())) ||
+            (this.jenkinsVersionInvalid || this.cheVersionInvalid || this.mavenRepoInvalid || this.boosterGitRefInvalid || this.boosterGitRepoInvalid));
+  }
+
+  /**
+   * Route to user profile
+   */
+  routeToProfile(): void {
+    this.router.navigate(['/', this.context.user.attributes.username]);
+  }
+
+  /**
+   * Set element focus to given HTML elment
+   *
+   * @param $event The triggered event
+   * @param element The component or HTML element to set focus
+   */
+  setElementFocus($event: MouseEvent, element: any) {
+    if (element instanceof HTMLElement) {
+      (element as HTMLElement).focus();
+    }
+  }
+
+  /**
+   * Resets the profile back to empty values
+   */
+
+  resetProfile(): void {
+/*
+    this.boosterGitRef = "";
+    this.boosterGitRepo = "";
+
+    this.jenkinsVersion = "";
+    this.cheVersion = "";
+    this.mavenRepo = "";
+    this.updateTenant = true;
+
+    this.boosterGitRepoValidate();
+    this.mavenRepoValidate();
+*/
+
+/*
+    this.profileForm.resetForm();
+*/
+    this.profileForm.reset();
+    this.updateTenant = true;
+  }
+
+  /**
+   * Update user profile
+   */
+  updateProfile(): void {
+    let profile = this.getTransientProfile();
+    let contextInformation = profile.contextInformation;
+    if (!contextInformation) {
+      contextInformation = {};
+      profile.contextInformation = contextInformation;
+    }
+
+    var boosterCatalog = contextInformation["boosterCatalog"];
+    if (!boosterCatalog) {
+      boosterCatalog = {};
+      contextInformation["boosterCatalog"] = boosterCatalog;
+    }
+    boosterCatalog["gitRef"] = this.boosterGitRef;
+    boosterCatalog["gitRepo"] = this.boosterGitRepo;
+
+    var tenantConfig = contextInformation["tenantConfig"];
+    if (!tenantConfig) {
+      tenantConfig = {};
+      contextInformation["tenantConfig"] = tenantConfig;
+    }
+    tenantConfig["jenkinsVersion"] = this.jenkinsVersion;
+    tenantConfig["cheVersion"] = this.cheVersion;
+    tenantConfig["mavenRepo"] = this.mavenRepo;
+    tenantConfig["updateTenant"] = this.updateTenant;
+
+
+    this.subscriptions.push(this.gettingStartedService.update(profile).subscribe(user => {
+      this.setUserProperties(user);
+      this.notifications.message({
+        message: `Profile updated!`,
+        type: NotificationType.SUCCESS
+      } as Notification);
+      this.routeToProfile();
+    }, error => {
+      if (error.status === 409) {
+        this.handleError("Email already exists", NotificationType.DANGER);
+      } else {
+        this.handleError("Failed to update profile", NotificationType.DANGER);
+      }
+    }));
+  }
+
+  boosterGitRepoValidate(): void {
+    this.boosterGitRefInvalid = !this.isUrlValid(this.boosterGitRepo);
+  }
+
+  mavenRepoValidate(): void {
+    this.mavenRepoInvalid = !this.isUrlValid(this.mavenRepo);
+  }
+
+  // Private
+
+  /**
+   * Helper to retrieve request parameters
+   *
+   * @param name The request parameter to retrieve
+   * @returns {any} The request parameter value or null
+   */
+  private getRequestParam(name: string): string {
+    let param = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(window.location.search);
+    if (param != null) {
+      return decodeURIComponent(param[1]);
+    }
+    return null;
+  }
+
+  /**
+   * Get transient profile with updated properties
+   *
+   * @returns {ExtProfile} The updated transient profile
+   */
+  private getTransientProfile(): ExtProfile {
+    let profile = this.gettingStartedService.createTransientProfile();
+    delete profile.username;
+    return profile;
+  }
+
+
+  /**
+   * Set user properties
+   *
+   * @param user
+   */
+  private setUserProperties(user: User): void {
+    if (user.attributes === undefined) {
+      return;
+    }
+
+    var contextInformation = user.attributes["contextInformation"];
+    if (!contextInformation) {
+      contextInformation = {};
+      user.attributes["contextInformation"] = contextInformation;
+    }
+
+    let boosterCatalog = contextInformation["boosterCatalog"];
+    if (boosterCatalog) {
+      this.boosterGitRef = boosterCatalog["gitRef"] || "";
+      this.boosterGitRepo = boosterCatalog["gitRepo"] || "";
+    }
+
+    let tenantConfig = contextInformation["tenantConfig"];
+    if (tenantConfig) {
+      this.jenkinsVersion = tenantConfig["jenkinsVersion"] || "";
+      this.cheVersion = tenantConfig["cheVersion"] || "";
+      this.mavenRepo = tenantConfig["mavenRepo"] || "";
+      this.updateTenant = tenantConfig["updateTenant"] || false;
+    }
+
+    this.loadedFormEmpty = this.formValuesEmpty();
+  }
+
+  /**
+   * Helper to test if URL is valid
+   *
+   * @returns {boolean}
+   */
+  private isUrlValid(url: string): boolean {
+    var trimmed = "";
+    if (url) {
+      trimmed = url.trim();
+    }
+    if (!trimmed) {
+      return true;
+    }
+    return trimmed.startsWith("http:") || trimmed.startsWith("https:");
+  }
+
+  private handleError(error: string, type: NotificationType) {
+    this.notifications.message({
+      message: error,
+      type: type
+    } as Notification);
+  }
+
+  private formValuesEmpty() {
+    return !(this.boosterGitRef || this.boosterGitRepo ||
+      this.jenkinsVersion || this.cheVersion || this.mavenRepo || !this.updateTenant);
+  }
+}

--- a/src/app/profile/tenant/tenant.module.ts
+++ b/src/app/profile/tenant/tenant.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, Http } from '@angular/http';
+import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
+
+import { RemainingCharsCountModule } from 'patternfly-ng';
+
+import { TenantComponent } from './tenant.component';
+import {TenantRoutingModule} from "./tenant-routing.module";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    HttpModule,
+    JWBootstrapSwitchModule,
+    RemainingCharsCountModule,
+    TenantRoutingModule
+  ],
+  declarations: [ TenantComponent ],
+})
+export class TenantModule {
+  constructor(http: Http) {}
+}


### PR DESCRIPTION
lets add a (hidden by default) tenant configuration screen that lets the user configure

* the booster catalog ref + URL
* the jenkins, che, maven repo for the tenant version

the idea is this UI will only really be visible for internal/test accounts
if ever & would be used by the E2E tests to test a specific booster PR or a
specific tenant release PR (e.g. jenkins or che) by setting some custom
properties on the user that forge + f8tenant can detect

this PR adds a new `_tenant` tab to the user profile that lets you edit tenant related stuff (booster catalog details + tenant version stuff)