### PR TITLE
refactor(deployments): use mock service for donut chart data

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -1,7 +1,7 @@
 <div class="card-pf" (click)="collapsed = !collapsed">
   <div class="card-pf-body">
     <span class="pficon pficon-ok" tooltip="Everything looks okay" placement="top"></span>
-    <deployments-donut [applicationId]="applicationId" [mini]="true" ></deployments-donut>
+    <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="true" ></deployments-donut>
     <span id="versionLabel">{{ version | async }}</span>
     <div class="pull-right dropdown-kebab-pf dropdown" dropdown (click)="$event.stopPropagation()">
       <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true"
@@ -26,7 +26,7 @@
       </ul>
     </div>
     <div [collapse]="collapsed">
-      <deployments-donut [applicationId]="applicationId" [mini]="false"></deployments-donut>
+      <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="false"></deployments-donut>
       <pfng-chart-sparkline [config]="config" [chartData]="data"></pfng-chart-sparkline>
     </div>
   </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -4,7 +4,11 @@ import {
 } from '@angular/core/testing';
 
 import { By } from '@angular/platform-browser';
-import { Component, DebugElement, Input } from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Input
+} from '@angular/core';
 
 import { Observable } from 'rxjs';
 
@@ -24,8 +28,10 @@ import 'patternfly/dist/js/patternfly-settings.js';
   template: ''
 })
 class FakeDeploymentsDonutComponent {
-  @Input() applicationId: string;
   @Input() mini: boolean;
+  @Input() spaceId: string;
+  @Input() applicationId: string;
+  @Input() environmentId: string;
 }
 
 describe('DeploymentCardComponent', () => {
@@ -38,7 +44,7 @@ describe('DeploymentCardComponent', () => {
     mockSvc = {
       getApplications: () => { throw 'Not Implemented'; },
       getEnvironments: () => { throw 'Not Implemented'; },
-      getPodCount: () => Observable.of(2),
+      getPods: (spaceId: string, applicationId: string, environmentId: string) => { throw 'NotImplemented'; },
       getVersion: () => Observable.of('1.2.3'),
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
       getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat)
@@ -46,7 +52,7 @@ describe('DeploymentCardComponent', () => {
 
     spyOn(mockSvc, 'getApplications').and.callThrough();
     spyOn(mockSvc, 'getEnvironments').and.callThrough();
-    spyOn(mockSvc, 'getPodCount').and.callThrough();
+    spyOn(mockSvc, 'getPods').and.callThrough();
     spyOn(mockSvc, 'getCpuStat').and.callThrough();
     spyOn(mockSvc, 'getMemoryStat').and.callThrough();
     spyOn(mockSvc, 'getVersion').and.callThrough();

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -21,6 +21,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
   static chartIdNum = 1;
 
+  @Input() spaceId: string;
   @Input() applicationId: string;
   @Input() environment: Environment;
 
@@ -37,7 +38,6 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   };
 
   collapsed: boolean = true;
-  podCount: Observable<number>;
   version: Observable<string>;
 
   constructor(
@@ -52,9 +52,6 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
 
     this.config.chartHeight = 60;
-
-    this.podCount =
-      this.deploymentsService.getPodCount(this.applicationId, this.environment.environmentId);
 
     this.version =
       this.deploymentsService.getVersion(this.applicationId, this.environment.environmentId);

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
@@ -1,8 +1,7 @@
 <div #chartElement id="{{chartId}}" class="deployments-donut-chart" [ngClass]="{'mini': mini}"></div>
 <div *ngIf="mini" class="deployments-donut-chart-mini-text">
   <span *ngIf="!idled; else elseIdle">
-    {{total}}
-    <span>{{(total === 1) ? 'pod' : 'pods'}}</span>
+    {{ pods.total }} {{ (pods.total === 1) ? 'pod' : 'pods' }}
   </span>
   <ng-template #elseIdle>
     <span>Idle</span>
@@ -10,12 +9,12 @@
 </div>
 
 <div class="sr-only">
-  <div *ngIf="pods?.length === 0; else elsePods">No pods.</div>
+  <div *ngIf="pods?.total === 0; else elsePods">No pods.</div>
   <ng-template #elsePods>
     <div>
       Pod status:
-      <li *ngFor="let column of podStatusData">
-        <span>{{ column[1] ? column[1] + ' ' + column[0] : '0 ' +  column[0] }}</span>
+      <li *ngFor="let column of pods.pods">
+        <span>{{ column[1] ? column[1] + ' ' + column[0] : '0 ' + column[0] }}</span>
       </li>
     </div>
   </ng-template>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
@@ -1,103 +1,86 @@
+import { Component, DebugElement, ViewChild } from '@angular/core';
 import {
   ComponentFixture,
   TestBed
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
 import { isEqual } from 'lodash';
+import { Observable } from 'rxjs';
 
 import { DeploymentsDonutChartComponent } from './deployments-donut-chart.component';
 
 describe('DeploymentsDonutChartComponent', () => {
-  let component: DeploymentsDonutChartComponent;
-  let fixture: ComponentFixture<DeploymentsDonutChartComponent>;
+  @Component({
+    template: `
+    <deployments-donut-chart [mini]="mini" [pods]="pods | async" [desiredReplicas]="desiredReplicas" [idled]="isIdled">
+    </deployments-donut-chart>
+    `
+  })
+  class TestHostComponent {
+    mini = false;
+    pods = Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 });
+    desiredReplicas = 1;
+    isIdled = false;
+
+    @ViewChild(DeploymentsDonutChartComponent)
+    childComponent: DeploymentsDonutChartComponent;
+  }
+
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  let de: DebugElement;
+  let el: HTMLElement;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DeploymentsDonutChartComponent]
+      declarations: [DeploymentsDonutChartComponent, TestHostComponent]
     });
 
-    fixture = TestBed.createComponent(DeploymentsDonutChartComponent);
-    component = fixture.componentInstance;
-
-    component.pods = [
-      {
-        status: {
-          phase: 'Running'
-        }
-      }, {
-        status: {
-          phase: 'Terminating'
-        }
-      }
-    ];
-    component.mini = false;
-    component.desiredReplicas = 1;
-    component.idled = false;
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
 
     fixture.detectChanges();
-    component.debounceUpdate.flush();
   });
 
   it('should set unique chartId', () => {
-    expect(component.chartId).toMatch('deployments-donut-chart.*');
+    expect(hostComponent.childComponent.chartId).toMatch('deployments-donut-chart.*');
   });
 
-  it('should set podStatusData', () => {
-    let expectedPodStatusData = [
-      ['Running', 1],
-      ['Not Ready', 0],
-      ['Warning', 0],
-      ['Error', 0],
-      ['Pulling', 0],
-      ['Pending', 0],
-      ['Succeeded', 0],
-      ['Terminating', 1],
-      ['Unknown', 0]
-    ];
-    component.debounceUpdate.flush();
-    expect(component.podStatusData).toEqual(expectedPodStatusData);
+  it('should not show mini text', () => {
+    expect(hostComponent.childComponent.mini).toBe(false);
+    de = fixture.debugElement.query(By.css('deployments-donut-chart-mini-text'));
+    expect(de).toBeFalsy();
   });
 
-  it('should update podStatusData', () => {
-    let expectedPodStatusData = [
-      ['Running', 1],
-      ['Not Ready', 0],
-      ['Warning', 0],
-      ['Error', 0],
-      ['Pulling', 0],
-      ['Pending', 0],
-      ['Succeeded', 0],
-      ['Terminating', 1],
-      ['Unknown', 0]
-    ];
-    component.debounceUpdate.flush();
-    expect(component.podStatusData).toEqual(expectedPodStatusData);
+  describe('Mini chart', () => {
+    beforeEach(() => {
+      hostComponent.mini = true;
+      fixture.detectChanges();
+    });
 
-    expectedPodStatusData = [
-      ['Running', 2],
-      ['Not Ready', 0],
-      ['Warning', 0],
-      ['Error', 0],
-      ['Pulling', 0],
-      ['Pending', 0],
-      ['Succeeded', 0],
-      ['Terminating', 0],
-      ['Unknown', 0]
-    ];
+    it('should show mini text', () => {
+      expect(hostComponent.childComponent.mini).toBe(true);
+      de = fixture.debugElement.query(By.css('.deployments-donut-chart-mini-text'));
+      expect(de).toBeTruthy();
+      el = de.nativeElement;
+      expect(el.innerText).toEqual('2 pods');
+    });
 
-    component.pods = [{
-      status: {
-        phase: 'Running'
-      }
-    }, {
-      status: {
-        phase: 'Running'
-      }
-    }];
+    describe('Mini Idle chart', () => {
+      beforeEach(() => {
+        hostComponent.isIdled = true;
+        fixture.detectChanges();
+      });
 
-    fixture.detectChanges();
-    component.debounceUpdate.flush();
-
-    expect(component.podStatusData).toEqual(expectedPodStatusData);
+      it('should show idled text', () => {
+        expect(hostComponent.childComponent.idled).toBe(true);
+        de = fixture.debugElement.query(By.css('.deployments-donut-chart-mini-text'));
+        expect(de).toBeTruthy();
+        el = de.nativeElement;
+        expect(el.innerText).toEqual('Idle');
+      });
+    });
   });
 });

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -11,6 +11,8 @@ import {
 import { debounce, get, isEqual, reject, size, uniqueId } from 'lodash';
 import { Observable } from 'rxjs';
 
+import { Pods } from '../../models/pods';
+
 import * as c3 from 'c3';
 import * as d3 from 'd3';
 
@@ -21,7 +23,7 @@ import * as d3 from 'd3';
 })
 export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges, OnDestroy, OnInit {
 
-  @Input() pods: any;
+  @Input() pods: Pods;
   @Input() mini: boolean;
   @Input() desiredReplicas: number;
   @Input() idled: boolean;

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -1,4 +1,4 @@
-<deployments-donut-chart [mini]="mini" [pods]="pods" [desiredReplicas]="desiredReplicas" [idled]="isIdled">
+<deployments-donut-chart [mini]="mini" [pods]="pods | async" [desiredReplicas]="desiredReplicas" [idled]="isIdled">
 </deployments-donut-chart>
 
 <span column class="deployment-donut-scale-controls fade-inline" *ngIf="!isIdled && !mini">

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -3,11 +3,16 @@ import {
   TestBed
 } from '@angular/core/testing';
 
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  Input
+} from '@angular/core';
 
 import { isEqual } from 'lodash';
+import { Observable } from 'rxjs';
 
 import { DeploymentsDonutComponent } from './deployments-donut.component';
+import { DeploymentsService } from '../services/deployments.service';
 
 @Component({
   selector: 'deployments-donut-chart',
@@ -23,10 +28,24 @@ class FakeDeploymentsDonutChartComponent {
 describe('DeploymentsDonutComponent', () => {
   let component: DeploymentsDonutComponent;
   let fixture: ComponentFixture<DeploymentsDonutComponent>;
+  let mockSvc: DeploymentsService;
 
   beforeEach(() => {
+    mockSvc = {
+      getApplications: () => { throw 'NotImplemented'; },
+      getEnvironments: () => { throw 'NotImplemented'; },
+      getPods: (spaceId: string, appId: string, envId: string) => Observable.of({
+        pods: [['Running', 1], ['Terminating', 1]],
+        total: 2
+      }),
+      getVersion: () => { throw 'NotImplemented'; },
+      getCpuStat: (spaceId: string, envId: string) => { throw 'NotImplemented'; },
+      getMemoryStat: (spaceId: string, envId: string) => { throw 'NotImplemented'; }
+    };
+
     TestBed.configureTestingModule({
-      declarations: [DeploymentsDonutComponent, FakeDeploymentsDonutChartComponent]
+      declarations: [DeploymentsDonutComponent, FakeDeploymentsDonutChartComponent],
+      providers: [{ provide: DeploymentsService, useValue: mockSvc }]
     });
 
     fixture = TestBed.createComponent(DeploymentsDonutComponent);
@@ -73,18 +92,13 @@ describe('DeploymentsDonutComponent', () => {
     expect(component.desiredReplicas).toBe(0);
   });
 
-  it('should acquire pods data', () => {
-    let expectedPods = [
-      {
-        status: {
-          phase: 'Running'
-        }
-      }, {
-        status: {
-          phase: 'Terminating'
-        }
-      }
-    ];
-    expect(component.pods).toEqual(expectedPods);
+  it('should acquire pods data', (done: DoneFn) => {
+    component.pods.subscribe(pods => {
+      expect(pods).toEqual({
+        pods: [['Running', 1], ['Terminating', 1]],
+        total: 2
+      });
+      done();
+    });
   });
 });

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -13,6 +13,7 @@ import { Observable } from 'rxjs';
 
 import { DeploymentsDonutComponent } from './deployments-donut.component';
 import { DeploymentsService } from '../services/deployments.service';
+import { Pods } from '../models/pods';
 
 @Component({
   selector: 'deployments-donut-chart',
@@ -37,7 +38,7 @@ describe('DeploymentsDonutComponent', () => {
       getPods: (spaceId: string, appId: string, envId: string) => Observable.of({
         pods: [['Running', 1], ['Terminating', 1]],
         total: 2
-      }),
+      } as Pods),
       getVersion: () => { throw 'NotImplemented'; },
       getCpuStat: (spaceId: string, envId: string) => { throw 'NotImplemented'; },
       getMemoryStat: (spaceId: string, envId: string) => { throw 'NotImplemented'; }

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { debounce } from 'lodash';
+import { Observable } from 'rxjs';
+
+import { DeploymentsService } from '../services/deployments.service';
 
 @Component({
   selector: 'deployments-donut',
@@ -9,20 +12,25 @@ import { debounce } from 'lodash';
 export class DeploymentsDonutComponent implements OnInit {
 
   @Input() mini: boolean;
+  @Input() spaceId: string;
   @Input() applicationId: string;
+  @Input() environmentId: string;
 
   isIdled = false;
   scalable = true;
-  pods: any;
+  pods: Observable<any>;
   desiredReplicas: number;
+
 
   private scaleRequestPending = false;
   private debounceScale = debounce(this.scale, 650);
 
-  constructor() { }
+  constructor(
+    private deploymentsService: DeploymentsService
+  ) { }
 
   ngOnInit(): void {
-    this.pods = this.getPods();
+    this.pods = this.deploymentsService.getPods(this.spaceId, this.applicationId, this.environmentId);
     this.desiredReplicas = this.getDesiredReplicas();
   }
 
@@ -66,17 +74,4 @@ export class DeploymentsDonutComponent implements OnInit {
   private scale(): void {
     // TODO: send service request to scale
   }
-
-  private getPods(): any {
-    return [{
-      status: {
-        phase: 'Running'
-      }
-    }, {
-      status: {
-        phase: 'Terminating'
-      }
-    }];
-  }
-
 }

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -3,6 +3,7 @@ import { debounce } from 'lodash';
 import { Observable } from 'rxjs';
 
 import { DeploymentsService } from '../services/deployments.service';
+import { Pods } from '../models/pods';
 
 @Component({
   selector: 'deployments-donut',
@@ -18,7 +19,7 @@ export class DeploymentsDonutComponent implements OnInit {
 
   isIdled = false;
   scalable = true;
-  pods: Observable<any>;
+  pods: Observable<Pods>;
   desiredReplicas: number;
 
 

--- a/src/app/space/create/deployments/deployments.component.spec.ts
+++ b/src/app/space/create/deployments/deployments.component.spec.ts
@@ -27,6 +27,7 @@ import { Spaces } from 'ngx-fabric8-wit';
   selector: 'deployments-resource-usage',
   template: ''
 })
+
 class FakeDeploymentsResourceUsageComponent {
   @Input() environments: Observable<Environment[]>;
 }
@@ -56,7 +57,7 @@ describe('DeploymentsComponent', () => {
     mockSvc = {
       getApplications: () => mockApplications,
       getEnvironments: () => mockEnvironments,
-      getPodCount: () => { throw 'Not Implemented'; },
+      getPods: (spaceId: string, appId: string, envId: string) => { throw 'NotImplemented'; },
       getVersion: () => { throw 'NotImplemented'; },
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
       getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat)
@@ -68,7 +69,7 @@ describe('DeploymentsComponent', () => {
 
     spyOn(mockSvc, 'getApplications').and.callThrough();
     spyOn(mockSvc, 'getEnvironments').and.callThrough();
-    spyOn(mockSvc, 'getPodCount').and.callThrough();
+    spyOn(mockSvc, 'getPods').and.callThrough();
     spyOn(mockSvc, 'getVersion').and.callThrough();
     spyOn(mockSvc, 'getCpuStat').and.callThrough();
     spyOn(mockSvc, 'getMemoryStat').and.callThrough();

--- a/src/app/space/create/deployments/models/pods.ts
+++ b/src/app/space/create/deployments/models/pods.ts
@@ -1,0 +1,8 @@
+
+
+type PodsData = [string, number];
+
+export declare interface Pods {
+  readonly pods: PodsData[];
+  readonly total: number;
+}

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -45,7 +45,7 @@ describe('ResourceCardComponent', () => {
         { environmentId: 'a1', name: 'stage' },
         { environmentId: 'b2', name: 'prod' }
       ]),
-      getPodCount: () => { throw 'Not Implemented'; },
+      getPods: () => { throw 'Not Implemented'; },
       getVersion: () => { throw 'NotImplemented'; },
       getCpuStat: (spaceId: string, envId: string) => cpuStatMock,
       getMemoryStat: (spaceId: string, envId: string) => memoryStatMock
@@ -53,7 +53,7 @@ describe('ResourceCardComponent', () => {
 
     spyOn(mockSvc, 'getApplications').and.callThrough();
     spyOn(mockSvc, 'getEnvironments').and.callThrough();
-    spyOn(mockSvc, 'getPodCount').and.callThrough();
+    spyOn(mockSvc, 'getPods').and.callThrough();
     spyOn(mockSvc, 'getVersion').and.callThrough();
     spyOn(mockSvc, 'getCpuStat').and.callThrough();
     spyOn(mockSvc, 'getMemoryStat').and.callThrough();

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -39,18 +39,6 @@ describe('DeploymentsService', () => {
     }));
   });
 
-  describe('#getPodCount', () => {
-    it('should return a number between 1 and 6', fakeAsync(() => {
-      svc.getPodCount('foo', 'bar')
-        .subscribe(val => {
-          expect(val).toBeGreaterThanOrEqual(1);
-          expect(val).toBeLessThanOrEqual(6);
-        });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
-  });
-
   describe('#getVersion', () => {
     it('should return 1.0.2', fakeAsync(() => {
       svc.getVersion('foo', 'bar').subscribe(val => {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { Environment } from '../models/environment';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
+import { Pods } from '../models/pods';
 
 @Injectable()
 export class DeploymentsService {
@@ -26,8 +27,8 @@ export class DeploymentsService {
     return Observable.of('1.0.2');
   }
 
-  getPods(spaceId: string, applicationId: string, environmentId: string): Observable<any> {
-    return Observable.of({ pods: [['Running', 2], ['Terminating', 1]], total: 3 });
+  getPods(spaceId: string, applicationId: string, environmentId: string): Observable<Pods> {
+    return Observable.of({ pods: [['Running', 2], ['Terminating', 1]], total: 3 } as Pods);
   }
 
   getCpuStat(spaceId: string, environmentId: string): Observable<CpuStat> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -22,15 +22,12 @@ export class DeploymentsService {
     ]);
   }
 
-  getPodCount(spaceId: string, environmentId: string): Observable<number> {
-    return Observable
-      .interval(DeploymentsService.POLL_RATE_MS)
-      .distinctUntilChanged()
-      .map(() => Math.floor(Math.random() * 5) + 1);
-  }
-
   getVersion(spaceId: string, environmentId: string): Observable<string> {
     return Observable.of('1.0.2');
+  }
+
+  getPods(spaceId: string, applicationId: string, environmentId: string): Observable<any> {
+    return Observable.of({ pods: [['Running', 2], ['Terminating', 1]], total: 3 });
   }
 
   getCpuStat(spaceId: string, environmentId: string): Observable<CpuStat> {


### PR DESCRIPTION
This updates the donut chart work to use the deployment service providing mock data. The chart code is also updated to better with with Angular's change detection lifecycle. Notable, the chart is initialized in AfterViewInit, and DoCheck is dropped in favor of only using OnChanges. Tests have been updated to fit as well.

Addresses: https://github.com/openshiftio/openshift.io/issues/1653