### PR TITLE
Show empty state for no codebases

### DIFF
--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -78,19 +78,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
           title: 'Add a Codebase',
           tooltip: 'Add a Codebase'
         }],
-        moreActions: [{
-          id: 'action2',
-          title: 'Secondary Action 1',
-          tooltip: 'Do the first thing'
-        }, {
-          id: 'action3',
-          title: 'Secondary Action 2',
-          tooltip: 'Do something else'
-        }, {
-          id: 'action4',
-          title: 'Secondary Action 3',
-          tooltip: 'Do something special'
-        }]
+        moreActions: []
       } as ActionConfig,
       iconStyleClass: 'pficon-add-circle-o',
       title: 'Add a Codebase',
@@ -274,7 +262,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
     // Get codebases
     this.subscriptions.push(this.codebasesService.getCodebases(this.context.space.id)
       .subscribe(codebases => {
-        if (codebases != null) {
+        if (codebases != null && codebases.length > 0) {
           this.allCodebases = codebases;
           this.codebases = cloneDeep(codebases);
           this.codebases.unshift({} as Codebase); // Add empty object for row header


### PR DESCRIPTION
The empty state should be shown when no codebases are available. Currently, only the column headers of the list are shown

Before:
![screen shot 2017-11-10 at 7 51 14 pm](https://user-images.githubusercontent.com/17481322/32684325-8855aa86-c650-11e7-92a3-4e3c77528b61.png)

After:
![screen shot 2017-11-10 at 7 48 03 pm](https://user-images.githubusercontent.com/17481322/32684331-9097b93c-c650-11e7-8907-65371190bfbf.png)

