### PR TITLE
fix(deployments): tweak deployment card styling to match design mock

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -1,31 +1,41 @@
 <div class="card-pf" (click)="collapsed = !collapsed">
   <div class="card-pf-body">
-    <span class="pficon pficon-ok" tooltip="Everything looks okay" placement="top"></span>
-    <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="true" ></deployments-donut>
-    <span id="versionLabel">{{ version | async }}</span>
-    <div class="pull-right dropdown-kebab-pf dropdown" dropdown (click)="$event.stopPropagation()">
-      <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true"
-        aria-expanded="true" data-toggle="dropdown" dropdownToggle>
-        <span class="fa fa-ellipsis-v"></span>
-      </button>
-      <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="kebab" role="menu" *dropdownMenu>
-        <li>
-          <a class="menu-item" [attr.href]="logsUrl | async" target="_blank">View logs</a>
-        </li>
-        <li>
-          <a class="menu-item" [attr.href]="consoleUrl | async" target="_blank">View OpenShift Console</a>
-        </li>
-        <ng-container *ngIf="appUrl | async; let appUrl">
-          <li role="separator" class="divider"></li>
-          <li>
-            <a class="menu-item" [attr.href]="appUrl" target="_blank">Open Application</a>
-          </li>
-        </ng-container>
-        <li role="separator" class="divider"></li>
-        <li>
-          <a class="menu-item" (click)="delete()">Delete</a>
-        </li>
-      </ul>
+    <div class="row mini-card-content">
+      <div class="col-sm-2">
+        <span class="pficon pficon-ok" tooltip="Everything looks okay" placement="top"></span>
+      </div>
+      <div class="col-sm-7">
+        <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="true"></deployments-donut>
+      </div>
+      <div class="col-sm-1">
+        <span id="versionLabel">{{ version | async }}</span>
+      </div>
+      <div class="col-sm-2">
+        <div class="dropdown-kebab-pf dropdown" (click)="$event.stopPropagation()" dropdown>
+          <button class="btn btn-link pull-right dropdown-toggle" id="kebab" type="button" aria-haspopup="true" aria-expanded="true"
+            data-toggle="dropdown" dropdownToggle>
+            <span class="fa fa-ellipsis-v"></span>
+          </button>
+          <ul class="dropdown-menu-right dropdown-menu deployment-dropdown" aria-labelledby="kebab" role="menu" *dropdownMenu>
+            <li>
+              <a class="menu-item" [attr.href]="logsUrl | async" target="_blank">View logs</a>
+            </li>
+            <li>
+              <a class="menu-item" [attr.href]="consoleUrl | async" target="_blank">View OpenShift Console</a>
+            </li>
+            <ng-container *ngIf="appUrl | async; let appUrl">
+              <li role="separator" class="divider"></li>
+              <li>
+                <a class="menu-item" [attr.href]="appUrl" target="_blank">Open Application</a>
+              </li>
+            </ng-container>
+            <li role="separator" class="divider"></li>
+            <li>
+              <a class="menu-item" (click)="delete()">Delete</a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
     <div [collapse]="collapsed">
       <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="false"></deployments-donut>

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -2,7 +2,7 @@
   <div class="card-pf-body">
     <div class="row mini-card-content">
       <div class="col-sm-2">
-        <span class="pficon pficon-ok" tooltip="Everything looks okay" placement="top"></span>
+        <span class="pficon pficon-ok fa-lg" tooltip="Everything looks okay" placement="top"></span>
       </div>
       <div class="col-sm-7">
         <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="true"></deployments-donut>

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -38,6 +38,7 @@
       </div>
     </div>
     <div [collapse]="collapsed">
+      <hr>
       <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="false"></deployments-donut>
       <div class="deployment-chart">
         <div class="chart-column">

--- a/src/app/space/create/deployments/apps/deployment-card.component.less
+++ b/src/app/space/create/deployments/apps/deployment-card.component.less
@@ -21,3 +21,15 @@
   height: 100%;
   width: 50%;
 }
+
+.mini-card-content {
+  padding-left: .8em;
+  padding-right: .5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.deployment-dropdown {
+  transform: translateY(2em);
+}


### PR DESCRIPTION
Design reference: https://redhat.invisionapp.com/share/YSDL0KRKW#/screens/260764295

![styling-before](https://user-images.githubusercontent.com/3787464/33853922-b8fb05c8-de8d-11e7-99ea-d5a7865ab74b.jpg)

![styling-after](https://user-images.githubusercontent.com/3787464/33853926-be8695ac-de8d-11e7-9336-d7f7a7c26a58.jpg)

This PR just contains some style changes to the deployment cards so that the layout of elements (status icon, mini pod donut, version label, and menu kebab) match the design.