### PR TITLE
fix(dashboards): Update Home and Space dashboards to be responsive

### DIFF
--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
@@ -30,7 +30,7 @@
             <div class="list-view-pf-description">
               <div class="list-group-item-text">
                 <span class="avatar fa" [ngClass]="{'fa-github': codebase.attributes.type === 'git'}"></span>
-                <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url">{{codebase.name}}</a>
+                <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url truncate">{{codebase.name}}</a>
               </div>
             </div>
           </div>

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.less
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.less
@@ -4,8 +4,10 @@
   left: 50px;
   width: 475px;
   @media (min-width: 1440px) and (max-width: 1920px) { width: 83%; }
-  @media (min-width: 1280px) and (max-width: 1440px) { width: 83%; }
-  @media (min-width: 1024px) and (max-width: 1280px) { width: 82%; }
+  @media (min-width: @screen-lg-min) and (max-width: 1440px) { width: 82%; }
+  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) { width: 82%; }
+  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) { width: 65%; }
+  @media (max-width: @screen-xs-min) { width: 82%; }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
@@ -2,13 +2,13 @@
   <div class="card-pf-heading f8-card-heading">
     <h2 id="spacehome-analytical-report-title" class="card-pf-title">
       Stack Report Recommendations
-      <div *ngIf="buildConfigsCount > 0" class="pull-right">
+      <span *ngIf="buildConfigsCount > 0" class="recommender-selector">
         <select id="spacehome-analytical-report-combobox" name="pipeSelect" [(ngModel)]="currentPipeline" (change)="selectedPipeline()"
           class="form-control">
           <option disabled value="default">Select a pipeline...</option>
           <option *ngFor="let build of pipelines | filter; let i = index;" [ngValue]="build.id">{{ build.name }}</option>
         </select>
-      </div>
+      </span>
     </h2>
   </div>
   <div class="card-pf-body f8-card-body">

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.less
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.less
@@ -4,17 +4,21 @@
   -ms-transform: translate(@x, @y);
   transform: translate(@x, @y);
 }
