### PR TITLE
Codebases: Implement Che start API

### DIFF
--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -4,7 +4,7 @@
   <span class="margin-right-5"></span>
 </ng-template>
 <ng-template #showCol>
-  <span class="dropdown dropdown-kebab-pf" dropdown>
+  <span class="dropdown dropdown-kebab-pf" dropdown *ngIf="cheRunning">
     <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
       <span class="fa fa-ellipsis-v"></span>
     </button>

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
@@ -27,7 +27,7 @@ describe('Codebases Item Actions Component', () => {
   beforeEach(() => {
     gitHubServiceMock = jasmine.createSpy('GitHubService');
     notificationMock = jasmine.createSpyObj('Notifications', ['message']);
-    broadcasterMock = jasmine.createSpyObj('Broadcaster', ['broadcast']);
+    broadcasterMock = jasmine.createSpyObj('Broadcaster', ['broadcast', 'on']);
     windowServiceMock = jasmine.createSpyObj('WindowService', ['open']);
     workspacesServiceMock = jasmine.createSpyObj('WorkspacesService', ['createWorkspace']);
 
@@ -56,9 +56,6 @@ describe('Codebases Item Actions Component', () => {
     });
     fixture = TestBed.createComponent(CodebasesItemActionsComponent);
   });
-/*
-  Temporarily disabling until this error is resolved:
-  "undefined is not a constructor (evaluating 'this.broadcaster.on('cheStateChange')')"
 
   it('Create And Open Workspace succesfully', async(() => {
     // given
@@ -74,6 +71,7 @@ describe('Codebases Item Actions Component', () => {
     const notificationAction = { name: "created" };
     notificationMock.message.and.returnValue(Observable.of(notificationAction));
     broadcasterMock.broadcast.and.returnValue();
+    broadcasterMock.on.and.returnValue(Observable.of({ running: true }));
     fixture.detectChanges();
     // when
     comp.createAndOpenWorkspace();
@@ -91,6 +89,7 @@ describe('Codebases Item Actions Component', () => {
     workspacesServiceMock.createWorkspace.and.returnValue(Observable.throw('ERROR'));
     const notificationAction = { name: "ERROR" };
     notificationMock.message.and.returnValue(Observable.of(notificationAction));
+    broadcasterMock.on.and.returnValue(Observable.of({ running: true }));
     fixture.detectChanges();
     // when
     comp.createAndOpenWorkspace();
@@ -98,5 +97,4 @@ describe('Codebases Item Actions Component', () => {
     // then
     expect(notificationMock.message).toHaveBeenCalled();
   }));
-*/
 });

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
@@ -56,6 +56,9 @@ describe('Codebases Item Actions Component', () => {
     });
     fixture = TestBed.createComponent(CodebasesItemActionsComponent);
   });
+/*
+  Temporarily disabling until this error is resolved:
+  "undefined is not a constructor (evaluating 'this.broadcaster.on('cheStateChange')')"
 
   it('Create And Open Workspace succesfully', async(() => {
     // given
@@ -95,4 +98,5 @@ describe('Codebases Item Actions Component', () => {
     // then
     expect(notificationMock.message).toHaveBeenCalled();
   }));
+*/
 });

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -26,13 +26,6 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
       private notifications: Notifications,
       private windowService: WindowService,
       private workspacesService: WorkspacesService) {
-    this.subscriptions.push(this.broadcaster
-      .on('cheStateChange')
-      .subscribe((che: Che) => {
-        if (che != undefined && che.running === true) {
-          this.cheRunning = true;
-        }
-      }));
   }
 
   ngOnDestroy(): void {
@@ -42,6 +35,13 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
+    this.subscriptions.push(this.broadcaster
+      .on('cheStateChange')
+      .subscribe((che: Che) => {
+        if (che != undefined && che.running === true) {
+          this.cheRunning = true;
+        }
+      }));
   }
 
   // Actions

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Subscription } from 'rxjs';
 
+import { Che } from '../services/che';
 import { Codebase } from '../services/codebase';
 import { Broadcaster, Notification, NotificationType, Notifications } from 'ngx-base';
 import { WindowService } from '../services/window.service';
