### PR TITLE
fix(color): Update colors on _home banner

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -22,7 +22,7 @@
                 {{brandInformation.name}} information
               </h2>
               <p class="card-pf-info">
-                <a [href]="brandInformation.moreInfoLink" target="_blank">Learn more</a>
+                <a [href]="brandInformation.moreInfoLink" class="home-banner-link" target="_blank">Learn more</a>
                 about what {{brandInformation.name}} can do for you.
               </p>
             </div>
@@ -36,7 +36,7 @@
                 Setup your profile
               </h2>
               <p class="card-pf-info">Let others know who you are by filling out
-                <a [routerLink]="['/', loggedInUser.attributes.username]">your profile</a>.
+                <a [routerLink]="['/', loggedInUser.attributes.username]" class="home-banner-link">your profile</a>.
               </p>
             </div>
           </div>
@@ -49,8 +49,7 @@
                 Learn about OpenShift
               </h2>
               <p class="card-pf-info">See how
-                <a href="https://www.openshift.com/container-platform" target="_blank">containerized development and
-                  deployment</a> can help you.
+                <a href="https://www.openshift.com/container-platform" class="home-banner-link" target="_blank">containerized development and deployment</a> can help you.
               </p>
             </div>
           </div>

--- a/src/app/home/home.component.less
+++ b/src/app/home/home.component.less
@@ -20,12 +20,18 @@
   .home-header-background-image;
   background-repeat: no-repeat;
   color: @color-pf-white;
-}
-.home-banner-title {
-  padding-left: 20px;
-  padding-right: 20px;
-  font-size: 1.429em;
-  font-weight: 300;
+  &-title {
+    padding-left: 20px;
+    padding-right: 20px;
+    font-size: 1.429em;
+    font-weight: 300;
+  }
+  &-link {
+    color: #73bcf7;
+    &:hover {
+      color: #2b9af3;
+    }
+  }
 }
 .list-group-item-text {
   width: 540px;


### PR DESCRIPTION
Change the color of the links on the _home banner to be more readable.

fixes https://github.com/openshiftio/openshift.io/issues/921
closes https://github.com/fabric8-ui/fabric8-ux/issues/749

<img width="1869" alt="screen shot 2017-11-20 at 6 02 03 pm" src="https://user-images.githubusercontent.com/4032718/33045970-f2de740e-ce1c-11e7-9596-b3e6f6212fd1.png">

