### PR TITLE
fix(linters): Add runtime-console to linter checks

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -5,6 +5,3 @@
 # Ignore certain shared Less files
 src/assets/stylesheets/shared/_formulas.less
 
-# Ignore the runtime console folder
-/src/a-runtime-console/
-

--- a/src/a-runtime-console/header/header.component.less
+++ b/src/a-runtime-console/header/header.component.less
@@ -1,5 +1,5 @@
 @import (reference) '../../assets/stylesheets/shared/osio.less';
-
+/* stylelint-disable */
 @pf-cust-navbar-text-size: @font-size-large;
 @pf-custom-navbar-top-border-width: 2px;
 @pf-custom-navbar-header-border-width: 0;
@@ -92,3 +92,4 @@
     }
   }
 }
+/* stylelint-enable */

--- a/src/a-runtime-console/kubernetes/components/pipeline-status/pipeline-status.component.less
+++ b/src/a-runtime-console/kubernetes/components/pipeline-status/pipeline-status.component.less
@@ -4,16 +4,16 @@
   display: -webkit-flex;
   display: -moz-flex;
   display: -ms-flexbox;
-  display: -ms-flex
+  display: -ms-flex;
 }
 .pipeline-status-bar .clip1:before,
 .pipeline-status-bar .clip2:before,
 .pipeline-status-bar .pipeline-line:before {
-  background-color: #d1d1d1
+  background-color: #d1d1d1;
 }
 .pipeline-status-bar .inner-circle-fill {
   background-color: #fff;
-  opacity: 0
+  opacity: 0;
 }
 .pipeline-status-bar.SUCCESS .clip1:before,
 .pipeline-status-bar.SUCCESS .clip2:before,
@@ -22,10 +22,10 @@
 .pipeline-status-bar.SUCCESS .pipeline-line:before,
 .pipeline-status-bar.SUCCESS .pipeline-circle,
 .pipeline-status-bar.SUCCESS .pipeline-circle .inner-circle {
-  background-color: #3f9c35
+  background-color: #3f9c35;
 }
 .pipeline-status-bar.SUCCESS .pipeline-circle:after {
-  content: "\f00c";
+  content: '\f00c';
   opacity: 1;
 }
 .pipeline-status-bar.FAILED .clip1:before,
@@ -35,10 +35,10 @@
 .pipeline-status-bar.FAILED .pipeline-line:before,
 .pipeline-status-bar.FAILED .pipeline-circle,
 .pipeline-status-bar.FAILED .pipeline-circle .inner-circle {
-  background-color: #c00
+  background-color: #c00;
 }
 .pipeline-status-bar.FAILED .pipeline-circle:after {
-  content: "\f00d";
+  content: '\f00d';
   opacity: 1;
 }
 .pipeline-status-bar.NOT_EXECUTED .clip1:before,
@@ -48,10 +48,10 @@
 .pipeline-status-bar.NOT_EXECUTED .pipeline-line:before,
 .pipeline-status-bar.NOT_EXECUTED .pipeline-circle,
 .pipeline-status-bar.NOT_EXECUTED .pipeline-circle .inner-circle {
-  background-color: #d1d1d1
+  background-color: #d1d1d1;
 }
 .pipeline-status-bar.NOT_EXECUTED .pipeline-circle:after {
-  content: "";
+  content: '';
   opacity: 1;
 }
 .pipeline-status-bar.PAUSED_PENDING_INPUT .clip1:before,
@@ -61,10 +61,10 @@
 .pipeline-status-bar.PAUSED_PENDING_INPUT .pipeline-line:before,
 .pipeline-status-bar.PAUSED_PENDING_INPUT .pipeline-circle,
 .pipeline-status-bar.PAUSED_PENDING_INPUT .pipeline-circle .inner-circle {
-  background-color: #f0ab00
+  background-color: #f0ab00;
 }
 .pipeline-status-bar.PAUSED_PENDING_INPUT .pipeline-circle:after {
-  content: "\f04c";
+  content: '\f04c';
   font-size: 10px;
   opacity: 1;
 }