@@ -16,6 +17,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   @Input() codebase: Codebase;
   @Input() index: number = -1;
 
+  cheRunning: boolean = false;
   subscriptions: Subscription[] = [];
   workspaceBusy: boolean = false;
 
@@ -24,6 +26,13 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
       private notifications: Notifications,
       private windowService: WindowService,
       private workspacesService: WorkspacesService) {
+    this.subscriptions.push(this.broadcaster
+      .on('cheStateChange')
+      .subscribe((che: Che) => {
+        if (che != undefined && che.running === true) {
+          this.cheRunning = true;
+        }
+      }));
   }
 
   ngOnDestroy(): void {

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
@@ -50,7 +50,6 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
     }
     this.workspaces = [];
     this.updateWorkspaces();
-    this.workspacePollTimer = Observable.timer(3000, 30000).take(10);
     this.broadcaster.on('workspaceCreated')
       .subscribe((val) => {
         if ((val as WorkspaceCreatedEvent).codebase.id === this.codebase.id) {
@@ -164,7 +163,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
           this.setWorkspaceUrl(this.codebase.attributes.last_used_workspace);
         }
       }, error => {
-        // Do nothing
+        console.log("Failed to retrieve workspaces for codebase ID: " + this.codebase.id);
       }));
   }
 
@@ -181,6 +180,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
     if (this.workspacePollSubscription !== undefined && !this.workspacePollSubscription.closed) {
       this.workspacePollSubscription.unsubscribe();
     }
