### PR TITLE
feat(deployments): add deployments donut component

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -4,8 +4,8 @@
     <deployments-donut [applicationId]="applicationId" [mini]="true" ></deployments-donut>
     <span id="versionLabel">{{ version | async }}</span>
     <div class="pull-right dropdown-kebab-pf dropdown" dropdown (click)="$event.stopPropagation()">
-      <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true" aria-expanded="true"
-        data-toggle="dropdown" dropdownToggle>
+      <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true"
+        aria-expanded="true" data-toggle="dropdown" dropdownToggle>
         <span class="fa fa-ellipsis-v"></span>
       </button>
       <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="kebab" role="menu" *dropdownMenu>

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -1,11 +1,11 @@
 <div class="card-pf" (click)="collapsed = !collapsed">
   <div class="card-pf-body">
     <span class="pficon pficon-ok" tooltip="Everything looks okay" placement="top"></span>
-    <span id="podCountLabel">{{ podCount | async }} Pods</span>
+    <deployments-donut [applicationId]="applicationId" [mini]="true" ></deployments-donut>
     <span id="versionLabel">{{ version | async }}</span>
     <div class="pull-right dropdown-kebab-pf dropdown" dropdown (click)="$event.stopPropagation()">
-      <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true"
-        aria-expanded="true" data-toggle="dropdown" dropdownToggle>
+      <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true" aria-expanded="true"
+        data-toggle="dropdown" dropdownToggle>
         <span class="fa fa-ellipsis-v"></span>
       </button>
       <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="kebab" role="menu" *dropdownMenu>
@@ -26,6 +26,7 @@
       </ul>
     </div>
     <div [collapse]="collapsed">
+      <deployments-donut [applicationId]="applicationId" [mini]="false"></deployments-donut>
       <pfng-chart-sparkline [config]="config" [chartData]="data"></pfng-chart-sparkline>
     </div>
   </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -4,17 +4,13 @@ import {
 } from '@angular/core/testing';
 
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement, Input } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 
 import { DeploymentCardComponent } from './deployment-card.component';
-import { DeploymentsDonutComponent } from '../deployments-donut/deployments-donut.component';
-import {
-  DeploymentsDonutChartComponent
-} from '../deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
 import { DeploymentsService } from '../services/deployments.service';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
@@ -22,6 +18,15 @@ import { MemoryStat } from '../models/memory-stat';
 // Makes patternfly charts available
 import { ChartModule } from 'patternfly-ng';
 import 'patternfly/dist/js/patternfly-settings.js';
+
+@Component({
+  selector: 'deployments-donut',
+  template: ''
+})
+class FakeDeploymentsDonutComponent {
+  @Input() applicationId: string;
+  @Input() mini: boolean;
+}
 
 describe('DeploymentCardComponent', () => {
 
@@ -48,7 +53,7 @@ describe('DeploymentCardComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [CollapseModule.forRoot(), ChartModule],
-      declarations: [DeploymentCardComponent, DeploymentsDonutComponent, DeploymentsDonutChartComponent],
+      declarations: [DeploymentCardComponent, FakeDeploymentsDonutComponent],
       providers: [{ provide: DeploymentsService, useValue: mockSvc }]
     });
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -11,6 +11,10 @@ import { Observable } from 'rxjs';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 
 import { DeploymentCardComponent } from './deployment-card.component';
+import { DeploymentsDonutComponent } from '../deployments-donut/deployments-donut.component';
+import {
+  DeploymentsDonutChartComponent
+} from '../deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
 import { DeploymentsService } from '../services/deployments.service';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
@@ -43,16 +47,16 @@ describe('DeploymentCardComponent', () => {
     spyOn(mockSvc, 'getVersion').and.callThrough();
 
     TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot(), ChartModule],
-      declarations: [ DeploymentCardComponent ],
-      providers: [ { provide: DeploymentsService, useValue: mockSvc } ]
+      imports: [CollapseModule.forRoot(), ChartModule],
+      declarations: [DeploymentCardComponent, DeploymentsDonutComponent, DeploymentsDonutChartComponent],
+      providers: [{ provide: DeploymentsService, useValue: mockSvc }]
     });
 
     fixture = TestBed.createComponent(DeploymentCardComponent);
     component = fixture.componentInstance;
 
     component.applicationId = 'mockAppId';
