### PR TITLE
Fix placeholder text for Company field

### DIFF
--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -29,7 +29,7 @@
           <label for="company" class="control-label">Company</label>
           <div [ngClass]="{'has-error': companyInvalid}">
             <input type="text" class="form-control" id="company" name="company"
-                    placeholder="name@gmail.com"
+                    placeholder="Enter your company's name"
                     [(ngModel)]="company">
           </div>
         </div>


### PR DESCRIPTION
Change placeholder for the Company field on the "Edit Profile" page so it has a relevant placeholder instead of "name@gmail.com".

