### PR TITLE
 fix(deployments): rename Applications tab to Deployments

### DIFF
--- a/src/app/layout/header/menus.service.ts
+++ b/src/app/layout/header/menus.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { MenuItem } from './../../models/menu-item';
 import { ContextType, Contexts, ContextTypes, Context } from 'ngx-fabric8-wit';
 import { cloneDeep } from 'lodash';
+import { useRuntimeConsole } from '../../space/create/config/use-runtime-console';
 
 @Injectable()
 export class MenusService {
@@ -58,8 +59,8 @@ export class MenusService {
                 path: 'pipelines'
               },
               {
-                name: 'Applications',
-                path: 'apps'
+                name: useRuntimeConsole() ? 'Applications' : 'Deployments',
+                path: useRuntimeConsole() ? 'apps' : 'deployments'
               },
               {
                 name: 'Environments',

--- a/src/app/space/create/apps/apps.module.ts
+++ b/src/app/space/create/apps/apps.module.ts
@@ -6,6 +6,8 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 
+import { useRuntimeConsole } from '../config/use-runtime-console';
+
 import { AppModule as RuntimeConsoleModule } from '../../../../a-runtime-console/index';
 
 import { AppsComponent } from './apps.component';
@@ -14,9 +16,7 @@ import { AppsRoutingModule } from './apps-routing.module';
 
 import { AppsService } from './services/apps.service';
 
-const USE_RUNTIME_CONSOLE = ENV !== 'development';
-
-const imports = USE_RUNTIME_CONSOLE ?
+const imports = useRuntimeConsole() ?
   [CommonModule, RuntimeConsoleModule] :
   [
     BsDropdownModule.forRoot(),
@@ -26,11 +26,11 @@ const imports = USE_RUNTIME_CONSOLE ?
     AppsRoutingModule
   ];
 
-const declarations = USE_RUNTIME_CONSOLE ?
+const declarations = useRuntimeConsole() ?
   [] :
   [AppsComponent, DeploymentCardComponent];
 
-const providers = USE_RUNTIME_CONSOLE ?
+const providers = useRuntimeConsole() ?
   [] :
   [BsDropdownConfig, AppsService];
 

--- a/src/app/space/create/config/use-runtime-console.ts
+++ b/src/app/space/create/config/use-runtime-console.ts
@@ -1,0 +1,3 @@
+export function useRuntimeConsole(): boolean {
+  return ENV !== 'development';
+}

--- a/src/app/space/create/create-routing.module.ts
+++ b/src/app/space/create/create-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { CreateComponent } from './create.component';
 import { CodebasesComponent } from './codebases/codebases.component';
 import { ExperimentalFeatureResolver } from '../../shared/experimental-feature.resolver';
+import { useRuntimeConsole } from './config/use-runtime-console';
 
 const routes: Routes = [
   {
@@ -29,14 +30,14 @@ const routes: Routes = [
         }
       },
       {
-        path: 'apps',
+        path: useRuntimeConsole() ? 'apps' : 'deployments',
         loadChildren: './apps/apps.module#AppsModule',
         resolve: {
           featureFlagConfig: ExperimentalFeatureResolver
         },
         data: {
-          title: 'Applications',
-          featureName: 'Applications'
+          title: useRuntimeConsole() ? 'Applications' : 'Deployments',
+          featureName: useRuntimeConsole() ? 'Applications' : 'Deployments'
         }
       },
     ]


### PR DESCRIPTION
This renames the Create > Applications tab to Create > Deployments (openshiftio/openshift.io#1382), but only when NODE_ENV is "development". In prod-preview and prod this PR should cause no visible or behavioural change.

The useRuntimeConsole function should also probably be replaced by a feature flag in the near future.