-    component.environment = { environmentId: 'mockEnvironmentId', name: 'mockEnvironment'};
+    component.environment = { environmentId: 'mockEnvironmentId', name: 'mockEnvironment' };
 
     fixture.detectChanges();
 
@@ -64,21 +68,6 @@ describe('DeploymentCardComponent', () => {
       expect(depCard1.getChartIdNum()).not.toBe(depCard2.getChartIdNum());
       expect(depCard1.getChartIdNum()).not.toBe(depCard3.getChartIdNum());
       expect(depCard2.getChartIdNum()).not.toBe(depCard3.getChartIdNum());
-      });
-  });
-
-  describe('podCountLabel', () => {
-    let de: DebugElement;
-    let el: HTMLElement;
-
-    beforeEach(() => {
-      de = fixture.debugElement.query(By.css('#podCountLabel'));
-      el = de.nativeElement;
-    });
-
-    it('should be set from mockSvc.getPodCount result', () => {
-      expect(mockSvc.getPodCount).toHaveBeenCalledWith('mockAppId', 'mockEnvironmentId');
-      expect(el.textContent).toEqual('2 Pods');
     });
   });
 

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
@@ -1,22 +1,22 @@
 <div #chartElement id="{{chartId}}" class="deployments-donut-chart" [ngClass]="{'mini': mini}"></div>
 <div *ngIf="mini" class="deployments-donut-chart-mini-text">
-  <span *ngIf="!idled">
+  <span *ngIf="!idled; else elseIdle">
     {{total}}
-    <span *ngIf="total === 1">pod</span>
-    <span *ngIf="total !== 1">pods</span>
+    <span>{{(total === 1) ? 'pod' : 'pods'}}</span>
   </span>
-  <span *ngIf="idled">
-    Idle
-  </span>
+  <ng-template #elseIdle>
+    <span>Idle</span>
+  </ng-template>
 </div>
 
 <div class="sr-only">
