### PR TITLE
fix(masthead): set masthead to fixed position

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="isGettingStartedPage; then showGettingStartedHeader else showHeader"></div>
 <ng-template #showGettingStartedHeader>
-  <nav class="navbar navbar-default navbar-inverse" role="navigation">
+  <nav class="navbar navbar-default navbar-inverse navbar-fixed-top" role="navigation">
     <img src="../../../assets/images/openshift-io_white.png" class="navbar-getting-started-logo" />
      <!-- user profile dropdown -->
         <ul id="getting_started_header_rightDropdown" class="nav navbar-nav navbar-right">
@@ -36,7 +36,7 @@
   </nav>
 </ng-template>
 <ng-template #showHeader>
-  <nav class="navbar navbar-default navbar-inverse navbar-pf" role="navigation" *ngIf="context">
+  <nav class="navbar navbar-default navbar-inverse navbar-pf navbar-fixed-top" role="navigation" *ngIf="context">
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" (click)="toggleState()">

--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.less
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.less
@@ -1,6 +1,6 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 .toolbar-header {
-  padding: 0 20px;
+  padding: 36px 20px;
 }
 .toolbar-pf-action-right {
   .pficon-add-circle-o {

--- a/src/app/space/create/pipelines/pipelines.component.less
+++ b/src/app/space/create/pipelines/pipelines.component.less
@@ -2,7 +2,7 @@
 .openshift-links { font-size: .857em; }
 .toolbar-header {
   margin-bottom: 20px;
-  padding: 0 20px;
+  padding: 36px 20px;
 }
 .pipeline-list-view .list-view-pf-view,
 .list-view-pf-view,

--- a/src/assets/stylesheets/shared/_experimental.less
+++ b/src/assets/stylesheets/shared/_experimental.less
@@ -9,6 +9,7 @@
     border-left-color: @color-pf-light-green-400;
   }
   &-bar {
+    margin-top: 35px;
     height: 25px;
     @media (max-width: 768px) { height: 48px; }
     background-color: @color-pf-light-green-400;

--- a/src/assets/stylesheets/shared/_layout.less
+++ b/src/assets/stylesheets/shared/_layout.less
@@ -3,6 +3,10 @@ body {
   position: relative;
   min-height: 100vh;
   margin: 0;
+  /* stylelint-disable */
+  /* for use with the fixed masthead */
+  padding-top: 45px !important;
+  /* stylelint-enable */
   padding: 0;
   font-family: 'Open Sans', sans-serif;
   /* stylelint-disable */


### PR DESCRIPTION
Set the masthead to be 'navbar-fixed-top' and adjust margins and paddings accordingly.

This is in preparation for the addition of the vertical navigation, which will be in subsequent PRs.

Eventually, this masthead will be replaced with the one that is included in PatternFly-ng.

closes https://github.com/fabric8-ui/fabric8-ux/issues/718
