### PR TITLE
context no longer contains 'forge'

### DIFF
--- a/src/app/space/forge-wizard/service/forge-config.ts
+++ b/src/app/space/forge-wizard/service/forge-config.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
+import { Location } from '@angular/common';
 import { Config } from 'ngx-forge';
 import { FABRIC8_FORGE_API_URL } from '../../../../a-runtime-console/shared/fabric8-forge-api';
 
@@ -10,13 +11,8 @@ export class ForgeConfig extends Config {
     let settings = {backend_url: 'TO_BE_DEFINED'};
 
     if (apiUrl) {
-      settings['backend_url'] = apiUrl;
+      settings['backend_url'] = Location.stripTrailingSlash(apiUrl);
     }
-
-    if (settings['backend_url'] && settings['backend_url'][settings['backend_url'].length - 1] !== '/') {
-      settings['backend_url'] += '/';
-    }
-    settings['backend_url'] += 'forge';
 
     this.settings = settings;
   }


### PR DESCRIPTION
now that the 'launcher-backend' is going to be used for backend the context path no longer has 'forge'