### PR TITLE
rh-che-449: Temporary removing Che status icon due to multi-tenant migration

### DIFF
--- a/src/a-runtime-console/kubernetes/ui/status/status-list.component.html
+++ b/src/a-runtime-console/kubernetes/ui/status/status-list.component.html
@@ -1,5 +1,5 @@
 <li class="list-group-item">
-  <status-info [info]="cheStatusObserver | async">
+  <status-info hidden [info]="cheStatusObserver | async">
     Che
   </status-info>
 </li>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1461122/33271484-ad6abcaa-d387-11e7-9a20-a8f0f09ec290.png)


rh-che issue - https://github.com/redhat-developer/rh-che/issues/449
openshift.io issue - https://github.com/openshiftio/openshift.io/issues/1423