### PR TITLE
fix(chat): Add Quick Chat option to user menu

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -151,6 +151,11 @@
                   About
                 </a>
               </li>
+              <li id="header_loggedinChat">
+                <a href="https://chat.openshift.io/developers/channels/town-square" target="top" class="pointer">
+                  Chat
+                </a>
+              </li>
               <li class="divider"></li>
               <li id="header_loggedinHelp">
                 <a href="https://docs.openshift.io" target="top" class="pointer">


### PR DESCRIPTION
Add the ability to quickly access chat.openshift.io from the user dropdown menu.

<img width="217" alt="screen shot 2017-11-02 at 9 52 16 am" src="https://user-images.githubusercontent.com/4032718/32329464-8fb8c310-bfb3-11e7-8c1e-9ca03d93b102.png">