### PR TITLE
enhancement(deployments): Add generated mock data to patternfly charts

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -33,19 +33,18 @@
         <div class="chart-column">
           <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
         </div>
-        <div class="chart-column chart-text">
-          <p class="chart-info-header">CPU (Cores)</p>
-          <p>{{ cpuVal }} of 10</p>
+        <div class="chart-column">
+          <deployment-graph-label type="CPU" dataMeasure="Cores" [value]="cpuVal" valueUpperBound="10"></deployment-graph-label>
         </div>
       </div>
+
       <div class="deployment-chart">
-          <div class="chart-column">
-            <pfng-chart-sparkline [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
+        <div class="chart-column">
+            <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
           </div>
-          <div class="chart-column chart-text">
-            <p class="chart-info-header">Memory (GB)</p>
-            <p>{{ cpuVal }} of 500</p>
-          </div>
+        <div class="chart-column chart-text">
+            <deployment-graph-label type="Memory" dataMeasure="GB" [value]="memVal" valueUpperBound="500"></deployment-graph-label>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -29,7 +29,11 @@
     </div>
     <div [collapse]="collapsed">
       <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="false"></deployments-donut>
-      <pfng-chart-sparkline [config]="config" [chartData]="data"></pfng-chart-sparkline>
+      <p>CPU Usage</p>
+      <pfng-chart-sparkline [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
+      <br>
+      <p>Memory Usage</p>
+      <pfng-chart-sparkline [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
     </div>
   </div>
 </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -29,11 +29,24 @@
     </div>
     <div [collapse]="collapsed">
       <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="false"></deployments-donut>
-      <p>CPU Usage</p>
-      <pfng-chart-sparkline [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
-      <br>
-      <p>Memory Usage</p>
-      <pfng-chart-sparkline [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
+      <div class="deployment-chart">
+        <div class="chart-column">
+          <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
+        </div>
+        <div class="chart-column chart-text">
+          <p class="chart-info-header">CPU (Cores)</p>
+          <p>{{ cpuVal }} of 10</p>
+        </div>
+      </div>
+      <div class="deployment-chart">
+          <div class="chart-column">
+            <pfng-chart-sparkline [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
+          </div>
+          <div class="chart-column chart-text">
+            <p class="chart-info-header">Memory (GB)</p>
+            <p>{{ cpuVal }} of 500</p>
+          </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.less
+++ b/src/app/space/create/deployments/apps/deployment-card.component.less
@@ -3,3 +3,25 @@
 .menu-item {
   cursor: pointer;
 }
+
+.deployment-chart {
+  display: flex;
+}
+
+.chart-sparkline {
+  float: left;
+}
+
+.chart-info-header {
+  margin-bottom: 10px;
+}
+
+.chart-column {
+  flex: 1;
+  height: 100%;
+  width: 50%;
+}
+
+.chart-text {
+  padding-left: 10px;
+}

--- a/src/app/space/create/deployments/apps/deployment-card.component.less
+++ b/src/app/space/create/deployments/apps/deployment-card.component.less
@@ -21,7 +21,3 @@
   height: 100%;
   width: 50%;
 }
-
-.chart-text {
-  padding-left: 10px;
-}

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -39,6 +39,16 @@ class FakeDeploymentsDonutComponent {
   @Input() applicationId: string;
   @Input() environmentId: string;
 }
+@Component({
+  selector: 'deployment-graph-label',
+  template: ''
+})
+class FakeDeploymentGraphLabelComponent {
+  @Input() type: any;
+  @Input() dataMeasure: any;
+  @Input() value: any;
+  @Input() valueUpperBound: any;
+}
 
 describe('DeploymentCardComponent', () => {
 
@@ -73,7 +83,7 @@ describe('DeploymentCardComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [ BsDropdownModule.forRoot(), CollapseModule.forRoot(), ChartModule ],
-      declarations: [ DeploymentCardComponent, FakeDeploymentsDonutComponent ],
+      declarations: [ DeploymentCardComponent, FakeDeploymentsDonutComponent, FakeDeploymentGraphLabelComponent ],
       providers: [ BsDropdownConfig, { provide: DeploymentsService, useValue: mockSvc } ]
     });
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -62,6 +62,8 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   memStat: Observable<MemoryStat>;
   cpuTime: number;
   memTime: number;
+  cpuVal: number;
+  memVal: number;
 
   logsUrl: Observable<string>;
   consoleUrl: Observable<string>;
@@ -82,8 +84,8 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
-    this.cpuConfig.chartHeight = 60;
-    this.memConfig.chartHeight = 60;
+    this.cpuConfig.chartHeight = 100;
+    this.memConfig.chartHeight = 100;
     this.cpuTime = 1;
     this.memTime = 1;
 
@@ -106,11 +108,13 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
       this.deploymentsService.getMemoryStat(this.applicationId, this.environment.environmentId);
 
     this.cpuStat.subscribe(stat => {
+      this.cpuVal = stat.used;
       this.cpuData.yData.push(stat.used);
       this.cpuData.xData.push(this.cpuTime++);
     });
 
     this.memStat.subscribe(stat => {
+      this.memVal = stat.used;
       this.memData.yData.push(stat.used);
       this.memData.xData.push(this.cpuTime++);
     });

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -12,6 +12,8 @@ import {
 
 import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
+import { CpuStat } from '../models/cpu-stat';
+import { MemoryStat } from '../models/memory-stat';
 
 // Makes patternfly charts available
 import 'patternfly/dist/js/patternfly-settings.js';
@@ -29,20 +31,36 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   @Input() applicationId: string;
   @Input() environment: Environment;
 
-  public data: any = {
+  public cpuData: any = {
     dataAvailable: true,
     total: 100,
-    xData: ['foo', 1, 2, 3, 4],
-    yData: ['used', 10, 20, 30, 40]
+    xData: ['time', 0],
+    yData: ['used', 1]
   };
 
-  public config: any = {
+  public memData: any = {
+    dataAvailable: true,
+    total: 100,
+    xData: ['time', 0],
+    yData: ['used', 1]
+  };
+
+  public cpuConfig: any = {
     // Seperate chart IDs must be unique, otherwise only one will appear
-    chartId: 'chart-' + DeploymentCardComponent.chartIdNum++ + '-'
+    chartId: 'cpu-chart-' + DeploymentCardComponent.chartIdNum++ + '-'
+  };
+
+  public memConfig: any = {
+    // Seperate chart IDs must be unique, otherwise only one will appear
+    chartId: 'mem-chart-' + DeploymentCardComponent.chartIdNum++ + '-'
   };
 
   collapsed: boolean = true;
   version: Observable<string>;
+  cpuStat: Observable<CpuStat>;
+  memStat: Observable<MemoryStat>;
+  cpuTime: number;
+  memTime: number;
 
   logsUrl: Observable<string>;
   consoleUrl: Observable<string>;
@@ -63,7 +81,10 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
-    this.config.chartHeight = 60;
+    this.cpuConfig.chartHeight = 60;
+    this.memConfig.chartHeight = 60;
+    this.cpuTime = 1;
+    this.memTime = 1;
 
     this.version =
       this.deploymentsService.getVersion(this.applicationId, this.environment.environmentId);
@@ -76,6 +97,22 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
     this.appUrl =
       this.deploymentsService.getAppUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+
+    this.cpuStat =
+      this.deploymentsService.getCpuStat(this.applicationId, this.environment.environmentId);
+
+    this.memStat =
+      this.deploymentsService.getMemoryStat(this.applicationId, this.environment.environmentId);
+
+    this.cpuStat.subscribe(stat => {
+      this.cpuData.yData.push(stat.used);
+      this.cpuData.xData.push(this.cpuTime++);
+    });
+
+    this.memStat.subscribe(stat => {
+      this.memData.yData.push(stat.used);
+      this.memData.xData.push(this.cpuTime++);
+    });
   }
 
   delete(): void {
@@ -84,5 +121,4 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
         .subscribe(alert)
     );
   }
-
 }

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -9,6 +9,7 @@ import {
   Observable,
   Subscription
 } from 'rxjs';
+import { uniqueId } from 'lodash';
 
 import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
@@ -46,13 +47,13 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   };
 
   public cpuConfig: any = {
-    // Seperate chart IDs must be unique, otherwise only one will appear
-    chartId: 'cpu-chart-' + DeploymentCardComponent.chartIdNum++ + '-'
+    // Seperate charts must have unique IDs, otherwise only one will appear
+    chartId: uniqueId('cpu-chart-') + '-'
   };
 
   public memConfig: any = {
-    // Seperate chart IDs must be unique, otherwise only one will appear
-    chartId: 'mem-chart-' + DeploymentCardComponent.chartIdNum++ + '-'
+    // Seperate charts must have unique IDs, otherwise only one will appear
+    chartId: uniqueId('mem-chart-') + '-'
   };
 
   collapsed: boolean = true;

--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.html
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.html
@@ -1,0 +1,4 @@
+<div class="chart-text">
+    <p class="chart-info-header">{{ type }} ({{ dataMeasure }})</p>
+    <p>{{ value }} of {{ valueUpperBound }}</p>
+</div>

--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.less
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.less
@@ -1,0 +1,3 @@
+.chart-text {
+  padding-left: 10px;
+}

--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.ts
@@ -1,0 +1,25 @@
+import {
+  Component,
+  Input,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
+
+@Component({
+  selector: 'deployment-graph-label',
+  templateUrl: 'deployment-graph-label.component.html',
+  styleUrls: ['./deployment-graph-label.component.less']
+
+})
+export class DeploymentGraphLabelComponent implements OnDestroy, OnInit {
+  @Input() type: any;
+  @Input() dataMeasure: any;
+  @Input() value: any;
+  @Input() valueUpperBound: any;
+
+  constructor() { }
+
+  ngOnDestroy(): void { }
+
+  ngOnInit(): void { }
+}

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -12,6 +12,7 @@ import { DeploymentsAppsComponent } from '../deployments/apps/deployments-apps.c
 import { DeploymentsResourceUsageComponent } from '../deployments/resource-usage/deployments-resource-usage.component';
 import { DeploymentCardContainerComponent } from '../deployments/apps/deployment-card-container.component';
 import { DeploymentCardComponent } from '../deployments/apps/deployment-card.component';
+import { DeploymentGraphLabelComponent } from '../deployments/apps/deployment-graph-label.component';
 import { DeploymentsDonutComponent } from './deployments-donut/deployments-donut.component';
 import {
   DeploymentsDonutChartComponent
@@ -39,6 +40,7 @@ import { ChartModule } from 'patternfly-ng';
     DeploymentsComponent,
     DeploymentCardContainerComponent,
     DeploymentCardComponent,
+    DeploymentGraphLabelComponent,
     DeploymentsAppsComponent,
     DeploymentsResourceUsageComponent,
     DeploymentsDonutComponent,


### PR DESCRIPTION
This patch adds mock data generated from a subscriber to our patternfly charts so that they update in real time. This will set the template for when we are ready to add real data to them.