-  <div *ngIf="pods?.length === 0">No pods.</div>
-  <div *ngIf="pods?.length !== 0">
-    Pod status:
-    <li *ngFor="let column of podStatusData">
-      <span *ngIf="column[1]">{{column[1]}} {{column[0]}}</span>
-      <span *ngIf="!column[1]">0 {{column[0]}}</span>"
-    </li>
-  </div>
+  <div *ngIf="pods?.length === 0; else elsePods">No pods.</div>
+  <ng-template #elsePods>
+    <div>
+      Pod status:
+      <li *ngFor="let column of podStatusData">
+        <span>{{ column[1] ? column[1] + ' ' + column[0] : '0 ' +  column[0] }}</span>
+      </li>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
@@ -1,0 +1,22 @@
+<div #chartElement id="{{chartId}}" class="deployments-donut-chart" [ngClass]="{'mini': mini}"></div>
+<div *ngIf="mini" class="deployments-donut-chart-mini-text">
+  <span *ngIf="!idled">
+    {{total}}
+    <span *ngIf="total === 1">pod</span>
+    <span *ngIf="total !== 1">pods</span>
+  </span>
+  <span *ngIf="idled">
+    Idle
+  </span>
+</div>
+
+<div class="sr-only">
+  <div *ngIf="pods?.length === 0">No pods.</div>
+  <div *ngIf="pods?.length !== 0">
+    Pod status:
+    <li *ngFor="let column of podStatusData">
+      <span *ngIf="column[1]">{{column[1]}} {{column[0]}}</span>
+      <span *ngIf="!column[1]">0 {{column[0]}}</span>"
+    </li>
+  </div>
+</div>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.less
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.less
@@ -1,0 +1,36 @@
+@import (reference) '../../../../../../assets/stylesheets/shared/osio.less';
+
+.deployments-donut-chart {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.deployments-donut-chart.mini {
+  display: inline-block;
+  margin: 0 0 0 -8px;
+  min-width: 45px;
+  min-height: 45px;
+  top: 3px;
+  vertical-align: middle;
+}
+.deployments-donut-chart .c3-defocused {
+  opacity: .5;
+}
+.deployments-donut-chart .c3-tooltip-container {
+  top: -27px;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+          transform: translateX(-50%);
+  white-space: nowrap;
+}
+.deployments-donut-chart path.c3-arc-Empty {
+  stroke: #d1d1d1;
+  cursor: inherit;
+}
+.deployments-donut-chart .c3-tooltip-name--Empty .name {
+  display: none;
+}
+.deployments-donut-chart-mini-text {
+  display: inline-block;
+  min-width: 50px;
+}

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
@@ -1,0 +1,103 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import { isEqual } from 'lodash';
+
+import { DeploymentsDonutChartComponent } from './deployments-donut-chart.component';
+
+describe('DeploymentsDonutChartComponent', () => {
+  let component: DeploymentsDonutChartComponent;
+  let fixture: ComponentFixture<DeploymentsDonutChartComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [DeploymentsDonutChartComponent]
+    });
+
+    fixture = TestBed.createComponent(DeploymentsDonutChartComponent);
+    component = fixture.componentInstance;
+
+    component.pods = [
+      {
+        status: {
+          phase: 'Running'
+        }
+      }, {
+        status: {
+          phase: 'Terminating'
+        }
+      }
+    ];
+    component.mini = false;
+    component.desiredReplicas = 1;
+    component.idled = false;
+
+    fixture.detectChanges();
+    component.debounceUpdate.flush();
+  });
+
+  it('should set unique chartId', () => {
+    expect(component.chartId).toMatch('deployments-donut-chart.*');
+  });
+
+  it('should set podStatusData', () => {
+    let expectedPodStatusData = [
+      ['Running', 1],
+      ['Not Ready', 0],
+      ['Warning', 0],
+      ['Error', 0],
+      ['Pulling', 0],
+      ['Pending', 0],
+      ['Succeeded', 0],
+      ['Terminating', 1],
+      ['Unknown', 0]
+    ];
+    component.debounceUpdate.flush();
+    expect(component.podStatusData).toEqual(expectedPodStatusData);
+  });
+
+  it('should update podStatusData', () => {
+    let expectedPodStatusData = [
+      ['Running', 1],
+      ['Not Ready', 0],
+      ['Warning', 0],
+      ['Error', 0],
+      ['Pulling', 0],
+      ['Pending', 0],
+      ['Succeeded', 0],
+      ['Terminating', 1],
+      ['Unknown', 0]
+    ];
+    component.debounceUpdate.flush();
+    expect(component.podStatusData).toEqual(expectedPodStatusData);
+
+    expectedPodStatusData = [
+      ['Running', 2],
+      ['Not Ready', 0],
+      ['Warning', 0],
+      ['Error', 0],
+      ['Pulling', 0],
+      ['Pending', 0],
+      ['Succeeded', 0],
+      ['Terminating', 0],
+      ['Unknown', 0]
+    ];
+
+    component.pods = [{
+      status: {
+        phase: 'Running'
+      }
+    }, {
+      status: {
+        phase: 'Running'
+      }
+    }];
+
+    fixture.detectChanges();
+    component.debounceUpdate.flush();
+
+    expect(component.podStatusData).toEqual(expectedPodStatusData);
+  });
+});

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -20,6 +20,7 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
   chartId = uniqueId('deployments-donut-chart');
   podStatusData: any;
   total: number;
