### PR TITLE
Apps dropdown menu items should perform actions

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card-container.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.html
@@ -5,6 +5,11 @@
         {{application}}
       </h4>
     </div>
-    <deployment-card class="col-xs-6 col-sm-4 col-md-3" [applicationId]="application" [environment]="environment" *ngFor="let environment of environments | async"></deployment-card>
+    <deployment-card class="col-xs-6 col-sm-4 col-md-3"
+      *ngFor="let environment of environments | async"
+      [spaceId]="spaceId"
+      [applicationId]="application"
+      [environment]="environment"
+    ></deployment-card>
   </div>
 </div>

--- a/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
@@ -22,6 +22,7 @@ import { Environment } from '../models/environment';
   template: ''
 })
 class FakeDeploymentCardComponent {
+  @Input() spaceId: string;
   @Input() applicationId: string;
   @Input() environment: Environment;
 }
@@ -32,8 +33,8 @@ describe('DeploymentCardContainer', () => {
   let fixture: ComponentFixture<DeploymentCardContainerComponent>;
   let mockEnvironments: Observable<Environment[]>;
   let mockEnvironmentData = [
-    { environmentId: "id1", name: "envId1"},
-    { environmentId: "id2", name: "envId2"}
+    { environmentId: 'id1', name: 'envId1'},
+    { environmentId: 'id2', name: 'envId2'}
   ];
 
   beforeEach(() => {

--- a/src/app/space/create/deployments/apps/deployment-card-container.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.ts
@@ -13,6 +13,7 @@ import { Environment } from '../models/environment';
 })
 export class DeploymentCardContainerComponent {
 
+  @Input() spaceId: string;
   @Input() environments: Observable<Environment[]>;
   @Input() application: string;
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -10,18 +10,20 @@
       </button>
       <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="kebab" role="menu" *dropdownMenu>
         <li>
-          <a>View logs</a>
+          <a [attr.href]="logsUrl | async" target="_blank">View logs</a>
         </li>
         <li>
-          <a>View OpenShift Console</a>
+          <a [attr.href]="consoleUrl | async" target="_blank">View OpenShift Console</a>
         </li>
+        <ng-container *ngIf="appUrl | async; let appUrl">
+          <li role="separator" class="divider"></li>
+          <li>
+            <a [attr.href]="appUrl" target="_blank">Open Application</a>
+          </li>
+        </ng-container>
         <li role="separator" class="divider"></li>
         <li>
-          <a>Open Application</a>
-        </li>
-        <li role="separator" class="divider"></li>
-        <li>
-          <a>Delete</a>
+          <a (click)="delete()">Delete</a>
         </li>
       </ul>
     </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -10,20 +10,20 @@
       </button>
       <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="kebab" role="menu" *dropdownMenu>
         <li>
-          <a [attr.href]="logsUrl | async" target="_blank">View logs</a>
+          <a class="menu-item" [attr.href]="logsUrl | async" target="_blank">View logs</a>
         </li>
         <li>
-          <a [attr.href]="consoleUrl | async" target="_blank">View OpenShift Console</a>
+          <a class="menu-item" [attr.href]="consoleUrl | async" target="_blank">View OpenShift Console</a>
         </li>
         <ng-container *ngIf="appUrl | async; let appUrl">
           <li role="separator" class="divider"></li>
           <li>
-            <a [attr.href]="appUrl" target="_blank">Open Application</a>
+            <a class="menu-item" [attr.href]="appUrl" target="_blank">Open Application</a>
           </li>
         </ng-container>
         <li role="separator" class="divider"></li>
         <li>
-          <a (click)="delete()">Delete</a>
+          <a class="menu-item" (click)="delete()">Delete</a>
         </li>
       </ul>
     </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.less
+++ b/src/app/space/create/deployments/apps/deployment-card.component.less
@@ -1,0 +1,5 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+.menu-item {
+  cursor: pointer;
+}

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -1,4 +1,5 @@
 import {
+  async,
   ComponentFixture,
   TestBed
 } from '@angular/core/testing';
@@ -8,6 +9,11 @@ import { Component, DebugElement, Input } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
+import {
+  BsDropdownConfig,
+  BsDropdownModule,
+  BsDropdownToggleDirective
+} from 'ngx-bootstrap/dropdown';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 
 import { DeploymentCardComponent } from './deployment-card.component';
@@ -60,14 +66,15 @@ describe('DeploymentCardComponent', () => {
     spyOn(mockSvc, 'deleteApplication').and.callThrough();
 
     TestBed.configureTestingModule({
-      imports: [CollapseModule.forRoot(), ChartModule],
-      declarations: [DeploymentCardComponent, FakeDeploymentsDonutComponent],
-      providers: [{ provide: DeploymentsService, useValue: mockSvc }]
+      imports: [ BsDropdownModule.forRoot(), CollapseModule.forRoot(), ChartModule ],
+      declarations: [ DeploymentCardComponent, FakeDeploymentsDonutComponent ],
+      providers: [ BsDropdownConfig, { provide: DeploymentsService, useValue: mockSvc } ]
     });
 
     fixture = TestBed.createComponent(DeploymentCardComponent);
     component = fixture.componentInstance;
 
+    component.spaceId = 'mockSpaceId';
     component.applicationId = 'mockAppId';
     component.environment = { environmentId: 'mockEnvironmentId', name: 'mockEnvironment' };
 
@@ -97,6 +104,81 @@ describe('DeploymentCardComponent', () => {
       expect(mockSvc.getVersion).toHaveBeenCalledWith('mockAppId', 'mockEnvironmentId');
       expect(el.textContent).toEqual('1.2.3');
     });
+  });
+
+  describe('dropdown menus', () => {
+    let menuItems: DebugElement[];
+
+    function getItemByLabel(label: string): DebugElement {
+      return menuItems
+        .filter(item => item.nativeElement.textContent.includes(label))[0];
+    }
+
+    beforeEach(async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        let de = fixture.debugElement.query(By.directive(BsDropdownToggleDirective));
+        de.triggerEventHandler('click', null);
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          let menu = fixture.debugElement.query(By.css('.dropdown-menu'));
+          menuItems = menu.queryAll(By.css('li'));
+        });
+      });
+    }));
+
+    it('should have menu items', () => {
+      expect(menuItems.length).toBeGreaterThan(0);
+    });
+
+    it('should link to fake logsUrl on \'View logs\'', () => {
+      let item = getItemByLabel('View logs');
+      expect(item).toBeTruthy();
+      let link = item.query(By.css('a'));
+      expect(link.attributes['target']).toEqual('_blank');
+      expect(link.attributes['href']).toEqual('mockLogsUrl');
+    });
+
+    it('should link to fake consoleUrl on \'View OpenShift Console\'', () => {
+      let item = getItemByLabel('View OpenShift Console');
+      expect(item).toBeTruthy();
+      let link = item.query(By.css('a'));
+      expect(link.attributes['target']).toEqual('_blank');
+      expect(link.attributes['href']).toEqual('mockConsoleUrl');
+    });
+
+    it('should link to fake appUrl on \'Open Application\'', () => {
+      let item = getItemByLabel('Open Application');
+      expect(item).toBeTruthy();
+      let link = item.query(By.css('a'));
+      expect(link.attributes['target']).toEqual('_blank');
+      expect(link.attributes['href']).toEqual('mockAppUrl');
+    });
+
+    it('should not display appUrl if none available', () => {
+      component.appUrl = Observable.of('');
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let menu = fixture.debugElement.query(By.css('.dropdown-menu'));
+        menuItems = menu.queryAll(By.css('li'));
+        let item = getItemByLabel('Open Application');
+        expect(item).toBeFalsy();
+      });
+    });
+
+    it('should invoke service \'delete\' function on Delete item click', async(() => {
+      let item = getItemByLabel('Delete');
+      expect(item).toBeTruthy();
+      expect(mockSvc.deleteApplication).not.toHaveBeenCalled();
+      item.query(By.css('a')).triggerEventHandler('click', null);
+
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(mockSvc.deleteApplication).toHaveBeenCalled();
+      });
+    }));
   });
 
 });

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -41,7 +41,11 @@ describe('DeploymentCardComponent', () => {
       getPodCount: () => Observable.of(2),
       getVersion: () => Observable.of('1.2.3'),
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
-      getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat)
+      getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat),
+      getAppUrl: () => Observable.of('mockAppUrl'),
+      getConsoleUrl: () => Observable.of('mockConsoleUrl'),
+      getLogsUrl: () => Observable.of('mockLogsUrl'),
+      deleteApplication: () => Observable.of('mockDeletedMessage')
     };
 
     spyOn(mockSvc, 'getApplications').and.callThrough();
