### PR TITLE
WIP Added buttons to user profile page for GH/OSO link/unlink

### DIFF
--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.html
@@ -41,10 +41,20 @@
                         <span>
                           Connected
                         </span>
+                        <span>
+                          <button class="btn btn-lg btn-default" id="gh_relink"
+                          (click)="connectGitHub()">Reconnect</button>
+                          <button class="btn btn-lg btn-default" id="gh_unlink"
+                          (click)="disconnectGitHub()">Disconnect</button>
+                        </span>
                       </ng-template>
                       <ng-template #ghUnlinkedUsername>
                         <span class="account-disconnected">
-                          Not Connected
+                          Disconnected
+                        </span>
+                        <span>
+                          <button class="btn btn-lg btn-default" id="gh_link"
+                          (click)="connectGitHub()">Connect</button>
                         </span>
                       </ng-template>
                     </div>
@@ -77,10 +87,20 @@
                         <span>
                           {{contextUserName}}
                         </span>
+                        <span>
+                          <button class="btn btn-lg btn-default" id="oso_relink"
+                          (click)="connectOpenShift()">Reconnect</button>
+                          <button class="btn btn-lg btn-default" id="oso_unlink"
+                          (click)="disconnectOpenShift()">Disconnect</button>
+                        </span>
                       </ng-template>
                       <ng-template #osoUnlinkedUsername>
                         <span class="account-disconnected">
                           Not Connected
+                        </span>
+                        <span>
+                          <button class="btn btn-lg btn-default" id="oso_link"
+                          (click)="connectOpenShift()">Connect</button>
                         </span>
                       </ng-template>
                     </div>

--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.html
@@ -38,24 +38,20 @@
                     <div class="list-view-pf-additional-info-item">
                       <div *ngIf="gitHubLinked; then ghLinkedUsername else ghUnlinkedUsername"></div>
                       <ng-template #ghLinkedUsername>
-                        <span>
+                        <span class="margin-right-15">
                           Connected
                         </span>
-                        <span>
-                          <button class="btn btn-lg btn-default" id="gh_relink"
-                          (click)="connectGitHub()">Reconnect</button>
-                          <button class="btn btn-lg btn-default" id="gh_unlink"
-                          (click)="disconnectGitHub()">Disconnect</button>
-                        </span>
+                        <button class="btn btn-sm btn-primary margin-right-15" id="gh_relink"
+                        (click)="connectGitHub()">Reconnect</button>
+                        <button class="btn btn-sm btn-danger" id="gh_unlink"
+                        (click)="disconnectGitHub()">Disconnect</button>
                       </ng-template>
                       <ng-template #ghUnlinkedUsername>
-                        <span class="account-disconnected">
+                        <span class="account-disconnected margin-right-15">
                           Disconnected
                         </span>
-                        <span>
-                          <button class="btn btn-lg btn-default" id="gh_link"
-                          (click)="connectGitHub()">Connect</button>
-                        </span>
+                        <button class="btn btn-sm btn-primary" id="gh_link"
+                        (click)="connectGitHub()">Connect</button>
                       </ng-template>
                     </div>
                   </div>
@@ -84,24 +80,20 @@
                     <div class="list-view-pf-additional-info-item">
                       <div *ngIf="openShiftLinked; then osoLinkedUsername else osoUnlinkedUsername"></div>
                       <ng-template #osoLinkedUsername>
-                        <span>
+                        <span class="margin-right-15">
                           {{contextUserName}}
                         </span>
-                        <span>
-                          <button class="btn btn-lg btn-default" id="oso_relink"
-                          (click)="connectOpenShift()">Reconnect</button>
-                          <button class="btn btn-lg btn-default" id="oso_unlink"
-                          (click)="disconnectOpenShift()">Disconnect</button>
-                        </span>
+                        <button class="btn btn-sm btn-primary" id="oso_relink"
+                        (click)="connectOpenShift()">Reconnect</button>
+                        <button class="btn btn-sm btn-danger" id="oso_unlink"
+                        (click)="disconnectOpenShift()">Disconnect</button>
                       </ng-template>
                       <ng-template #osoUnlinkedUsername>
-                        <span class="account-disconnected">
-                          Not Connected
+                        <span class="account-disconnected margin-right-15">
+                          Disconnected
                         </span>
-                        <span>
-                          <button class="btn btn-lg btn-default" id="oso_link"
-                          (click)="connectOpenShift()">Connect</button>
-                        </span>
+                        <button class="btn btn-sm btn-primary" id="oso_link"
+                        (click)="connectOpenShift()">Connect</button>
                       </ng-template>
                     </div>
                   </div>

--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.html
@@ -83,7 +83,7 @@
                         <span class="margin-right-15">
                           {{contextUserName}}
                         </span>
-                        <button class="btn btn-sm btn-primary" id="oso_relink"
+                        <button class="btn btn-sm btn-primary margin-right-15" id="oso_relink"
                         (click)="connectOpenShift()">Reconnect</button>
                         <button class="btn btn-sm btn-danger" id="oso_unlink"
                         (click)="disconnectOpenShift()">Disconnect</button>


### PR DESCRIPTION
### Work in progress

This PR adds buttons to the user profile page, allowing the connected GitHub and Openshift accounts to be (re)linked/unlinked.  See this issue for more details:

[](https://github.com/fabric8-services/fabric8-auth/issues/151)

Some styling is still required to position buttons correctly.

These changes depend on the following PR in the ngx-login-client module:

[](https://github.com/fabric8-ui/ngx-login-client/pull/94)

Signed-off-by: Shane Bryzak <sbryzak@redhat.com>

