### PR TITLE
enhancement(deployments): add patternfly charts to deployment cards

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -57,7 +57,7 @@ import {
   UserService
 }                             from 'ngx-login-client';
 import { WidgetsModule }      from 'ngx-widgets';
-import { ActionModule, ListModule, TreeListComponent, PatternFlyNgModule } from 'patternfly-ng';
+import { ActionModule, ListModule, TreeListComponent, PatternFlyNgModule, ChartModule } from 'patternfly-ng';
 
 /*
  * Platform and Environment providers/directives/pipes
@@ -145,6 +145,7 @@ export type StoreType = {
     BrowserAnimationsModule,
     BrowserModule,
     BsDropdownModule.forRoot(),
+    ChartModule,
     FormsModule,
     HttpModule,
     KubernetesRestangularModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -57,7 +57,12 @@ import {
   UserService
 }                             from 'ngx-login-client';
 import { WidgetsModule }      from 'ngx-widgets';
-import { ActionModule, ListModule, TreeListComponent, PatternFlyNgModule, ChartModule } from 'patternfly-ng';
+import {
+  ActionModule,
+  ChartModule,
+  ListModule,
+  TreeListComponent,
+  PatternFlyNgModule }        from 'patternfly-ng';
 
 /*
  * Platform and Environment providers/directives/pipes

--- a/src/app/space/create/deployments/components/deployment-card/deployment-card.component.html
+++ b/src/app/space/create/deployments/components/deployment-card/deployment-card.component.html
@@ -15,7 +15,7 @@
       </ul>
     </div>
     <div [collapse]="collapsed">
-      Detailed Information Placeholder
+      <pfng-chart-sparkline [config]="config" [chartData]="data"></pfng-chart-sparkline>
     </div>
   </div>
 </div>

--- a/src/app/space/create/deployments/components/deployment-card/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/components/deployment-card/deployment-card.component.spec.ts
@@ -57,8 +57,10 @@ describe('DeploymentCardComponent', () => {
       let depCard2 = new DeploymentCardComponent(null);
       let depCard3 = new DeploymentCardComponent(null);
 
-      expect(depCard1.config.chartId !== depCard2.config.chartId !== depCard3.config.chartId);
-    });
+      expect(depCard1.getChartIdNum()).not.toBe(depCard2.getChartIdNum());
+      expect(depCard1.getChartIdNum()).not.toBe(depCard3.getChartIdNum());
+      expect(depCard2.getChartIdNum()).not.toBe(depCard3.getChartIdNum());
+      });
   });
 
   describe('podCountLabel', () => {

--- a/src/app/space/create/deployments/components/deployment-card/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/components/deployment-card/deployment-card.component.spec.ts
@@ -51,6 +51,14 @@ describe('DeploymentCardComponent', () => {
     component.environment = { environmentId: 'mockEnvironmentId', name: 'mockEnvironment'};
 
     fixture.detectChanges();
+
+    it('should generate a unique chartid for each DeploymentCardComponent instance', () => {
+      let depCard1 = new DeploymentCardComponent(null);
+      let depCard2 = new DeploymentCardComponent(null);
+      let depCard3 = new DeploymentCardComponent(null);
+
+      expect(depCard1.config.chartId !== depCard2.config.chartId !== depCard3.config.chartId);
+    });
   });
 
   describe('podCountLabel', () => {

--- a/src/app/space/create/deployments/components/deployment-card/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/components/deployment-card/deployment-card.component.spec.ts
@@ -15,6 +15,10 @@ import { DeploymentsService } from '../../services/deployments.service';
 import { CpuStat } from '../../models/cpu-stat';
 import { MemoryStat } from '../../models/memory-stat';
 
+// Makes patternfly charts available
+import { ChartModule } from 'patternfly-ng';
+import 'patternfly/dist/js/patternfly-settings.js';
+
 describe('DeploymentCardComponent', () => {
 
   let component: DeploymentCardComponent;
@@ -39,7 +43,7 @@ describe('DeploymentCardComponent', () => {
     spyOn(mockSvc, 'getVersion').and.callThrough();
 
     TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot() ],
+      imports: [ CollapseModule.forRoot(), ChartModule],
       declarations: [ DeploymentCardComponent ],
       providers: [ { provide: DeploymentsService, useValue: mockSvc } ]
     });

--- a/src/app/space/create/deployments/components/deployment-card/deployment-card.component.ts
+++ b/src/app/space/create/deployments/components/deployment-card/deployment-card.component.ts
@@ -44,6 +44,9 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
     private deploymentsService: DeploymentsService
   ) { }
 
+  getChartIdNum(): number {
+    return DeploymentCardComponent.chartIdNum;
+  }
   ngOnDestroy(): void { }
 
   ngOnInit(): void {

--- a/src/app/space/create/deployments/components/deployment-card/deployment-card.component.ts
+++ b/src/app/space/create/deployments/components/deployment-card/deployment-card.component.ts
@@ -10,14 +10,31 @@ import { Observable } from 'rxjs';
 import { DeploymentsService } from '../../services/deployments.service';
 import { Environment } from '../../models/environment';
 
+// Makes patternfly charts available
+import 'patternfly/dist/js/patternfly-settings.js';
+
 @Component({
   selector: 'deployment-card',
   templateUrl: 'deployment-card.component.html'
 })
 export class DeploymentCardComponent implements OnDestroy, OnInit {
 
+  static chartIdNum = 1;
+
   @Input() applicationId: string;
   @Input() environment: Environment;
+
+  public data: any = {
+    dataAvailable: true,
+    total: 100,
+    xData: ['foo', 1, 2, 3, 4],
+    yData: ['used', 10, 20, 30, 40]
+  };
+
+  public config: any = {
+    // Seperate chart IDs must be unique, otherwise only one will appear
+    chartId: 'chart-' + DeploymentCardComponent.chartIdNum++ + '-'
+  };
 
   collapsed: boolean = true;
   podCount: Observable<number>;
@@ -30,6 +47,9 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   ngOnDestroy(): void { }
 
   ngOnInit(): void {
+
+    this.config.chartHeight = 60;
+
     this.podCount =
       this.deploymentsService.getPodCount(this.applicationId, this.environment.environmentId);
 

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -13,12 +13,15 @@ import { DeploymentsRoutingModule } from './deployments-routing.module';
 
 import { DeploymentsService } from '../deployments/services/deployments.service';
 
+import { ChartModule } from 'patternfly-ng';
+
 @NgModule({
   imports: [
     BsDropdownModule.forRoot(),
     CollapseModule.forRoot(),
     AccordionModule.forRoot(),
     CommonModule,
+    ChartModule,
     DeploymentsRoutingModule
   ],
   declarations: [


### PR DESCRIPTION
Our deployment card components no longer use a static message "Detailed
information placeholder", but instead display dummy patternfly charts
that will eventually be used to show real data. Polling mock data will be added in
the charts in a follow up patch.

This patch is a first step towards resolving https://github.com/openshiftio/openshift.io/issues/1366
