### PR TITLE
fix(link): update link to documentation

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -79,7 +79,7 @@
               </div>
               <h3>Create a space</h3>
               <p>Learn how to get started
-                <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift.io/1/html-single/user_guide">
+                <a href="https://docs.openshift.io" target="top">
                   in the documentation.
                 </a>
               </p>


### PR DESCRIPTION
Update the documentation link on the empty Space card to point to docs.openshift.io

fixes https://github.com/openshiftio/openshift.io/issues/1339

