### PR TITLE
Reload codebases on ‘addedCodebase’ event

### DIFF
--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -57,7 +57,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
     this.subscriptions.push(this.broadcaster
       .on('codebaseAdded')
       .subscribe((codebase: Codebase) => {
-        this.addCodebase(codebase);
+        this.updateCodebases();
       }));
   }
 
@@ -278,6 +278,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
           this.allCodebases = codebases;
           this.codebases = cloneDeep(codebases);
           this.codebases.unshift({} as Codebase); // Add empty object for row header
+          this.applyFilters(this.appliedFilters);
         }
       }, error => {
         this.handleError("Failed to retrieve codebases", NotificationType.DANGER);


### PR DESCRIPTION
Modified the codebases page to reload the codebases list whenever the 'codebaseAdded' event is received. 

fixes  https://github.com/openshiftio/openshift.io/issues/797

This new approach is somewhat less efficient considering we already retrieve a new codebase from the "Add Codebase" slide-out panel. However, this will ensure we only display codebases for the current space, regardless of what forge wizard does.

Currently, the forge wizard is broadcasting the ‘addedCodebase’ event, inadvertently showing a newly created codebase for the wrong space. The forge wizard probably should not broadcast that event, but it will no longer effect the codebases page other than to force the list to reload.