### PR TITLE
fix(htmlhint): change tagname case requirements

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,5 +1,5 @@
 {
-  "tagname-lowercase": true,
+  "tagname-lowercase": false,
   "attr-value-not-empty": false,
   "attr-no-duplication": true,
   "doctype-first": false,


### PR DESCRIPTION
remove the requirement that tagnames are all lowercase, due to Angular element conflicts