@@ -76,32 +76,32 @@
 .pipeline-status-bar.ABORTED .pipeline-line:before,
 .pipeline-status-bar.ABORTED .pipeline-circle,
 .pipeline-status-bar.ABORTED .pipeline-circle .inner-circle {
-  background-color: #d1d1d1
+  background-color: #d1d1d1;
 }
 .pipeline-status-bar.ABORTED .pipeline-circle:after {
-  content: "\f05e";
+  content: '\f05e';
   opacity: 1;
 }
 /** we have animations on in progress stages */
 .pipeline-status-bar.IN_PROGRESS .clip1:before,
 .pipeline-status-bar.IN_PROGRESS .clip2:before,
 .pipeline-status-bar.IN_PROGRESS .inner-circle-fill {
-  background-color: #0088ce
+  background-color: #0088ce;
 }
 .pipeline-status-bar.IN_PROGRESS .pipeline-circle {
-  animation: fadeInProgress 0s .7s linear forwards
+  animation: fadeInProgress 0s .7s linear forwards;
 }
 .pipeline-status-bar.IN_PROGRESS .pipeline-circle:after {
-  content: "\f021";
+  content: '\f021';
 }
 .pipeline-status-bar.IN_PROGRESS .pipeline-line {
-  overflow: hidden
+  overflow: hidden;
 }
 .pipeline-status-bar.IN_PROGRESS .pipeline-line:before {
   animation: progress-rail 5s .5s linear infinite;
   background-color: #0088ce;
   transform: translateX(-100%);
-  width: 25%
+  width: 25%;
 }
 .pipeline-status-bar {
   display: flex;

--- a/src/a-runtime-console/kubernetes/components/resource-header/resource.header.component.less
+++ b/src/a-runtime-console/kubernetes/components/resource-header/resource.header.component.less
@@ -7,7 +7,7 @@
     margin-bottom: 0;
     border: 1px solid transparent;
     border-color: #bbb;
-    box-shadow: 0 2px 3px rgba(3, 3, 3, 0.1);
+    box-shadow: 0 2px 3px rgba(3, 3, 3, .1);
     background-color: #f1f1f1;
     background-image: -webkit-linear-gradient(top, #fafafa 0%, #ededed 100%);
     background-image: linear-gradient(to bottom, #fafafa 0%, #ededed 100%);
@@ -41,7 +41,9 @@
   .dropdown {
     a {
       color: @color-pf-white;
+      /* stylelint-disable */
       background-color: transparent !important;
+      /* stylelint-enable */
       &:hover { text-decoration: none; }
     }
   }

--- a/src/a-runtime-console/kubernetes/ui/app/list-toolbar/list-toolbar.app.component.less
+++ b/src/a-runtime-console/kubernetes/ui/app/list-toolbar/list-toolbar.app.component.less
@@ -1,6 +1,8 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
   padding: 0 rem(20);
   border-bottom: 1px solid;
   border-bottom-color: #d1d1d1;

--- a/src/a-runtime-console/kubernetes/ui/build/list-toolbar/list-toolbar.build.component.less
+++ b/src/a-runtime-console/kubernetes/ui/build/list-toolbar/list-toolbar.build.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/buildconfig/list-toolbar/list-toolbar.buildconfig.component.less
+++ b/src/a-runtime-console/kubernetes/ui/buildconfig/list-toolbar/list-toolbar.buildconfig.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/configmap/list-toolbar/list-toolbar.configmap.component.less
+++ b/src/a-runtime-console/kubernetes/ui/configmap/list-toolbar/list-toolbar.configmap.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/deployment/list-toolbar/list-toolbar.deployment.component.less
+++ b/src/a-runtime-console/kubernetes/ui/deployment/list-toolbar/list-toolbar.deployment.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/deployment/view/view.deployment.component.html
+++ b/src/a-runtime-console/kubernetes/ui/deployment/view/view.deployment.component.html
@@ -109,9 +109,10 @@
       </div>
     </div>
   </div>
+</div>
 
-  <modal #scaleDeploymentModal title="Scale Deployment">
-    <modal-content>
-      <scale-deployment-dialog></scale-deployment-dialog>
-    </modal-content>
-  </modal>
+<modal #scaleDeploymentModal title="Scale Deployment">
+  <modal-content>
+    <scale-deployment-dialog></scale-deployment-dialog>
+  </modal-content>
+</modal>

--- a/src/a-runtime-console/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.less
+++ b/src/a-runtime-console/kubernetes/ui/environment/list-toolbar/list-toolbar.environment.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/event/list-toolbar/list-toolbar.event.component.less
+++ b/src/a-runtime-console/kubernetes/ui/event/list-toolbar/list-toolbar.event.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/namespace/list-toolbar/list-toolbar.namespace.component.less
+++ b/src/a-runtime-console/kubernetes/ui/namespace/list-toolbar/list-toolbar.namespace.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/pipeline/build-stage-view/build-stage-view.component.html
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/build-stage-view/build-stage-view.component.html
@@ -27,7 +27,7 @@
             <div class="pipeline-stage-name {{build.statusPhase}}"
                  title="stage status: {{stage.status}}">
               {{stage.name}} &nbsp;
-              <span class='open-service-icon'*ngIf="stage.serviceUrl">
+              <span class="open-service-icon" *ngIf="stage.serviceUrl">
                 <a target="deployment"
                    class="external-service"
                    [href]="stage.serviceUrl"

--- a/src/a-runtime-console/kubernetes/ui/pipeline/build-stage-view/build-stage-view.component.less
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/build-stage-view/build-stage-view.component.less
@@ -151,7 +151,9 @@
 .pipeline .pipeline-stage.no-stages {
   align-items: center;
   display: flex;
-  width: auto!important;
+  /* stylelint-disable */
+  width: auto !important;
+  /* stylelint-enable */
 }
 .pipeline .pipeline-stage.no-stages:before {
   display: none;

--- a/src/a-runtime-console/kubernetes/ui/pipeline/full-history-toolbar/full-history-toolbar.pipeline.component.less
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/full-history-toolbar/full-history-toolbar.pipeline.component.less
@@ -1,6 +1,8 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
   .form-group.sort {
+    /* stylelint-disable */
     border-right: 0 !important;
+    /* stylelint-enable */
   }
 }

--- a/src/a-runtime-console/kubernetes/ui/pipeline/history-toolbar/history-toolbar.pipeline.component.less
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/history-toolbar/history-toolbar.pipeline.component.less
@@ -1,6 +1,8 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
   .form-group.sort {
+    /* stylelint-disable */
     border-right: 0 !important;
+    /* stylelint-enable */
   }
 }

--- a/src/a-runtime-console/kubernetes/ui/pipeline/list-toolbar/list-toolbar.pipeline.component.less
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/list-toolbar/list-toolbar.pipeline.component.less
@@ -1,6 +1,8 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
   .form-group.sort {
+    /* stylelint-disable */
     border-right: 0 !important;
+    /* stylelint-enable */
   }
 }

--- a/src/a-runtime-console/kubernetes/ui/pod/list-toolbar/list-toolbar.pod.component.less
+++ b/src/a-runtime-console/kubernetes/ui/pod/list-toolbar/list-toolbar.pod.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/replicaset/edit-toolbar/edit-toolbar.replicaset.component.less
+++ b/src/a-runtime-console/kubernetes/ui/replicaset/edit-toolbar/edit-toolbar.replicaset.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
-.form-group { border-right: 0;
-}
+.form-group { border-right: 0; }
 ol {
   margin-bottom: 0;
   &.breadcrumb { padding: 0; }

--- a/src/a-runtime-console/kubernetes/ui/replicaset/list-toolbar/list-toolbar.replicaset.component.less
+++ b/src/a-runtime-console/kubernetes/ui/replicaset/list-toolbar/list-toolbar.replicaset.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/replicaset/view-toolbar/view-toolbar.replicaset.component.less
+++ b/src/a-runtime-console/kubernetes/ui/replicaset/view-toolbar/view-toolbar.replicaset.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
-.form-group { border-right: 0;
-}
+.form-group { border-right: 0; }
 ol {
   margin-bottom: 0;
   &.breadcrumb { padding: 0; }

--- a/src/a-runtime-console/kubernetes/ui/replicaset/view/view.replicaset.component.html
+++ b/src/a-runtime-console/kubernetes/ui/replicaset/view/view.replicaset.component.html
@@ -109,9 +109,9 @@
       </div>
     </div>
   </div>
-
-  <modal #scaleReplicaSetModal title="Scale ReplicaSet">
-    <modal-content>
-      <scale-replicaset-dialog></scale-replicaset-dialog>
-    </modal-content>
-  </modal>
+</div>
+<modal #scaleReplicaSetModal title="Scale ReplicaSet">
+  <modal-content>
+    <scale-replicaset-dialog></scale-replicaset-dialog>
+  </modal-content>
+</modal>

--- a/src/a-runtime-console/kubernetes/ui/service/edit-toolbar/edit-toolbar.service.component.less
+++ b/src/a-runtime-console/kubernetes/ui/service/edit-toolbar/edit-toolbar.service.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
-.form-group { border-right: 0;
-}
+.form-group { border-right: 0; }
 ol {
   margin-bottom: 0;
   &.breadcrumb { padding: 0; }

--- a/src/a-runtime-console/kubernetes/ui/service/list-toolbar/list-toolbar.service.component.less
+++ b/src/a-runtime-console/kubernetes/ui/service/list-toolbar/list-toolbar.service.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }

--- a/src/a-runtime-console/kubernetes/ui/service/view-toolbar/view-toolbar.service.component.less
+++ b/src/a-runtime-console/kubernetes/ui/service/view-toolbar/view-toolbar.service.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
-.form-group { border-right: 0;
-}
+.form-group { border-right: 0; }
 ol {
   margin-bottom: 0;
   &.breadcrumb { padding: 0; }

--- a/src/a-runtime-console/kubernetes/ui/space/edit-toolbar/edit-toolbar.space.component.less
+++ b/src/a-runtime-console/kubernetes/ui/space/edit-toolbar/edit-toolbar.space.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
-.form-group { border-right: 0;
-}
+.form-group { border-right: 0; }
 ol {
   margin-bottom: 0;
   &.breadcrumb { padding: 0; }

--- a/src/a-runtime-console/kubernetes/ui/space/list-toolbar/list-toolbar.space.component.less
+++ b/src/a-runtime-console/kubernetes/ui/space/list-toolbar/list-toolbar.space.component.less
@@ -1,4 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-pf {
+  /* stylelint-disable */
   .form-group.sort { border-right: 0 !important; }
+  /* stylelint-enable */
 }


### PR DESCRIPTION
Remove the runtime-console from the stylelint ignore file. Updated any errors, leaving warnings.
Run htmlhint and fix any errors.

run `htmlhint` or `stylelint "**/*.less"` to check for errors
