### PR TITLE
fix(cards): remove padding overrides from cards

### DIFF
--- a/src/assets/stylesheets/shared/_cards.less
+++ b/src/assets/stylesheets/shared/_cards.less
@@ -1,8 +1,6 @@
 // -- Cards --
 .f8 {
   &-card {
-    padding-right: 0;
-    padding-left: 0;
     height: 440px;
     &-body {
       margin-top: 0;


### PR DESCRIPTION
remove the padding overrides from cards, returning them to default PatternFly style

related to https://github.com/fabric8-ui/fabric8-ux/issues/661