+.recommender-selector {
+  @media (min-width: @screen-sm-min) { float: right; }
+  @media (max-width: @screen-xs-min) { clear: right; }
+}
 .card-pf {
   &.analytical-report-widget {
     position: relative;
-    overflow: auto;
     .fifty-shades-of-grey {
       color: @color-pf-black-500;
     }
     .fabric8-stack-analysis {
-      position: relative;
-      padding: 0 10px;
-      margin-top: 20px;
+      margin-top: 5px;
+      height: 370px;
+      @media (max-width: @screen-xs-min) { height: 335px; }
+      overflow-y: scroll;
       .recommender-overlay {
         position: absolute;
         top: 0;

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.html
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.html
@@ -23,7 +23,7 @@
         <button id="spacehome-my-workitems-create-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-work-item' } }]">Create work item</button>
       </div>
     </div>
-    <ul id="spacehome-my-workitems-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="(myWorkItemsCount | async) > 0">
+    <ul id="spacehome-my-workitems-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped f8-card-list" *ngIf="(myWorkItemsCount | async) > 0">
       <li class="list-group-item" *ngFor="let workItem of myWorkItems | async | take: 6">
         <div class="list-view-pf-main-info">
           <div class="list-view-pf-body">

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -59,7 +59,7 @@
   </div>
   <div class="cards-pf">
     <div class="row row-cards-pf">
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <div class="card-pf f8-card">
           <div class="card-pf-heading f8-card-heading">
             <div class="card-pf-heading-details f8-card-heading-details" *ngIf="_spaces.length > 0">
@@ -107,10 +107,10 @@
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <alm-work-item-widget></alm-work-item-widget>
       </div>
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <fabric8-recent-pipelines-widget></fabric8-recent-pipelines-widget>
       </div>
     </div>

--- a/src/app/home/home.component.less
+++ b/src/app/home/home.component.less
@@ -15,8 +15,8 @@
   margin-bottom: 40px;
   margin-left: -30px;
   background-color: @color-pf-black-900;
-  @media (min-width: 768px) and (max-width: 1200px) { height: 450px; }
-  @media (max-width: 768px) { height: auto; }
+  @media (min-width: @screen-sm-min) and (max-width: @screen-lg-min) { height: 450px; }
+  @media (max-width: @screen-xs-min) { height: auto; }
   .home-header-background-image;
   background-repeat: no-repeat;
   color: @color-pf-white;

--- a/src/app/home/work-item-widget/work-item-widget.component.less
+++ b/src/app/home/work-item-widget/work-item-widget.component.less
@@ -3,7 +3,7 @@
   position: absolute;
   top: 15px;
   right: 25px;
-  width: 50%;
+  width: 45%;
 }
 .work-item-title {
   position: absolute;

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -1,31 +1,31 @@
 <div id="analyze-overview" class="container-fluid analyze-overview-wrapper">
-  <section class="row col-sm-12 margin-top-15">
-    <div class="col-sm-10 padding-0">
+  <div class="row margin-top-15">
+    <div class="col-xs-12 col-sm-10">
       <fabric8-edit-space-description-widget></fabric8-edit-space-description-widget>
     </div>
-    <div class="col-sm-2">
-      <button id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right width-100" (click)="openForgeWizard(addSpace)">Add to space</button>
+    <div class="col-xs-4 col-xs-offset-4 col-sm-2 col-sm-offset-0">
+      <button id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right" (click)="openForgeWizard(addSpace)">Add to space</button>
     </div>
-  </section>
+  </div>
   <div class="cards-pf">
     <div class="row row-cards-pf">
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <fabric8-add-codebase-widget (addToSpace)="openForgeWizard(addSpace)"></fabric8-add-codebase-widget>
       </div>
-      <div class="col-sm-8">
+      <div class="col-xs-12 col-md-8">
         <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
       </div>
     </div>
   </div>
   <div class="cards-pf">
     <div class="row row-cards-pf padding-top-0">
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <fabric8-create-work-item-widget></fabric8-create-work-item-widget>
       </div>
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <fabric8-pipelines-widget (addToSpace)="openForgeWizard(addSpace)"></fabric8-pipelines-widget>
       </div>
-      <div class="col-sm-4">
+      <div class="col-xs-12 col-md-4">
         <fabric8-environment-widget></fabric8-environment-widget>
       </div>
     </div>

--- a/src/assets/stylesheets/shared/_cards.less
+++ b/src/assets/stylesheets/shared/_cards.less
@@ -8,16 +8,12 @@
     &-body {
       margin-top: 0;
       padding-bottom: 0;
-      // height: 375px;
-      // overflow-y: auto;
       overflow-x: hidden;
       .list-group { padding-bottom: 0; }
       .list-view-pf-view { margin-top: -1px; }
     }
     &-heading {
-      // margin-right: 0;
       margin-bottom: 0;
-      // margin-left: 0;
       &-btn {
         &-link {
           display: inline-flex;
@@ -39,6 +35,8 @@
     }
     &-list {
       padding: 0;
+      max-height: 375px;
+      overflow-y: scroll;
       .list-group-item {
         margin-left: -2px;
         &-heading {

--- a/src/assets/stylesheets/shared/_formulas.less
+++ b/src/assets/stylesheets/shared/_formulas.less
@@ -36,7 +36,10 @@
   }
   .margin-loop(@i - 1);
 }
-.margin-loop(15);
+/*
+ * maximum number that can be used in the padding-loop and margin-loop formulas
+  */
+.margin-loop(50);
 
 @include: padding-x;
 @include: margin-x;

--- a/src/assets/stylesheets/shared/_layout.less
+++ b/src/assets/stylesheets/shared/_layout.less
@@ -24,6 +24,27 @@ body {
   margin: 0;
   border-width: 0;
 }
+.padding {
+  &-0 { padding: 0; }
+  &-top-0 { padding-top: 0; }
+  &-right-0 { padding-right: 0; }
+  &-bottom-0 { padding-bottom: 0; }
+  &-left-0 { padding-left: 0; }
+}
+.margin {
+  &-0 { margin: 0; }
+  &-top-0 { margin-top: 0; }
+  &-right-0 { margin-right: 0; }
+  &-bottom-0 { margin-bottom: 0; }
+  &-left-0 { margin-left: 0; }
+}
+/*
+ * place on the parent a <div> to remove left and right padding from child columns
+ */
+.no-gutter > [class*='col-'] {
+  padding-left: 0;
+  padding-right: 0;
+}
 .containerPadd { padding: em(96) 0 em(66) 0; }
 .containerPadd-nologin { padding-bottom: 0; }
 @media (max-width: @grid-float-breakpoint) {


### PR DESCRIPTION
Update the Home and Space dashboards to be responsive. They will now adjust based on viewport size and cards will resize to fit content accordingly.

Padding and Margin variables were also updated, to fix empty classes used for layouts.

This PR is related to https://github.com/fabric8-ui/fabric8-ux/issues/751 and https://github.com/openshiftio/openshift.io/issues/1443, but does not complete the work.