@@ -50,6 +54,10 @@ describe('DeploymentCardComponent', () => {
     spyOn(mockSvc, 'getCpuStat').and.callThrough();
     spyOn(mockSvc, 'getMemoryStat').and.callThrough();
     spyOn(mockSvc, 'getVersion').and.callThrough();
+    spyOn(mockSvc, 'getAppUrl').and.callThrough();
+    spyOn(mockSvc, 'getConsoleUrl').and.callThrough();
+    spyOn(mockSvc, 'getLogsUrl').and.callThrough();
+    spyOn(mockSvc, 'deleteApplication').and.callThrough();
 
     TestBed.configureTestingModule({
       imports: [CollapseModule.forRoot(), ChartModule],

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -18,7 +18,8 @@ import 'patternfly/dist/js/patternfly-settings.js';
 
 @Component({
   selector: 'deployment-card',
-  templateUrl: 'deployment-card.component.html'
+  templateUrl: 'deployment-card.component.html',
+  styleUrls: ['./deployment-card.component.less']
 })
 export class DeploymentCardComponent implements OnDestroy, OnInit {
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -5,7 +5,10 @@ import {
   OnInit
 } from '@angular/core';
 
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  Subscription
+} from 'rxjs';
 
 import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
@@ -21,6 +24,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
   static chartIdNum = 1;
 
+  @Input() spaceId: string;
   @Input() applicationId: string;
   @Input() environment: Environment;
 
@@ -40,6 +44,12 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   podCount: Observable<number>;
   version: Observable<string>;
 
+  logsUrl: Observable<string>;
+  consoleUrl: Observable<string>;
+  appUrl: Observable<string>;
+
+  subscriptions: Array<Subscription> = [];
+
   constructor(
     private deploymentsService: DeploymentsService
   ) { }
@@ -47,10 +57,12 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   getChartIdNum(): number {
     return DeploymentCardComponent.chartIdNum;
   }
-  ngOnDestroy(): void { }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
 
   ngOnInit(): void {
-
     this.config.chartHeight = 60;
 
     this.podCount =
@@ -58,6 +70,22 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
     this.version =
       this.deploymentsService.getVersion(this.applicationId, this.environment.environmentId);
+
+    this.logsUrl =
+      this.deploymentsService.getLogsUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+
+    this.consoleUrl =
+      this.deploymentsService.getConsoleUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+
+    this.appUrl =
+      this.deploymentsService.getAppUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+  }
+
+  delete(): void {
+    this.subscriptions.push(
+      this.deploymentsService.deleteApplication(this.spaceId, this.applicationId, this.environment.environmentId)
+        .subscribe(alert)
+    );
   }
 
 }

--- a/src/app/space/create/deployments/apps/deployments-apps.component.html
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.html
@@ -25,5 +25,5 @@
 </div>
 
 <div *ngFor="let application of applications | async">
-  <deployment-card-container [application]="application" [environments]="environments"></deployment-card-container>
+  <deployment-card-container [spaceId]="spaceId | async" [application]="application" [environments]="environments"></deployment-card-container>
 </div>

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -24,6 +24,7 @@ import { Spaces } from 'ngx-fabric8-wit';
   template: ''
 })
 class FakeDeploymentCardContainerComponent {
+  @Input() spaceId: string;
   @Input() environments: Observable<Environment[]>;
   @Input() application: string;
 }
@@ -35,8 +36,8 @@ describe('DeploymentsAppsComponent', () => {
   let mockApplicationData = ['first', 'second'];
   let mockApplications = Observable.of(mockApplicationData);
   let mockEnvironments = Observable.of([
-    { environmentId: "id1", name: "envId1"},
-    { environmentId: "id2", name: "envId2"}
+    { environmentId: 'id1', name: 'envId1'},
+    { environmentId: 'id2', name: 'envId2'}
   ]);
 
   beforeEach(() => {

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -13,6 +13,7 @@ import { Observable } from 'rxjs';
 })
 export class DeploymentsAppsComponent {
 
+  @Input() spaceId: Observable<string>;
   @Input() environments: Observable<Environment[]>;
   @Input() applications: Observable<string[]>;
 

--- a/src/app/space/create/deployments/deployments.component.html
+++ b/src/app/space/create/deployments/deployments.component.html
@@ -1,4 +1,4 @@
 <div id="apps">
-  <deployments-apps [environments]="environments" [applications]="applications"></deployments-apps>
+  <deployments-apps [spaceId]="spaceId" [environments]="environments" [applications]="applications"></deployments-apps>
   <deployments-resource-usage [environments]="environments"></deployments-resource-usage>
 </div>

--- a/src/app/space/create/deployments/deployments.component.spec.ts
+++ b/src/app/space/create/deployments/deployments.component.spec.ts
@@ -36,6 +36,7 @@ class FakeDeploymentsResourceUsageComponent {
   template: ''
 })
 class FakeDeploymentAppsComponent {
+  @Input() spaceId: Observable<string>;
   @Input() environments: Observable<Environment[]>;
   @Input() applications: Observable<string[]>;
 }
@@ -59,7 +60,11 @@ describe('DeploymentsComponent', () => {
       getPodCount: () => { throw 'Not Implemented'; },
       getVersion: () => { throw 'NotImplemented'; },
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
-      getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat)
+      getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat),
+      getLogsUrl: () => { throw 'Not Implemented'; },
+      getConsoleUrl: () => { throw 'Not Implemented'; },
+      getAppUrl: () => { throw 'Not Implemented'; },
+      deleteApplication: () => { throw 'Not Implemented'; }
     };
 
     spaces = {
@@ -72,6 +77,10 @@ describe('DeploymentsComponent', () => {
     spyOn(mockSvc, 'getVersion').and.callThrough();
     spyOn(mockSvc, 'getCpuStat').and.callThrough();
     spyOn(mockSvc, 'getMemoryStat').and.callThrough();
+    spyOn(mockSvc, 'getLogsUrl').and.callThrough();
+    spyOn(mockSvc, 'getConsoleUrl').and.callThrough();
+    spyOn(mockSvc, 'getAppUrl').and.callThrough();
+    spyOn(mockSvc, 'deleteApplication').and.callThrough();
 
     TestBed.configureTestingModule({
       imports: [ CollapseModule.forRoot() ],

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -48,7 +48,11 @@ describe('ResourceCardComponent', () => {
       getPodCount: () => { throw 'Not Implemented'; },
       getVersion: () => { throw 'NotImplemented'; },
       getCpuStat: (spaceId: string, envId: string) => cpuStatMock,
-      getMemoryStat: (spaceId: string, envId: string) => memoryStatMock
+      getMemoryStat: (spaceId: string, envId: string) => memoryStatMock,
+      getLogsUrl: () => { throw 'Not Implemented'; },
+      getConsoleUrl: () => { throw 'Not Implemented'; },
+      getAppUrl: () => { throw 'Not Implemented'; },
+      deleteApplication: () => { throw 'Not Implemented'; }
     };
 
     spyOn(mockSvc, 'getApplications').and.callThrough();
@@ -57,6 +61,10 @@ describe('ResourceCardComponent', () => {
     spyOn(mockSvc, 'getVersion').and.callThrough();
     spyOn(mockSvc, 'getCpuStat').and.callThrough();
     spyOn(mockSvc, 'getMemoryStat').and.callThrough();
+    spyOn(mockSvc, 'getLogsUrl').and.callThrough();
+    spyOn(mockSvc, 'getConsoleUrl').and.callThrough();
+    spyOn(mockSvc, 'getAppUrl').and.callThrough();
+    spyOn(mockSvc, 'deleteApplication').and.callThrough();
 
     TestBed.configureTestingModule({
       declarations: [

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -48,4 +48,25 @@ export class DeploymentsService {
       .map(() => ({ used: Math.floor(Math.random() * 156) + 100, total: 256 } as MemoryStat))
       .startWith({ used: 200, total: 256 } as MemoryStat);
   }
+
+  getLogsUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+    return Observable.of('http://example.com/');
+  }
+
+  getConsoleUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+    return Observable.of('http://example.com/');
+  }
+
+  getAppUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+    if (Math.random() > 0.5) {
+      return Observable.of('http://example.com/');
+    } else {
+      return Observable.of('');
+    }
+  }
+
+  deleteApplication(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+    return Observable.of(`Deleted ${applicationId} in ${spaceId} (${environmentId})`);
+  }
+
 }


### PR DESCRIPTION
https://github.com/openshiftio/openshift.io/issues/1578

This PR adds stub URLs and actions to the menu items in the deployments cards. For the "Open Application", "View Logs" and "View OpenShift Console" items, the mock service simply returns example.com URLs for now. When the backend is ready this can now be switched, transparently to the card component. The "Delete" handler in the service simply returns a fake message immediately which is currently displayed as an alert. We'll need some guidance for a follow-up PR to potentially replace this alert with some other confirmation, or include some progress/working indicator, etc.

Additionally, the service supplies an example.com URL for the "Open Application" item 50% of the time, and the other 50% it supplies an empty string. This is to simulate the case where a deployment does not actually have a URL to visit. In this situation the menu item and separator are not displayed.