### PR TITLE
chore(build): fix the Dockerfile to be functional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-# Builds a Docker to deliver dist/
-FROM nginx:latest
-COPY dist/ /usr/share/nginx/html

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,11 +1,8 @@
 FROM fabric8/fabric8-openshift-nginx:vd83b3a1
-MAINTAINER "Pete Muir <pmuir@bleepbleep.org.uk>"
 
 USER root
 
-RUN rm -rf /usr/share/nginx/html/
+RUN rm -rf /usr/share/nginx/html
 COPY dist /usr/share/nginx/html
-RUN chmod -R 777 /usr/share/nginx/html/
-
 
 USER ${FABRIC8_USER_NAME}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - default
   ui:
     build: .
+    dockerfile: Dockerfile.deploy
     entrypoint:
       - /usr/local/bin/wait-for-it.sh
       - core:8080


### PR DESCRIPTION
Fix the base `Dockerfile` to be useful and functional

This also makes the `Dockerfile.deploy` somewhat unnecessary, except
- it's already used in various orchestration and CI/CD
- it uses a different/custom nginx image with certain tag

So for that reason, I haven't removed the file. But unless the custom nginx image is necessary, that file can be removed and the main Dockerfile can be renamed to Dockerfile.deploy.