+  debounceUpdate = debounce(this.updateChart, 350, { maxWait: 500 });
 
   private phases = [
     'Running',
@@ -36,8 +37,6 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
   private config: any;
   private chart: any;
 
-
-  private debounceUpdate = debounce(this.updateChart, 350, { maxWait: 500 });
   private prevPodPhaseCount: any;
 
   constructor() { }

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -1,0 +1,245 @@
+import { Component, DoCheck, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+
+import { debounce, get, isEmpty, isEqual, reject, size, uniqueId } from 'lodash';
+
+import * as c3 from 'c3';
+import * as d3 from 'd3';
+
+@Component({
+  selector: 'deployments-donut-chart',
+  templateUrl: './deployments-donut-chart.component.html',
+  styleUrls: ['./deployments-donut-chart.component.less']
+})
+export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChanges, OnDestroy {
+
+  @Input() pods: any;
+  @Input() mini: boolean;
+  @Input() desiredReplicas: number;
+  @Input() idled: boolean;
+
+  chartId = uniqueId('deployments-donut-chart');
+  podStatusData: any;
+  total: number;
+
+  private phases = ['Running',
+    'Not Ready',
+    'Warning',
+    'Error',
+    'Pulling',
+    'Pending',
+    'Succeeded',
+    'Terminating',
+    'Unknown'];
+
+  private config: any;
+  private chart: any;
+
+
+  private debounceUpdate: (countByPhase: any) => void;
+  private prevPodPhaseCount: any;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    this.config = {
+      type: 'donut',
+      bindto: '#' + this.chartId,
+      donut: {
+        expand: false,
+        label: {
+          show: false
+        },
+        width: this.mini ? 5 : 10
+      },
+      size: {
+        height: this.mini ? 45 : 150,
+        width: this.mini ? 45 : 150
+      },
+      legend: {
+        show: false
+      },
+      tooltip: {
+        format: {
+          value: function (value, ratio, id) {
+            if (!value) {
+              return undefined;
+            }
+            if (id === 'Empty') {
+              return undefined;
+            }
+
+            return value;
+          }
+        }
+      },
+      transition: {
+        duration: 350
+      },
+      data: {
+        type: 'donut',
+        groups: [this.phases],
+        order: null,
+        colors: {
+          Empty: '#ffffff',
+          Running: '#00b9e4',
+          'Not Ready': '#beedf9',
+          Warning: '#f39d3c',
+          Error: '#d9534f',
+          Pulling: '#d1d1d1',
+          Pending: '#ededed',
+          Succeeded: '#3f9c35',
+          Terminating: '#00659c',
+          Unknown: '#f9d67a'
+        },
+        selection: {
+          enabled: false
+        }
+      }
+    };
+
+    if (this.mini) {
+      this.config.padding = {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0
+      };
+    }
+
+    this.debounceUpdate = debounce(this.updateChart, 350, { maxWait: 500 });
+  }
+
+  ngDoCheck(): void {
+    let podPhaseCount = this.countPodPhases();
+    if (!isEqual(this.prevPodPhaseCount, podPhaseCount)) {
+      this.prevPodPhaseCount = podPhaseCount;
+      this.debounceUpdate(podPhaseCount);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes.desiredReplicas.firstChange || !changes.idled.firstChange) {
+      this.updatePodCount();
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.chart) {
+      this.chart = this.chart.destroy();
+    }
+  }
+
+  private updatePodCount(): void {
+    let pods = reject(this.pods, { status: { phase: 'Failed' } });
+    let total = size(this.pods);
+
+    if (this.mini) {
+      this.total = total;
+      return;
+    }
+
+    let smallText: string;
+    if (isNaN(this.desiredReplicas) || this.desiredReplicas === total) {
+      smallText = (total === 1) ? 'pod' : 'pods';
+    } else {
+      smallText = 'scaling to ' + this.desiredReplicas + '...';
+    }
+
+    if (this.idled) {
+      this.updateCenterText('Idle');
+    } else {
+      this.updateCenterText(total, smallText);
+    }
+  }
+
+  private updateChart(countByPhase): void {
+    let columns = [];
+    this.phases.forEach((phase) => {
+      columns.push([phase, countByPhase[phase] || 0]);
+    });
+
+    if (isEmpty(countByPhase)) {
+      columns.push(['Empty', 1]);
+    } else {
+      // unload empty
+    }
+
+    if (!this.chart) {
+      this.config.data.columns = columns;
+      this.chart = c3.generate(this.config);
+    } else {
+      this.chart.load(this.config.data);
+    }
+
+    this.podStatusData = columns;
+
+    this.updatePodCount();
+  }
+
+  // TODO : get correct phases
+
+  // private isReady(pod: any): boolean {
+  //   let numReady = this.numContainersReadyFilter(pod);
+  //   let total = size(pod.spec.containers);
+
+  //   return numReady === total;
+  // }
+
+  private getPhase(pod: any): any {
+    // if (this.isTerminatingFilter(pod)) {
+    //   return 'Terminating';
+    // }
+
+    // let warnings = this.podWarningsFilter(pod);
+    // if (some(warnings, { severity: 'error' })) {
+    //   return 'Error';
+    // } else if (isEmpty(warnings)) {
+    //   return 'Warning';
+    // }
+
+    // if (this.isPullingImageFilter(pod)) {
+    //   return 'Pulling';
+    // }
+
+    // Also count running, but not ready, as its own phase.
+    // if (pod.status.phase === 'Running' && !this.isReady(pod)) {
+    //   return 'Not Ready';
+    // }
+
+    return get(pod, 'status.phase', 'Unknown');
+  }
+
+  private countPodPhases(): any {
+    let countByPhase = {};
+
+    this.pods.forEach(pod => {
+      let phase = this.getPhase(pod);
+      countByPhase[phase] = (countByPhase[phase] || 0) + 1;
+    });
+
+    return countByPhase;
+  }
+
+  private updateCenterText(bigText: any, smallText?: any): void {
+    let donutChartTitle;
+
+    if (!this.chart) {
+      return;
+    }
+
+    donutChartTitle = d3.select(this.chart.element).select('text.c3-chart-arcs-title');
+    if (!donutChartTitle) {
+      return;
+    }
+
+    donutChartTitle.text('');
+    if (bigText && !smallText) {
+      donutChartTitle.text(bigText);
+    } else {
+      donutChartTitle.insert('tspan', null).text(bigText)
+        .classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
+      donutChartTitle.insert('tspan', null).text(smallText).
+        classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+    }
+  }
+}

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -1,6 +1,6 @@
 import { Component, DoCheck, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 
-import { debounce, get, isEmpty, isEqual, reject, size, uniqueId } from 'lodash';
+import { debounce, get, isEqual, reject, size, uniqueId } from 'lodash';
 
 import * as c3 from 'c3';
 import * as d3 from 'd3';
@@ -12,7 +12,7 @@ import * as d3 from 'd3';
 })
 export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChanges, OnDestroy {
 
-  @Input() pods: any;
+  @Input() pods: any[];
   @Input() mini: boolean;
   @Input() desiredReplicas: number;
   @Input() idled: boolean;
@@ -21,7 +21,8 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
   podStatusData: any;
   total: number;
 
-  private phases = ['Running',
+  private phases = [
+    'Running',
     'Not Ready',
     'Warning',
     'Error',
@@ -29,13 +30,14 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
     'Pending',
     'Succeeded',
     'Terminating',
-    'Unknown'];
+    'Unknown'
+  ];
 
   private config: any;
   private chart: any;
 
 
-  private debounceUpdate: (countByPhase: any) => void;
+  private debounceUpdate = debounce(this.updateChart, 350, { maxWait: 500 });
   private prevPodPhaseCount: any;
 
   constructor() { }
@@ -80,16 +82,16 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
         groups: [this.phases],
         order: null,
         colors: {
-          Empty: '#ffffff',
-          Running: '#00b9e4',
-          'Not Ready': '#beedf9',
-          Warning: '#f39d3c',
-          Error: '#d9534f',
-          Pulling: '#d1d1d1',
-          Pending: '#ededed',
-          Succeeded: '#3f9c35',
-          Terminating: '#00659c',
-          Unknown: '#f9d67a'
+          'Empty': '#ffffff', // black
+          'Running': '#00b9e4', // dark blue
+          'Not Ready': '#beedf9', // light blue
+          'Warning': '#f39d3c', // orange
+          'Error': '#d9534f', // red
+          'Pulling': '#d1d1d1', // grey
+          'Pending': '#ededed', // light grey
+          'Succeeded': '#3f9c35', // green
+          'Terminating': '#00659c', // dark blue
+          'Unknown': '#f9d67a' // light yellow
         },
         selection: {
           enabled: false
@@ -105,8 +107,6 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
         left: 0
       };
     }