+    this.workspacePollTimer = Observable.timer(2000, 20000).take(30);
     this.workspacePollSubscription = this.workspacePollTimer
       .switchMap(() => this.workspacesService.getWorkspaces(this.codebase.id))
       .map(workspaces => {

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.html
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.html
@@ -18,9 +18,9 @@
            placement="top"></i>
         <div class="workspaces-banner">
           <f8-workspaces-notification *ngIf="cheStarting"
-                                  [dismiss]="cheRunning"
-                                  [message]="notificationMessage"
-                                  [type]="notificationType"></f8-workspaces-notification>
+                                      [dismiss]="cheRunning"
+                                      [message]="notificationMessage"
+                                      [type]="notificationType"></f8-workspaces-notification>
         </div>
       </div>
     </div>

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.html
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.html
@@ -16,6 +16,12 @@
         <i class="pficon pficon-info margin-left-5"
            tooltip="Workspaces are web based development environments for your code and runtime needs"
            placement="top"></i>
+        <div class="workspaces-banner">
+          <f8-workspaces-notification *ngIf="cheStarting"
+                                  [dismiss]="cheRunning"
+                                  [message]="notificationMessage"
+                                  [type]="notificationType"></f8-workspaces-notification>
+        </div>
       </div>
     </div>
   </div>
@@ -34,7 +40,7 @@
       <div class="list-pf-description">{{lastCommitDate | date:'medium'}}</div>
     </div>
     <div class="list-pf-additional-content">
-      <codebases-item-workspaces [codebase]="codebase" [index]="index"></codebases-item-workspaces>
+      <codebases-item-workspaces [codebase]="codebase" [index]="index" *ngIf="cheRunning"></codebases-item-workspaces>
     </div>
   </div>
 </ng-template>

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.less
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.less
@@ -1,2 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .margin-right-30 { margin-right: 30px; }
+.workspaces-banner {
+  .workspaces-notification { margin-top: 5px; }
+}

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
@@ -1,7 +1,7 @@
 import { CodebasesItemComponent } from './codebases-item.component';
 import { Observable } from 'rxjs';
 import { Contexts } from 'ngx-fabric8-wit';
-import { Notifications, NotificationType } from 'ngx-base';
+import { Broadcaster, Notifications, NotificationType } from 'ngx-base';
 import { CodebasesService } from '../services/codebases.service';
 import { GitHubService } from '../services/github.service';
 import { NO_ERRORS_SCHEMA } from "@angular/core";
@@ -18,11 +18,13 @@ import {
 import { cloneDeep } from 'lodash';
 
 describe('Codebases Item Component', () => {
+  let broadcasterMock: any;
   let gitHubServiceMock: any;
   let notificationMock: any;
   let fixture, codebases, codebase;
 
   beforeEach(() => {
+    broadcasterMock = jasmine.createSpyObj('Broadcaster', ['broadcast']);
     gitHubServiceMock = jasmine.createSpyObj('GitHubService', ['getRepoDetailsByUrl']);
     notificationMock = jasmine.createSpyObj('Notifications', ['message']);
 
@@ -30,6 +32,9 @@ describe('Codebases Item Component', () => {
       imports: [FormsModule, HttpModule],
       declarations: [CodebasesItemComponent],
       providers: [
+        {
+          provide: Broadcaster, useValue: broadcasterMock
+        },
         {
           provide: GitHubService, useValue: gitHubServiceMock
         },
@@ -72,6 +77,10 @@ describe('Codebases Item Component', () => {
     fixture = TestBed.createComponent(CodebasesItemComponent);
   });
 
+/*
+  Temporarily disabling until this error is resolved:
+  Error: No provider for Broadcaster! in config/spec-bundle.js (line 198839)
+
   it('Init component succesfully', async(() => {
     // given
     let comp = fixture.componentInstance;
@@ -83,4 +92,5 @@ describe('Codebases Item Component', () => {
       expect(spanDisplayedInformation.length).toEqual(1)
     });
   }));
+*/
 });

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
@@ -24,7 +24,7 @@ describe('Codebases Item Component', () => {
   let fixture, codebases, codebase;
 
   beforeEach(() => {
-    broadcasterMock = jasmine.createSpyObj('Broadcaster', ['broadcast']);
+    broadcasterMock = jasmine.createSpyObj('Broadcaster', ['on']);
     gitHubServiceMock = jasmine.createSpyObj('GitHubService', ['getRepoDetailsByUrl']);
     notificationMock = jasmine.createSpyObj('Notifications', ['message']);
 
@@ -77,20 +77,16 @@ describe('Codebases Item Component', () => {
     fixture = TestBed.createComponent(CodebasesItemComponent);
   });
 
-/*
-  Temporarily disabling until this error is resolved:
-  Error: No provider for Broadcaster! in config/spec-bundle.js (line 198839)
-
   it('Init component succesfully', async(() => {
     // given
     let comp = fixture.componentInstance;
     let debug = fixture.debugElement;
     comp.codebase = codebase;
+    broadcasterMock.on.and.returnValue(Observable.of({ running: true }));
     fixture.detectChanges();
     let spanDisplayedInformation = debug.queryAll(By.css('.list-pf-title'));
     fixture.whenStable().then(() => {
       expect(spanDisplayedInformation.length).toEqual(1)
     });
   }));
-*/
 });

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Subscription } from 'rxjs';
 
+import { Che } from '../services/che';
 import { Codebase } from '../services/codebase';
-import { CodebasesService } from '../services/codebases.service';
 import { GitHubService } from "../services/github.service";
-import { Notification, NotificationType, Notifications } from 'ngx-base';
+import { Broadcaster, Notification, NotificationType, Notifications } from 'ngx-base';
+import { NotificationType as NotificationTypes } from 'patternfly-ng';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -16,15 +17,40 @@ export class CodebasesItemComponent implements OnDestroy, OnInit {
   @Input() codebase: Codebase;
   @Input() index: number = -1;
 
+  cheErrorMessage: string = "Your Workspaces failed to load";
+  cheStarting: boolean = false;
+  cheStartingMessage: string = "Your Workspaces are loading...";
+  cheRunning: boolean = false;
+  cheRunningMessage: string = "Your Workspaces have loaded successfully";
   createdDate: string;
   fullName: string;
   lastCommitDate: string;
   htmlUrl: string;
+  notificationMessage: string;
+  notificationType: string;
   subscriptions: Subscription[] = [];
 
   constructor(
-    private gitHubService: GitHubService,
-    private notifications: Notifications) {
+      private broadcaster: Broadcaster,
+      private gitHubService: GitHubService,
+      private notifications: Notifications) {
+    this.subscriptions.push(this.broadcaster
+      .on('cheStateChange')
+      .subscribe((che: Che) => {
+        if (che === undefined) {
+          this.notificationMessage = this.cheErrorMessage;
+          this.notificationType = NotificationTypes.DANGER;
+          this.cheStarting = true;
+        } else if (che.running === true) {
+          this.notificationMessage = this.cheRunningMessage;
+          this.notificationType = NotificationTypes.SUCCESS;
+          this.cheRunning = true;
+        } else if (che.running === false) {
+          this.notificationMessage = this.cheStartingMessage;
+          this.notificationType = NotificationTypes.INFO;
+          this.cheStarting = true;
+        }
+      }));
   }
 
   ngOnDestroy(): void {

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.ts
@@ -18,22 +18,31 @@ export class CodebasesItemComponent implements OnDestroy, OnInit {
   @Input() index: number = -1;
 
   cheErrorMessage: string = "Your Workspaces failed to load";
-  cheStarting: boolean = false;
-  cheStartingMessage: string = "Your Workspaces are loading...";
   cheRunning: boolean = false;
   cheRunningMessage: string = "Your Workspaces have loaded successfully";
+  cheStarting: boolean = false;
+  cheStartingMessage: string = "Your Workspaces are loading...";
   createdDate: string;
   fullName: string;
   lastCommitDate: string;
   htmlUrl: string;
-  notificationMessage: string;
-  notificationType: string;
+  notificationMessage: string = this.cheStartingMessage;
+  notificationType: string = NotificationTypes.INFO;
   subscriptions: Subscription[] = [];
 
   constructor(
       private broadcaster: Broadcaster,
       private gitHubService: GitHubService,
       private notifications: Notifications) {
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => {
+      sub.unsubscribe();
+    });
+  }
+
+  ngOnInit(): void {
     this.subscriptions.push(this.broadcaster
       .on('cheStateChange')
       .subscribe((che: Che) => {
@@ -51,15 +60,6 @@ export class CodebasesItemComponent implements OnDestroy, OnInit {
           this.cheStarting = true;
         }
       }));
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.forEach(sub => {
-      sub.unsubscribe();
-    });
-  }
-
-  ngOnInit(): void {
     if (this.codebase === undefined || this.codebase.attributes === undefined) {
       return;
     }

--- a/src/app/space/create/codebases/codebases-item/codebases-item.module.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.module.ts
@@ -4,7 +4,9 @@ import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
+import { NotificationModule } from 'patternfly-ng';
 
+import { WorkspacesNotificationModule } from '../workspaces-notification/workspaces-notification.module';
 import { CodebasesService } from '../services/codebases.service';
 import { GitHubService } from "../services/github.service";
 import { CodebasesItemComponent } from './codebases-item.component';
@@ -15,7 +17,9 @@ import { CodebasesItemWorkspacesModule } from '../codebases-item-workspaces/code
     CodebasesItemWorkspacesModule,
     CommonModule,
     FormsModule,
-    TooltipModule.forRoot()
+    NotificationModule,
+    TooltipModule.forRoot(),
+    WorkspacesNotificationModule
   ],
   declarations: [ CodebasesItemComponent ],
   exports: [ CodebasesItemComponent ],

--- a/src/app/space/create/codebases/services/che.service.ts
+++ b/src/app/space/create/codebases/services/che.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, Inject } from '@angular/core';
+import { Headers, Http } from '@angular/http';
+import { AuthenticationService, UserService } from 'ngx-login-client';
+import { Logger } from 'ngx-base';
+import { Observable } from 'rxjs';
+
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { Che } from './che';
+
+@Injectable()
+export class CheService {
+  private headers = new Headers({ 'Content-Type': 'application/json' });
+  private workspacesUrl: string;
+
+  constructor(
+      private http: Http,
+      private logger: Logger,
+      private auth: AuthenticationService,
+      private userService: UserService,
+      @Inject(WIT_API_URL) apiUrl: string) {
+    if (this.auth.getToken() != null) {
+      this.headers.set('Authorization', 'Bearer ' + this.auth.getToken());
+    }
+    this.workspacesUrl = apiUrl + 'codebases/che';
+  }
+
+  /**
+   * Get state of Che server
+   *
+   * @returns {Observable<Che>}
+   */
+  getState(): Observable<Che> {
+    let url = `${this.workspacesUrl}/state`;
+    return this.http
+      .get(url, { headers: this.headers })
+      .map(response => {
+        return response.json() as Che;
+      })
+      .catch((error) => {
+        return this.handleError(error);
+      });
+  }
+
+  /**
+   * Start the Che server
+   *
+   * @returns {Observable<Che>}
+   */
+  start(): Observable<Che> {
+    let url = `${this.workspacesUrl}/start`;
+    return this.http
+      .patch(url, {}, { headers: this.headers })
+      .map(response => {
+        return response.json() as Che;
+      })
+      .catch((error) => {
+        return this.handleError(error);
+      });
+  }
+
+  // Private
+
+  private handleError(error: any) {
+    this.logger.error(error);
+    return Observable.throw(error.message || error);
+  }
+}

--- a/src/app/space/create/codebases/services/che.ts
+++ b/src/app/space/create/codebases/services/che.ts
@@ -1,0 +1,3 @@
+export class Che {
+  running: boolean;
+}

--- a/src/app/space/create/codebases/services/workspaces.service.ts
+++ b/src/app/space/create/codebases/services/workspaces.service.ts
@@ -54,6 +54,12 @@ export class WorkspacesService {
     let url = `${this.workspacesUrl}/${codebaseId}/edit`;
     return this.http
       .get(url, { headers: this.headers })
+      .retryWhen(attempts => {
+        let count = 0;
+        return attempts.flatMap(error => {
+          return ++count >= 10 ? Observable.throw(error) : Observable.timer(count * 3000); // Wait for Che to start
+        });
+      })
       .map(response => {
         return response.json().data as Workspace[];
       })

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.html
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.html
@@ -1,6 +1,6 @@
 <div class="workspaces-notification" [class.workspaces-notification-hide]="hide">
   <div class="workspaces-notification-bar workspaces-notification-{{type}}">
-    <i class="pficon pficon-in-progress" *ngIf="type === 'info'"></i>
+    <i class="fa-spin pficon pficon-in-progress" *ngIf="type === 'info'"></i>
     <i class="fa fa-check-circle-o" *ngIf="type === 'success'"></i>
     <i class="fa fa-times-circle-o" *ngIf="type === 'danger'"></i>
     <span class="workspaces-notification-message">{{message}}</span>

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.html
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.html
@@ -1,0 +1,8 @@
+<div class="workspaces-notification" [class.workspaces-notification-hide]="hide">
+  <div class="workspaces-notification-bar workspaces-notification-{{type}}">
+    <i class="pficon pficon-in-progress" *ngIf="type === 'info'"></i>
+    <i class="fa fa-check-circle-o" *ngIf="type === 'success'"></i>
+    <i class="fa fa-times-circle-o" *ngIf="type === 'danger'"></i>
+    <span class="workspaces-notification-message">{{message}}</span>
+  </div>
+</div>

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.less
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.less
@@ -1,0 +1,38 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+.workspaces-notification {
+  position: absolute;
+  vertical-align: middle;
+  z-index: 1;
+  &-bar {
+    color: @color-pf-white;
+    margin: 0;
+    padding-bottom: 2px;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 0;
+    position: relative;
+    text-align: center;
+  }
+  &-danger {
+    background-color: @color-pf-red;
+    i { font-size: 1.2em; }
+  }
+  &-hide {
+    display: none;
+  }
+  &-info {
+    background-color: @color-pf-black-700;
+  }
+  &-message {
+    font-size: .8em;
+    padding-bottom: 5px;
+    padding-left: 5px;
+  }
+  &-success {
+    background-color: @color-pf-green-500;
+    i { font-size: 1.2em; }
+  }
+  i { vertical-align: middle; }
+}
+

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.ts
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.ts
@@ -1,0 +1,58 @@
+import {
+  Component,
+  DoCheck,
+  Input,
+  OnInit
+} from '@angular/core';
+
+import { NotificationType } from 'patternfly-ng';
+
+@Component({
+  selector: 'f8-workspaces-notification',
+  styleUrls: ['./workspaces-notification.component.less'],
+  templateUrl: './workspaces-notification.component.html'
+})
+export class WorkspacesNotificationComponent implements DoCheck, OnInit {
+  /**
+   * Indicates notification is shown
+   */
+  @Input() dismiss: boolean = false;
+
+  /**
+   * Delay (in ms) indicating for how long to display notification after show is set to false
+   */
+  @Input() dismissDelay: number = 7000;
+
+  /**
+   * Notification message
+   */
+  @Input() message: string = '';
+
+  /**
+   * The notification type (e.g., NotificationType.SUCCESS, NotificationType.INFO, etc.)
+   */
+  @Input() type: string = NotificationType.INFO;
+
+  private _hide: boolean = false;
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+
+  ngDoCheck() {
+    if (this.dismiss === true) {
+      setTimeout(() => {
+        this._hide = this.dismiss;
+      }, this.dismissDelay);
+    }
+  }
+
+  /**
+   * Indicates notification should be hidden
+   */
+  get hide(): boolean {
+    return this._hide;
+  }
+}

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.module.ts
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Http } from '@angular/http';
+
+import { NotificationModule } from 'patternfly-ng';
+
+import { WorkspacesNotificationComponent } from './workspaces-notification.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    NotificationModule
+  ],
+  declarations: [ WorkspacesNotificationComponent ],
+  exports: [ WorkspacesNotificationComponent ]
+})
+export class WorkspacesNotificationModule {
+  constructor(http: Http) {}
+}


### PR DESCRIPTION
The codebases page has been refactored to use the new Che start API. 

When the user enters the codebases page, we test if the Che server is running and start Che if necessary. While waiting for Che to start, the user is prompted with a status message. In the mean time, controls to create and open Che workspaces are hidden from view. Once we detect that the Che server is running, the user is presented with a final message indicating success. At this point, the controls to create and open Che workspaces are now visible. The success message remains visible for 7 seconds, then it's removed from view.

This functionality is based on the UX design located here: https://redhat.invisionapp.com/share/KMD5F2BV4#/screens/249837717

This addresses the following issues:
- https://github.com/fabric8-ui/fabric8-ui/issues/1825.
- https://github.com/openshiftio/openshift.io/issues/560
- https://github.com/openshiftio/openshift.io/issues/514

To test, open the Openshift console, select the Che project, and scale down Che so it becomes idle. For example, https://console.starter-us-east-2.openshift.com/console/project/username-che/overview

![screen shot 2017-09-01 at 11 33 06 am](https://user-images.githubusercontent.com/17481322/29977848-c6b59f0a-8f0c-11e7-98bb-7f672ae60413.png)

Now, navigate to the codebases page or reload. You should see the "Your Workspaces are loading..." message below.

![screen shot 2017-09-01 at 11 51 24 am](https://user-images.githubusercontent.com/17481322/29977878-ee56a194-8f0c-11e7-9185-4f963d4742d2.png)

After Che has started in the Openshift console, it may take a few moments before the underlying API applies the Che running state. Ultimately, the copdebases page will display the "Your Workspaces have loaded successfully" message below. The controls to open and/or create workspaces should also be visible.

![screen shot 2017-09-01 at 11 52 59 am](https://user-images.githubusercontent.com/17481322/29977976-516c3c76-8f0d-11e7-8cb0-55ebfc5a1f5c.png)

Finally, after a 7 second timeout, the success message is removed from view.
![screen shot 2017-09-01 at 11 53 45 am](https://user-images.githubusercontent.com/17481322/29978015-78933340-8f0d-11e7-961e-d7005c94ec10.png)
