### PR TITLE
fix(setting): update header on Areas/Collaborators

### DIFF
--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -1,12 +1,12 @@
 <div class="container-fluid">
-  <h3 class="areas-header">Areas that make up the {{context.space.attributes.name | spaceName}} Space:</h3>
   <div class="row">
-    <div class="col-md-11">
-      Areas
+    <div class="col-xs-8 col-sm-8 col-md-9">
+      <h3 class="areas-header">Areas that make up the {{context.space.attributes.name | spaceName}} Space:</h3>
     </div>
-    <div class="table-action-heading" (click)="addChildArea()">
-      <i class="pficon pficon-add-circle-o margin-top-4">
-      </i>
+    <div class="col-xs-4 col-sm-4 col-md-3">
+      <div class="table-action-heading" (click)="addChildArea()">
+        <a><i class="pficon pficon-add-circle-o"></i> Add Areas</a>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/src/app/space/settings/areas/areas.component.less
+++ b/src/app/space/settings/areas/areas.component.less
@@ -7,6 +7,7 @@
 .table-action-heading {
   .pointer;
   float: right;
+  margin-top: 50px;
   padding-right: 32px;
   .pficon { color: @color-pf-blue-300; }
 }

--- a/src/app/space/settings/collaborators/collaborators.component.html
+++ b/src/app/space/settings/collaborators/collaborators.component.html
@@ -1,12 +1,12 @@
 <div class="container-fluid">
-  <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name | spaceName}} Space:</h3>
   <div class="row">
-    <div class="col-md-11">
-      Collaborator details:
+    <div class="col-xs-8 col-sm-8 col-md-9">
+      <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name | spaceName}} Space:</h3>
     </div>
-    <div class="table-action-heading" (click)="launchAddCollaborators()">
-      <i class="pficon pficon-add-circle-o margin-top-4">
-      </i>
+    <div class="col-xs-4 col-sm-4 col-md-3">
+      <div class="table-action-heading" (click)="launchAddCollaborators()">
+        <a><i class="pficon pficon-add-circle-o"></i> Add Collaborators</a>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/src/app/space/settings/collaborators/collaborators.component.less
+++ b/src/app/space/settings/collaborators/collaborators.component.less
@@ -10,6 +10,7 @@
 .table-action-heading {
   .pointer;
   float: right;
+  margin-top: 50px;
   padding-right: 32px;
   .pficon { color: @color-pf-blue-300; }
 }


### PR DESCRIPTION
## Description
The purpose of this is to as following:

- Remove the redundant phrase
- Fix the alignment of the add button on Collaborators and Areas pages
- Add "Add Collaborators" and "Add Areas" beside the plus icon

Related to this story:
https://github.com/fabric8-ui/fabric8-ux/issues/654

## Link to rawgit and/or image
![areas](https://user-images.githubusercontent.com/701009/31040009-115dbc90-a5b5-11e7-8554-75f85e75774f.png)
--------------------------------------------------
![colllaborators](https://user-images.githubusercontent.com/701009/31040004-0bd1f98a-a5b5-11e7-9609-d35b2f5401f1.png)





@catrobson Please help to review it, thanks.
