### PR TITLE
openshift.io #1495: Adding default 'success' icon for multi-tenant Che server

### DIFF
--- a/src/a-runtime-console/kubernetes/ui/status/status-list.component.html
+++ b/src/a-runtime-console/kubernetes/ui/status/status-list.component.html
@@ -1,7 +1,8 @@
 <li class="list-group-item">
-  <status-info hidden [info]="cheStatusObserver | async">
+  <span>
+    <span class="pficon pficon-ok"></span>
     Che
-  </status-info>
+  </span>
 </li>
 <li class="list-group-item">
   <status-info [info]="pipelineStatusObserver | async">


### PR DESCRIPTION
openshift.io issue https://github.com/openshiftio/openshift.io/issues/1495

Currently there is no mechanism for obtaining status for dsaas services like Forge
and default "success" placeholders is used for displaying the status. As a first step status for multi-tenant Che would be also just a default "Success" placeholder:

![image](https://user-images.githubusercontent.com/1461122/33767229-1bdb8d9e-dc21-11e7-8755-5fdaae1739e8.png)

In the future there should be a mechanism in place for obtaining status of the dsaas services.

WIP status since [1] getting started pdf document must be also updated.

https://github.com/openshiftio/openshift.io/blob/master/src/assets/documents/osiogettingstarted.pdf