### PR TITLE
New planner non-contextual detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "angular2-tree-component": "2.7.0",
     "chunk-manifest-webpack2-plugin": "1.0.1",
     "core-js": "2.4.1",
-    "fabric8-planner": "0.31.1",
+    "fabric8-planner": "0.34.0",
     "fabric8-stack-analysis-ui": "0.6.1",
     "http-server": "0.9.0",
     "ie-shim": "0.1.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -101,11 +101,16 @@ export const routes: Routes = [
     }
   },
 
+  // Plan details
   {
     path: ':entity/:space/plan/detail',
+    resolve: {
+      context: ContextResolver,
+      featureFlagConfig: ExperimentalFeatureResolver
+    },
     loadChildren: './space/plan/detail/detail.module#DetailModule',
     data: {
-      title: 'Plan: Dailet',
+      title: 'Plan: Detail',
       featureName: 'Planner'
     }
   },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -101,6 +101,15 @@ export const routes: Routes = [
     }
   },
 
+  {
+    path: ':entity/:space/plan/detail',
+    loadChildren: './space/plan/detail/detail.module#DetailModule',
+    data: {
+      title: 'Plan: Dailet',
+      featureName: 'Planner'
+    }
+  },
+
   // Create
   {
     path: ':entity/:space/create',

--- a/src/app/space/plan/detail/detail.module.ts
+++ b/src/app/space/plan/detail/detail.module.ts
@@ -1,0 +1,12 @@
+import { WorkItemNewDetailModule } from 'fabric8-planner';
+import { NgModule }         from '@angular/core';
+import { CommonModule }     from '@angular/common';
+import { Http } from '@angular/http';
+
+
+@NgModule({
+  imports:      [ CommonModule, WorkItemNewDetailModule ]
+})
+export class DetailModule {
+  constructor(http: Http) {}
+}

--- a/src/app/space/plan/detail/detail.module.ts
+++ b/src/app/space/plan/detail/detail.module.ts
@@ -1,11 +1,11 @@
-import { WorkItemNewDetailModule } from 'fabric8-planner';
+import { PlannerDetailModule } from 'fabric8-planner';
 import { NgModule }         from '@angular/core';
 import { CommonModule }     from '@angular/common';
 import { Http } from '@angular/http';
 
 
 @NgModule({
-  imports:      [ CommonModule, WorkItemNewDetailModule ]
+  imports:      [ CommonModule, PlannerDetailModule ]
 })
 export class DetailModule {
   constructor(http: Http) {}


### PR DESCRIPTION
Now the detail page is a separate module all together and the URL structure has changed. This depends https://github.com/fabric8-ui/fabric8-planner/pull/2126 . 
