### PR TITLE
fix(tooltip): update tooltip location to prevent scrollbar

### DIFF
--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
@@ -64,7 +64,7 @@ export class CodebasesToolbarComponent implements OnInit {
       resultsCount: this.resultsCount,
       selectedCount: 0,
       totalCount: 0,
-      tooltipPlacement: 'right'
+      tooltipPlacement: 'left'
     } as FilterConfig;
 
     this.sortConfig = {


### PR DESCRIPTION
When hovering over the '+' button, the tooltip was set to be placed to the right of the icon. With the icon set to the right, there was no room, causing the scroll and jumping. This PR sets the tooltip placement to the left of the icon, preventing the offscreen issues.

fixes https://github.com/openshiftio/openshift.io/issues/1181

