### PR TITLE
Remove create space notification

### DIFF
--- a/src/app/space/wizard/space-wizard.component.ts
+++ b/src/app/space/wizard/space-wizard.component.ts
@@ -79,24 +79,6 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
           .catch(err => Observable.of(createdSpace));
       })
       .subscribe(createdSpace => {
-          const primaryAction: NotificationAction = {
-            isDisabled: false,
-            isSeparator: false,
-            name: `Open Space`,
-            title: `Open ${this.spaceNamePipe.transform(createdSpace.attributes.name)}`,
-            id: 'openSpace'
-          };
-          this.notifications.message(<Notification>{
-            message: `Your new space is created!`,
-            type: NotificationType.SUCCESS,
-            primaryAction: primaryAction
-          })
-            .filter(action => action.id === primaryAction.id)
-            .subscribe(action => {
-              this.router.navigate([createdSpace.relationalData.creator.attributes.username,
-                createdSpace.attributes.name]);
-              this.finish();
-            });
           this.router.navigate([createdSpace.relationalData.creator.attributes.username,
             createdSpace.attributes.name]);
           this.finish();


### PR DESCRIPTION
Removed the “Your new space is created” notification per UXD's request. Since the user is already navigated to the created space, and prompted by the space wizard, another notification to take you to that space is unnecessary.