### PR TITLE
Disable email update in profile

### DIFF
--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -21,7 +21,8 @@
             <input type="email" class="form-control" id="email" name="email" #_email
                     placeholder="name@gmail.com"
                     [(ngModel)]="email"
-                    (change)="validateEmail()">
+                    (change)="validateEmail()"
+                    disabled>
           </div>
         </div>
         <div class="form-group">


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/fabric8-auth/issues/63
Related to https://github.com/openshiftio/openshift.io/issues/713

This PR just disable the email field in user's profile page. Eventually we will verify updated emails and will allow updating emails. See https://github.com/fabric8-services/fabric8-auth/issues/62

![profile](https://user-images.githubusercontent.com/620087/29883192-531ea162-8d64-11e7-9f0a-a0797f850c79.png)
