### PR TITLE
fix(status): Update app label used for jenkins

### DIFF
--- a/src/a-runtime-console/kubernetes/ui/status/status-list.component.ts
+++ b/src/a-runtime-console/kubernetes/ui/status/status-list.component.ts
@@ -114,7 +114,7 @@ export class StatusListComponent extends AbstractWatchComponent implements OnIni
       .subscribe(ns => {
         if (ns) {
           let namespaceName = ns.name;
-          let data = this.listAndWatch(this.podService, namespaceName, Pod).map(pods => podsToStatusInfo(pods, "app", "jenkins-openshift"));
+          let data = this.listAndWatch(this.podService, namespaceName, Pod).map(pods => podsToStatusInfo(pods, "app", "jenkins"));
           this.loading.next(false);
           this.pipelineStatus.replaceSubscription(ns, data);
         }


### PR DESCRIPTION
"app" label has changed from "jenkins-openshift" to "jenkins"

Fixes openshiftio/openshift.io#665

This fixes the above problem, but unsure if it should be fixed in UI or in the templates?