### PR TITLE
fix(docs): Update Help link

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -152,6 +152,12 @@
                 </a>
               </li>
               <li class="divider"></li>
+              <li id="header_loggedinHelp">
+                <a href="https://docs.openshift.io" target="top" class="pointer">
+                  Documentation
+                </a>
+              </li>
+              <li class="divider"></li>
               <li id="header_logout">
                 <a *ngIf="loggedInUser" (click)="logout();" class="pointer">
                   Log Out


### PR DESCRIPTION
Update the Help link to point to the proper documentation URL

fixes https://github.com/openshiftio/openshift.io/issues/912

<img width="206" alt="screen shot 2017-11-02 at 10 26 53 am" src="https://user-images.githubusercontent.com/4032718/32331146-8af07224-bfb8-11e7-8009-b57b60fab340.png">


