### PR TITLE
searchFilterText property no longer supported

### DIFF
--- a/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.ts
+++ b/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.ts
@@ -69,7 +69,7 @@ export class AddCollaboratorsDialogComponent implements OnInit, OnDestroy {
   }
 
   changed(enteredValue: any) {
-    let searchValue = this.typeahead.searchFilterText;
+    let searchValue = this.typeahead.filterControl.value;
     this.userService.getUsersBySearchString(searchValue).subscribe((users) => {
       this.dropdownOptions = [];
       users.forEach(user => {


### PR DESCRIPTION
It appears that the searchFilterText property of angular-2-dropdown-multiselect was removed at some point after v1.1.0. However, filterControl.value is available to use instead.

Fixes: https://github.com/openshiftio/openshift.io/issues/1140#issuecomment-337446877