-
-    this.debounceUpdate = debounce(this.updateChart, 350, { maxWait: 500 });
   }
 
   ngDoCheck(): void {
@@ -142,7 +142,7 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
     if (isNaN(this.desiredReplicas) || this.desiredReplicas === total) {
       smallText = (total === 1) ? 'pod' : 'pods';
     } else {
-      smallText = 'scaling to ' + this.desiredReplicas + '...';
+      smallText = `scaling to ${this.desiredReplicas}...`;
     }
 
     if (this.idled) {
@@ -152,17 +152,11 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
     }
   }
 
-  private updateChart(countByPhase): void {
+  private updateChart(countByPhase: any): void {
     let columns = [];
     this.phases.forEach((phase) => {
       columns.push([phase, countByPhase[phase] || 0]);
     });
-
-    if (isEmpty(countByPhase)) {
-      columns.push(['Empty', 1]);
-    } else {
-      // unload empty
-    }
 
     if (!this.chart) {
       this.config.data.columns = columns;
@@ -220,7 +214,7 @@ export class DeploymentsDonutChartComponent implements DoCheck, OnInit, OnChange
     return countByPhase;
   }
 
-  private updateCenterText(bigText: any, smallText?: any): void {
+  private updateCenterText(bigText: string | number, smallText?: string | number): void {
     let donutChartTitle;
 
     if (!this.chart) {

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -1,0 +1,20 @@
+<deployments-donut-chart [mini]="mini" [pods]="pods" [desiredReplicas]="desiredReplicas" [idled]="isIdled">
+</deployments-donut-chart>
+
+<span column class="deployment-donut-scale-controls fade-inline" *ngIf="!isIdled && !mini">
+  <div>
+    <a (click)="$event.stopPropagation(); scaleUp()" [ngClass]="{ disabled: !scalable }" [attr.title]="!scalable ? undefined : 'Scale up'"
+      [attr.aria-disabled]="!scalable ? 'true' : undefined" role="button">
+      <i class="fa fa-chevron-up"></i>
+      <span class="sr-only">Scale up</span>
+    </a>
+  </div>
+  <div>
+    <!-- Remove the title when disabled because the not-allowed styled cursor overlaps the tooltip on some browsers. -->
+    <a (click)="$event.stopPropagation(); scaleDown()" [ngClass]="{ disabled: !scalable || desiredReplicas === 0 }" [attr.title]="!scalable || desiredReplicas === 0 ? undefined : 'Scale down'"
+      [attr.aria-disabled]="!scalable || desiredReplicas === 0 ? 'true' : undefined" role="button">
+      <i class="fa fa-chevron-down"></i>
+      <span class="sr-only">Scale down</span>
+    </a>
+  </div>
+</span>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.less
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.less
@@ -1,0 +1,39 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+.deployment-donut-scale-controls {
+  -webkit-box-pack: center;
+          justify-content: center;
+  font-size: 24px;
+  display: inline-block;
+  vertical-align: middle;
+}
+.deployment-donut-scale-controls a {
+  color: #bbb;
+}
+.deployment-donut-scale-controls a:hover,
+.deployment-donut-scale-controls a:active {
+  color: #72767b;
+  text-decoration: none;
+}
+.deployment-donut-scale-controls a.disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+.deployment-donut-scale-controls a.disabled:hover {
+  color: #bbb;
+}
+
+.fade-inline.ng-hide {
+  opacity: 0;
+}
+.fade-inline.ng-show {
+  opacity: 1;
+}
+.fade-inline.ng-hide-remove,
+.fade-inline.ng-hide-add {
+  display: inline-block;
+}
+.fade-inline.ng-hide-remove,
+.fade-inline.ng-hide-add {
+  transition: opacity .2s ease .5s;
+}

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -3,10 +3,22 @@ import {
   TestBed
 } from '@angular/core/testing';
 
+import { Component, Input } from '@angular/core';
+
 import { isEqual } from 'lodash';
 
 import { DeploymentsDonutComponent } from './deployments-donut.component';
-import { DeploymentsDonutChartComponent } from './deployments-donut-chart/deployments-donut-chart.component';
+
+@Component({
+  selector: 'deployments-donut-chart',
+  template: ''
+})
+class FakeDeploymentsDonutChartComponent {
+  @Input() desiredReplicas: number;
+  @Input() idled: boolean;
+  @Input() mini: boolean;
+  @Input() pods: any[];
+}
 
 describe('DeploymentsDonutComponent', () => {
   let component: DeploymentsDonutComponent;
@@ -14,7 +26,7 @@ describe('DeploymentsDonutComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DeploymentsDonutComponent, DeploymentsDonutChartComponent]
+      declarations: [DeploymentsDonutComponent, FakeDeploymentsDonutChartComponent]
     });
 
     fixture = TestBed.createComponent(DeploymentsDonutComponent);

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -1,0 +1,78 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import { isEqual } from 'lodash';
+
+import { DeploymentsDonutComponent } from './deployments-donut.component';
+import { DeploymentsDonutChartComponent } from './deployments-donut-chart/deployments-donut-chart.component';
+
+describe('DeploymentsDonutComponent', () => {
+  let component: DeploymentsDonutComponent;
+  let fixture: ComponentFixture<DeploymentsDonutComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [DeploymentsDonutComponent, DeploymentsDonutChartComponent]
+    });
+
+    fixture = TestBed.createComponent(DeploymentsDonutComponent);
+    component = fixture.componentInstance;
+
+    component.mini = false;
+    component.applicationId = 'application';
+
+    fixture.detectChanges();
+  });
+
+  it('should default with 1 desired replica', () => {
+    expect(component.desiredReplicas).toBe(1);
+  });
+
+  it('should increment desired replicas on scale up by one', () => {
+    let desired = 1;
+    expect(component.desiredReplicas).toBe(desired);
+
+    component.scaleUp();
+    fixture.detectChanges();
+    expect(component.desiredReplicas).toBe(desired + 1);
+  });
+
+  it('should decrement desired replicas on scale down by one', () => {
+    let desired = 1;
+    expect(component.desiredReplicas).toBe(desired);
+
+    component.scaleDown();
+    fixture.detectChanges();
+    expect(component.desiredReplicas).toBe(desired - 1);
+  });
+
+  it('should not decrement desired replicas below zero when scaling down', () => {
+    let desired = 1;
+    expect(component.desiredReplicas).toBe(desired);
+
+    component.scaleDown();
+    fixture.detectChanges();
+    expect(component.desiredReplicas).toBe(desired - 1);
+
+    component.scaleDown();
+    fixture.detectChanges();
+    expect(component.desiredReplicas).toBe(0);
+  });
+
+  it('should acquire pods data', () => {
+    let expectedPods = [
+      {
+        status: {
+          phase: 'Running'
+        }
+      }, {
+        status: {
+          phase: 'Terminating'
+        }
+      }
+    ];
+    expect(component.pods).toEqual(expectedPods);
+  });
+});

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -54,7 +54,7 @@ export class DeploymentsDonutComponent implements OnInit {
   }
 
   getDesiredReplicas(): number {
-    if (this.desiredReplicas) {
+    if (this.desiredReplicas !== undefined) {
       return this.desiredReplicas;
     }
 

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -1,0 +1,84 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { debounce } from 'lodash';
+
+@Component({
+  selector: 'deployments-donut',
+  templateUrl: './deployments-donut.component.html',
+  styleUrls: ['./deployments-donut.component.less']
+})
+export class DeploymentsDonutComponent implements OnInit {
+
+  @Input() mini: boolean;
+  @Input() applicationId: string;
+
+  isIdled = false;
+  scalable = true;
+  pods: any;
+  desiredReplicas: number;
+
+  private scaleRequestPending = false;
+  private debounceScale: () => void;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    this.debounceScale = debounce(this.scale, 650);
+    this.pods = this.getPods();
+    this.desiredReplicas = this.getDesiredReplicas();
+  }
+
+  scaleUp(): void {
+    if (!this.scalable) {
+      return;
+    }
+    let desired = this.getDesiredReplicas();
+    this.desiredReplicas = desired + 1;
+
+    this.scaleRequestPending = true;
+    this.debounceScale();
+  }
+
+  scaleDown(): void {
+    if (!this.scalable) {
+      return;
+    }
+
+    if (0 === this.getDesiredReplicas()) {
+      return;
+    }
+
+    let desired = this.getDesiredReplicas();
+    this.desiredReplicas = desired - 1;
+
+    this.scaleRequestPending = true;
+    this.debounceScale();
+  }
+
+  getDesiredReplicas(): number {
+    if (this.desiredReplicas) {
+      return this.desiredReplicas;
+    }
+
+    // TODO: acquire replicas from service
+
+    return 1;
+  }
+
+  private scale(): void {
+    // TODO: send service request to scale
+    console.log('scale call');
+  }
+
+  private getPods(): any {
+    return [{
+      status: {
+        phase: 'Running'
+      }
+    }, {
+      status: {
+        phase: 'Terminating'
+      }
+    }];
+  }
+
+}

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -17,12 +17,11 @@ export class DeploymentsDonutComponent implements OnInit {
   desiredReplicas: number;
 
   private scaleRequestPending = false;
-  private debounceScale: () => void;
+  private debounceScale = debounce(this.scale, 650);
 
   constructor() { }
 
   ngOnInit(): void {
-    this.debounceScale = debounce(this.scale, 650);
     this.pods = this.getPods();
     this.desiredReplicas = this.getDesiredReplicas();
   }
@@ -43,7 +42,7 @@ export class DeploymentsDonutComponent implements OnInit {
       return;
     }
 
-    if (0 === this.getDesiredReplicas()) {
+    if (this.getDesiredReplicas() === 0) {
       return;
     }
 
@@ -66,7 +65,6 @@ export class DeploymentsDonutComponent implements OnInit {
 
   private scale(): void {
     // TODO: send service request to scale
-    console.log('scale call');
   }
 
   private getPods(): any {

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -12,8 +12,12 @@ import { DeploymentsAppsComponent } from '../deployments/apps/deployments-apps.c
 import { DeploymentsResourceUsageComponent } from '../deployments/resource-usage/deployments-resource-usage.component';
 import { DeploymentCardContainerComponent } from '../deployments/apps/deployment-card-container.component';
 import { DeploymentCardComponent } from '../deployments/apps/deployment-card.component';
+import { DeploymentsDonutComponent } from './deployments-donut/deployments-donut.component';
+import { DeploymentsDonutChartComponent }
+  from './deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
 import { ResourceCardComponent } from '../deployments/resource-usage/resource-card.component';
 import { UtilizationBarComponent } from '../deployments/resource-usage/utilization-bar.component';
+
 import { DeploymentsRoutingModule } from './deployments-routing.module';
 
 import { DeploymentsService } from '../deployments/services/deployments.service';
@@ -36,6 +40,8 @@ import { ChartModule } from 'patternfly-ng';
     DeploymentCardComponent,
     DeploymentsAppsComponent,
     DeploymentsResourceUsageComponent,
+    DeploymentsDonutComponent,
+    DeploymentsDonutChartComponent,
     ResourceCardComponent,
     UtilizationBarComponent
   ],

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -13,8 +13,9 @@ import { DeploymentsResourceUsageComponent } from '../deployments/resource-usage
 import { DeploymentCardContainerComponent } from '../deployments/apps/deployment-card-container.component';
 import { DeploymentCardComponent } from '../deployments/apps/deployment-card.component';
 import { DeploymentsDonutComponent } from './deployments-donut/deployments-donut.component';
-import { DeploymentsDonutChartComponent }
-  from './deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
+import {
+  DeploymentsDonutChartComponent
+} from './deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
 import { ResourceCardComponent } from '../deployments/resource-usage/resource-card.component';
 import { UtilizationBarComponent } from '../deployments/resource-usage/utilization-bar.component';
 


### PR DESCRIPTION
This is an initial step to completing: https://github.com/openshiftio/openshift.io/issues/1369

This adds a donut chart with scaling buttons, ported from the openshift web-console version [1] and following the mock [2]. The css styling comes from the web-console code.

This version uses mock data, which will be changed to be acquired from the backend service in a subsequent PR. As well, this version does not have support for HPA (Horizontal Pod Auto-scaling) that the web-console version has. This is also planned for a subsequent PR.

[1] https://github.com/openshift/origin-web-console
[2] https://redhat.invisionapp.com/share/YSDL0KRKW#/screens/260764293

Preview:
![deployments-donut](https://user-images.githubusercontent.com/5430520/33566386-d37a29a6-d8ed-11e7-9477-aafc78614c24.png)
