### PR TITLE
refactor(deployments): update resource utilization bars to show warning color when usage is high

### DIFF
--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
@@ -4,7 +4,8 @@
   </div>
   <div class="progress">
     <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"
-      [style.background]="color" [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
+      [ngClass]="getUtilizationClasses()"
+      [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
       <span><b id="resourceCardLabel">{{ used }} of {{ total }}</b></span>
     </div>
     <div class="progress-bar progress-bar-remaining" role="progressbar" [attr.aria-valuenow]="unusedPercent" aria-valuemin="0" aria-valuemax="100"

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
@@ -4,7 +4,7 @@
   </div>
   <div class="progress">
     <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"
-      [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
+      [style.background]="color" [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
       <span><b id="resourceCardLabel">{{ used }} of {{ total }}</b></span>
     </div>
     <div class="progress-bar progress-bar-remaining" role="progressbar" [attr.aria-valuenow]="unusedPercent" aria-valuemin="0" aria-valuemax="100"

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.less
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.less
@@ -1,0 +1,10 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+.utilization {
+  &-okay {
+    background: @color-pf-blue-300;
+  }
+  &-warning {
+    background: @color-pf-orange-300;
+  }
+}

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -54,8 +54,14 @@ describe('UtilizationBarComponent', () => {
       expect(el.textContent.trim()).toEqual('1 of 4');
     });
 
-    it('should set color to Okay when under 75% used', () => {
-      expect(component.color).toEqual('#39a5dc');
+    it('should set state to okay when under 75% used', () => {
+      expect(component.currentState).toEqual(['utilization-okay']);
+
+      let de = fixture.debugElement.query(By.css('.utilization-okay'));
+      expect(de).toBeTruthy();
+
+      let de2 = fixture.debugElement.query(By.css('.utilization-warning'));
+      expect(de2).toBeFalsy();
     });
   });
 
@@ -99,8 +105,14 @@ describe('UtilizationBarComponent', () => {
       expect(el.textContent.trim()).toEqual('3 of 4');
     });
 
-    it('should set color to Warning when 75% or higher used', () => {
-      expect(component.color).toEqual('#f39d3c');
+    it('should set state to warning to false when 75% or higher used', () => {
+      expect(component.currentState).toEqual(['utilization-warning']);
+
+      let de = fixture.debugElement.query(By.css('.utilization-okay'));
+      expect(de).toBeFalsy();
+
+      let de2 = fixture.debugElement.query(By.css('.utilization-warning'));
+      expect(de2).toBeTruthy();
     });
   });
 

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -54,6 +54,54 @@ describe('UtilizationBarComponent', () => {
       expect(el.textContent.trim()).toEqual('1 of 4');
     });
 
+    it('should set color to Okay when under 75% used', () => {
+      expect(component.color).toEqual('#39a5dc');
+    });
+  });
+
+  describe('with Warning level Stat', () => {
+
+    let component: UtilizationBarComponent;
+    let fixture: ComponentFixture<UtilizationBarComponent>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [CollapseModule.forRoot()],
+        declarations: [UtilizationBarComponent]
+      });
+
+      fixture = TestBed.createComponent(UtilizationBarComponent);
+      component = fixture.componentInstance;
+
+      component.resourceTitle = 'someTitle';
+      component.resourceUnit = 'someUnit';
+      component.stat = Observable.of({ used: 3, quota: 4 } as Stat);
+
+      fixture.detectChanges();
+    });
+
+    it('should have proper stat fields set', () => {
+      expect(component.used).toEqual(3);
+      expect(component.total).toEqual(4);
+      expect(component.usedPercent).toEqual(75);
+      expect(component.unusedPercent).toEqual(25);
+    });
+
+    it('should have a properly set title', () => {
+      let de = fixture.debugElement.query(By.css('.progress-description'));
+      let el = de.nativeElement;
+      expect(el.textContent.trim()).toEqual('someTitle (someUnit)');
+    });
+
+    it('should have properly set card label information', () => {
+      let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
+      let el = de.nativeElement;
+      expect(el.textContent.trim()).toEqual('3 of 4');
+    });
+
+    it('should set color to Warning when 75% or higher used', () => {
+      expect(component.color).toEqual('#f39d3c');
+    });
   });
 
   describe('with invalid Stat', () => {

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -26,17 +26,31 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   total: number;
   usedPercent: number;
   unusedPercent: number;
+  color: string;
+
+  private colors = {
+    'Okay': '#39a5dc', // Light blue
+    'Warning': '#f39d3c' // Orange
+  };
 
   private statSubscription: Subscription;
 
   constructor() { }
 
   ngOnInit(): void {
+    this.color = this.colors.Okay;
+
     this.statSubscription = this.stat.subscribe(val => {
       this.used = val.used;
       this.total = val.quota;
       this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
       this.unusedPercent = 100 - this.usedPercent;
+
+      if (this.usedPercent < 75) {
+        this.color = this.colors.Okay;
+      } else {
+        this.color = this.colors.Warning;
+      }
     });
   }
 

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -34,6 +34,7 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   };
 
   private statSubscription: Subscription;
+  private readonly warningThreshold = 75;
 
   constructor() { }
 
@@ -46,7 +47,7 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
       this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
       this.unusedPercent = 100 - this.usedPercent;
 
-      if (this.usedPercent < 75) {
+      if (this.usedPercent < this.warningThreshold) {
         this.color = this.colors.Okay;
       } else {
         this.color = this.colors.Warning;

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -14,7 +14,8 @@ import {
 
 @Component({
   selector: 'utilization-bar',
-  templateUrl: 'utilization-bar.component.html'
+  templateUrl: 'utilization-bar.component.html',
+  styleUrls: ['./utilization-bar.component.less']
 })
 export class UtilizationBarComponent implements OnDestroy, OnInit {
 
@@ -26,20 +27,22 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   total: number;
   usedPercent: number;
   unusedPercent: number;
-  color: string;
 
-  private colors = {
-    'Okay': '#39a5dc', // Light blue
-    'Warning': '#f39d3c' // Orange
-  };
+  currentState: any;
 
   private statSubscription: Subscription;
   private readonly warningThreshold = 75;
 
+  private states = {
+    'Okay' : ['utilization-okay'],
+    'Warning' : ['utilization-warning']
+  };
+
+
   constructor() { }
 
   ngOnInit(): void {
-    this.color = this.colors.Okay;
+    this.currentState = this.states.Okay;
 
     this.statSubscription = this.stat.subscribe(val => {
       this.used = val.used;
@@ -48,15 +51,19 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
       this.unusedPercent = 100 - this.usedPercent;
 
       if (this.usedPercent < this.warningThreshold) {
-        this.color = this.colors.Okay;
+        this.currentState = this.states.Okay;
       } else {
-        this.color = this.colors.Warning;
+        this.currentState = this.states.Warning;
       }
     });
   }
 
   ngOnDestroy(): void {
     this.statSubscription.unsubscribe();
+  }
+
+  getUtilizationClasses() {
+    return this.currentState;
   }
 
 }


### PR DESCRIPTION
This addresses https://github.com/openshiftio/openshift.io/issues/1535

The usage bars now change to the warning color when usage is 75% or above.