### PR TITLE
fix(scrollbar): fix empty scrollbar in cards

### DIFF
--- a/src/assets/stylesheets/shared/_cards.less
+++ b/src/assets/stylesheets/shared/_cards.less
@@ -36,7 +36,7 @@
     &-list {
       padding: 0;
       max-height: 375px;
-      overflow-y: scroll;
+      overflow-y: auto;
       .list-group-item {
         margin-left: -2px;
         &-heading {


### PR DESCRIPTION
Fixed an issue where scrollbars always appeared inside of card components.

