### PR TITLE
Deployments Http prep

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
@@ -33,8 +33,8 @@ describe('DeploymentCardContainer', () => {
   let fixture: ComponentFixture<DeploymentCardContainerComponent>;
   let mockEnvironments: Observable<Environment[]>;
   let mockEnvironmentData = [
-    { environmentId: 'id1', name: 'envId1'},
-    { environmentId: 'id2', name: 'envId2'}
+    { name: 'envId1'} as Environment,
+    { name: 'envId2'} as Environment
   ];
 
   beforeEach(() => {

--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -5,7 +5,7 @@
         <span class="pficon pficon-ok fa-lg" tooltip="Everything looks okay" placement="top"></span>
       </div>
       <div class="col-sm-7">
-        <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="true"></deployments-donut>
+        <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="true"></deployments-donut>
       </div>
       <div class="col-sm-1">
         <span id="versionLabel">{{ version | async }}</span>
@@ -39,7 +39,7 @@
     </div>
     <div [collapse]="collapsed">
       <hr>
-      <deployments-donut [applicationId]="applicationId" [environmentId]="environment.name" [spaceId]="spaceId" [mini]="false"></deployments-donut>
+      <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="false"></deployments-donut>
       <div class="deployment-chart">
         <div class="chart-column">
           <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -26,6 +26,7 @@ import { DeploymentCardComponent } from './deployment-card.component';
 import { DeploymentsService } from '../services/deployments.service';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
+import { Environment } from '../models/environment';
 
 // Makes patternfly charts available
 import { ChartModule } from 'patternfly-ng';
@@ -39,7 +40,7 @@ class FakeDeploymentsDonutComponent {
   @Input() mini: boolean;
   @Input() spaceId: string;
   @Input() applicationId: string;
-  @Input() environmentId: string;
+  @Input() environment: Environment;
 }
 @Component({
   selector: 'deployment-graph-label',

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -124,7 +124,7 @@ describe('DeploymentCardComponent', () => {
     });
 
     it('should be set from mockSvc.getVersion result', () => {
-      expect(mockSvc.getVersion).toHaveBeenCalledWith('mockAppId', 'mockEnvironmentId');
+      expect(mockSvc.getVersion).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
       expect(el.textContent).toEqual('1.2.3');
     });
   });
@@ -139,7 +139,7 @@ describe('DeploymentCardComponent', () => {
     });
 
     it('should use units from service result', () => {
-      expect(mockSvc.getMemoryStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironmentId');
+      expect(mockSvc.getMemoryStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
       expect(de.componentInstance.dataMeasure).toEqual('GB');
     });
   });

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -66,9 +66,9 @@ describe('DeploymentCardComponent', () => {
       getPods: (spaceId: string, applicationId: string, environmentName: string) => { throw 'NotImplemented'; },
       scalePods: (spaceId: string, appId: string, envId: string, desired: number) => { throw 'NotImplemented'; },
       getVersion: () => Observable.of('1.2.3'),
-      getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
+      getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, quota: 2 } as CpuStat),
       getMemoryStat: (spaceId: string, envId: string) =>
-        Observable.of({ used: 1, total: 2, units: 'GB' } as MemoryStat),
+        Observable.of({ used: 1, quota: 2, units: 'GB' } as MemoryStat),
       getAppUrl: () => Observable.of('mockAppUrl'),
       getConsoleUrl: () => Observable.of('mockConsoleUrl'),
       getLogsUrl: () => Observable.of('mockLogsUrl'),

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -63,7 +63,7 @@ describe('DeploymentCardComponent', () => {
     mockSvc = {
       getApplications: () => { throw 'Not Implemented'; },
       getEnvironments: () => { throw 'Not Implemented'; },
-      getPods: (spaceId: string, applicationId: string, environmentId: string) => { throw 'NotImplemented'; },
+      getPods: (spaceId: string, applicationId: string, environmentName: string) => { throw 'NotImplemented'; },
       scalePods: (spaceId: string, appId: string, envId: string, desired: number) => { throw 'NotImplemented'; },
       getVersion: () => Observable.of('1.2.3'),
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
@@ -97,7 +97,7 @@ describe('DeploymentCardComponent', () => {
 
     component.spaceId = 'mockSpaceId';
     component.applicationId = 'mockAppId';
-    component.environment = { environmentId: 'mockEnvironmentId', name: 'mockEnvironment' };
+    component.environment = { name: 'mockEnvironment' } as Environment;
 
     fixture.detectChanges();
     flush();

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -91,22 +91,22 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
     this.memTime = 1;
 
     this.version =
-      this.deploymentsService.getVersion(this.applicationId, this.environment.environmentId);
+      this.deploymentsService.getVersion(this.applicationId, this.environment.name);
 
     this.logsUrl =
-      this.deploymentsService.getLogsUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+      this.deploymentsService.getLogsUrl(this.spaceId, this.applicationId, this.environment.name);
 
     this.consoleUrl =
-      this.deploymentsService.getConsoleUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+      this.deploymentsService.getConsoleUrl(this.spaceId, this.applicationId, this.environment.name);
 
     this.appUrl =
-      this.deploymentsService.getAppUrl(this.spaceId, this.applicationId, this.environment.environmentId);
+      this.deploymentsService.getAppUrl(this.spaceId, this.applicationId, this.environment.name);
 
     this.cpuStat =
-      this.deploymentsService.getCpuStat(this.applicationId, this.environment.environmentId);
+      this.deploymentsService.getCpuStat(this.applicationId, this.environment.name);
 
     this.memStat =
-      this.deploymentsService.getMemoryStat(this.applicationId, this.environment.environmentId);
+      this.deploymentsService.getMemoryStat(this.applicationId, this.environment.name);
 
     this.cpuStat.subscribe(stat => {
       this.cpuVal = stat.used;
@@ -124,7 +124,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
   delete(): void {
     this.subscriptions.push(
-      this.deploymentsService.deleteApplication(this.spaceId, this.applicationId, this.environment.environmentId)
+      this.deploymentsService.deleteApplication(this.spaceId, this.applicationId, this.environment.name)
         .subscribe(alert)
     );
   }

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -36,8 +36,8 @@ describe('DeploymentsAppsComponent', () => {
   let mockApplicationData = ['first', 'second'];
   let mockApplications = Observable.of(mockApplicationData);
   let mockEnvironments = Observable.of([
-    { environmentId: 'id1', name: 'envId1'},
-    { environmentId: 'id2', name: 'envId2'}
+    { name: 'envId1'} as Environment,
+    { name: 'envId2'} as Environment
   ]);
 
   beforeEach(() => {

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -116,7 +116,7 @@ describe('DeploymentsDonutComponent', () => {
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 3);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 3);
   });
 
   it('should call scalePods when scaling down', () => {
@@ -125,7 +125,7 @@ describe('DeploymentsDonutComponent', () => {
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 1);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 1);
   });
 
   it('should not call scalePods when scaling below 0', () => {
@@ -134,11 +134,11 @@ describe('DeploymentsDonutComponent', () => {
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 1);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 1);
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 0);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 0);
 
 
     el.click();

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -17,6 +17,7 @@ import { Observable } from 'rxjs';
 
 import { DeploymentsDonutComponent } from './deployments-donut.component';
 import { DeploymentsService } from '../services/deployments.service';
+import { Environment } from '../models/environment';
 import { Pods } from '../models/pods';
 
 import { createMock } from '../../../../../testing/mock';
@@ -60,7 +61,7 @@ describe('DeploymentsDonutComponent', () => {
     component.mini = false;
     component.spaceId = 'space';
     component.applicationId = 'application';
-    component.environment = { environmentId: 'environmentId', name: 'environmentName' };
+    component.environment = { name: 'environmentName' } as Environment;
 
     fixture.detectChanges();
   });

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -59,8 +59,8 @@ describe('DeploymentsDonutComponent', () => {
 
     component.mini = false;
     component.spaceId = 'space';
-    component.environmentId = 'environment';
     component.applicationId = 'application';
+    component.environment = { environmentId: 'environmentId', name: 'environmentName' };
 
     fixture.detectChanges();
   });
@@ -116,7 +116,7 @@ describe('DeploymentsDonutComponent', () => {
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environment', 'application', 3);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 3);
   });
 
   it('should call scalePods when scaling down', () => {
@@ -125,7 +125,7 @@ describe('DeploymentsDonutComponent', () => {
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environment', 'application', 1);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 1);
   });
 
   it('should not call scalePods when scaling below 0', () => {
@@ -134,11 +134,11 @@ describe('DeploymentsDonutComponent', () => {
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environment', 'application', 1);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 1);
 
     el.click();
     component.debounceScale.flush();
-    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environment', 'application', 0);
+    expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentId', 'application', 0);
 
 
     el.click();

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -32,7 +32,7 @@ export class DeploymentsDonutComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.pods = this.deploymentsService.getPods(this.spaceId, this.applicationId, this.environment.environmentId);
+    this.pods = this.deploymentsService.getPods(this.spaceId, this.applicationId, this.environment.name);
     this.pods.subscribe(pods => this.replicas = pods.total);
 
     this.desiredReplicas = this.getDesiredReplicas();
@@ -77,7 +77,7 @@ export class DeploymentsDonutComponent implements OnInit {
 
   private scale(): void {
     this.deploymentsService.scalePods(
-      this.spaceId, this.environment.environmentId, this.applicationId, this.desiredReplicas
+      this.spaceId, this.environment.name, this.applicationId, this.desiredReplicas
     );
   }
 }

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 import { DeploymentsService } from '../services/deployments.service';
 import { Pods } from '../models/pods';
+import { Environment } from '../models/environment';
 
 @Component({
   selector: 'deployments-donut',
@@ -15,7 +16,7 @@ export class DeploymentsDonutComponent implements OnInit {
   @Input() mini: boolean;
   @Input() spaceId: string;
   @Input() applicationId: string;
-  @Input() environmentId: string;
+  @Input() environment: Environment;
 
   isIdled = false;
   scalable = true;
@@ -31,7 +32,7 @@ export class DeploymentsDonutComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.pods = this.deploymentsService.getPods(this.spaceId, this.environmentId, this.applicationId);
+    this.pods = this.deploymentsService.getPods(this.spaceId, this.applicationId, this.environment.environmentId);
     this.pods.subscribe(pods => this.replicas = pods.total);
 
     this.desiredReplicas = this.getDesiredReplicas();
@@ -75,6 +76,8 @@ export class DeploymentsDonutComponent implements OnInit {
   }
 
   private scale(): void {
-    this.deploymentsService.scalePods(this.spaceId, this.environmentId, this.applicationId, this.desiredReplicas);
+    this.deploymentsService.scalePods(
+      this.spaceId, this.environment.environmentId, this.applicationId, this.desiredReplicas
+    );
   }
 }

--- a/src/app/space/create/deployments/deployments.component.spec.ts
+++ b/src/app/space/create/deployments/deployments.component.spec.ts
@@ -57,8 +57,8 @@ describe('DeploymentsComponent', () => {
   let spaces = { current: Observable.of({ id: 'fake-spaceId' }) };
   let mockApplications = Observable.of(['foo-app', 'bar-app']);
   let mockEnvironments = Observable.of([
-    { environmentId: 'a1', name: 'stage' },
-    { environmentId: 'b2', name: 'prod' }
+    { name: 'stage' } as Environment,
+    { name: 'prod' } as Environment
   ]);
 
   beforeAll(() => {
@@ -91,8 +91,8 @@ describe('DeploymentsComponent', () => {
     expect(mockSvc.getEnvironments).toHaveBeenCalledWith('fake-spaceId');
     this.testedDirective.environments.subscribe(environments => {
       expect(environments).toEqual([
-        { environmentId: 'a1', name: 'stage' },
-        { environmentId: 'b2', name: 'prod' }
+        { name: 'stage' } as Environment,
+        { name: 'prod' } as Environment
       ]);
       done();
     });

--- a/src/app/space/create/deployments/models/environment.ts
+++ b/src/app/space/create/deployments/models/environment.ts
@@ -1,4 +1,3 @@
 export declare interface Environment {
-  readonly environmentId: string;
   readonly name: string;
 }

--- a/src/app/space/create/deployments/models/stat.ts
+++ b/src/app/space/create/deployments/models/stat.ts
@@ -1,4 +1,4 @@
 export declare interface Stat {
   readonly used: number;
-  readonly total: number;
+  readonly quota: number;
 }

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.html
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.html
@@ -13,7 +13,7 @@
         </div>
         <div [collapse]="resourcesCollapsed">
           <div class="col-xs-12 col-sm-4 col-md-3" *ngFor="let environment of environments | async">
-            <resource-card [spaceId]="spaceId | async" [environmentId]="environment.environmentId"></resource-card>
+            <resource-card [spaceId]="spaceId | async" [environment]="environment"></resource-card>
           </div>
         </div>
       </div>

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
@@ -24,7 +24,7 @@ import { Stat } from '../models/stat';
 })
 class FakeResourceCardComponent {
   @Input() spaceId: string;
-  @Input() environmentId: string;
+  @Input() environment: Environment;
 }
 
 describe('DeploymentsResourceUsageComponent', () => {
@@ -33,8 +33,8 @@ describe('DeploymentsResourceUsageComponent', () => {
   let fixture: ComponentFixture<DeploymentsResourceUsageComponent>;
   let mockEnvironments: Observable<Environment[]>;
   let mockEnvironmentData = [
-    { environmentId: "id1", name: "envId1"},
-    { environmentId: "id2", name: "envId2"}
+    { environmentId: 'id1', name: 'envId1'},
+    { environmentId: 'id2', name: 'envId2'}
   ];
   let spaceIdObservable = Observable.of('spaceId');
 
@@ -60,7 +60,7 @@ describe('DeploymentsResourceUsageComponent', () => {
 
     mockEnvironmentData.forEach((envData, index) => {
       let cardComponent = arrayOfComponents[index].componentInstance;
-      expect(cardComponent.environmentId).toEqual(mockEnvironmentData[index].environmentId);
+      expect(cardComponent.environment).toEqual(mockEnvironmentData[index]);
       expect(cardComponent.spaceId).toEqual('spaceId');
     });
   });

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
@@ -33,8 +33,8 @@ describe('DeploymentsResourceUsageComponent', () => {
   let fixture: ComponentFixture<DeploymentsResourceUsageComponent>;
   let mockEnvironments: Observable<Environment[]>;
   let mockEnvironmentData = [
-    { environmentId: 'id1', name: 'envId1'},
-    { environmentId: 'id2', name: 'envId2'}
+    { name: 'envId1'} as Environment,
+    { name: 'envId2'} as Environment
   ];
   let spaceIdObservable = Observable.of('spaceId');
 

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,6 +1,6 @@
 <div class="card-pf">
   <div class="card-pf-body resource-card-body">
-    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environment.environmentId)"></utilization-bar>
-    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environment.environmentId)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environment.name)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environment.name)"></utilization-bar>
   </div>
 </div>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,6 +1,6 @@
 <div class="card-pf">
   <div class="card-pf-body resource-card-body">
-    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environmentId)"></utilization-bar>
-    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environmentId)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environment.environmentId)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environment.environmentId)"></utilization-bar>
   </div>
 </div>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -14,6 +14,7 @@ import { Observable } from 'rxjs';
 
 import { DeploymentsService } from '../services/deployments.service';
 
+import { Environment } from '../models/environment';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
 import { Stat } from '../models/stat';
@@ -43,8 +44,8 @@ describe('ResourceCardComponent', () => {
     mockSvc = {
       getApplications: () => Observable.of(['foo-app', 'bar-app']),
       getEnvironments: () => Observable.of([
-        { environmentId: 'a1', name: 'stage' },
-        { environmentId: 'b2', name: 'prod' }
+        { name: 'stage' } as Environment,
+        { name: 'prod' } as Environment
       ]),
       getPods: () => { throw 'NotImplemented'; },
       scalePods: (spaceId: string, envId: string, appId: string) => { throw 'Not Implemented'; },
@@ -80,7 +81,7 @@ describe('ResourceCardComponent', () => {
     component = fixture.componentInstance;
 
     component.spaceId = 'spaceId';
-    component.environment = { environmentId: 'environmentId', name: 'environmentName' };
+    component.environment = { name: 'stage' } as Environment;
 
     fixture.detectChanges();
   });

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -80,7 +80,7 @@ describe('ResourceCardComponent', () => {
     component = fixture.componentInstance;
 
     component.spaceId = 'spaceId';
-    component.environmentId = 'environmentId';
+    component.environment = { environmentId: 'environmentId', name: 'environmentName' };
 
     fixture.detectChanges();
   });

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -37,8 +37,8 @@ describe('ResourceCardComponent', () => {
   let fixture: ComponentFixture<ResourceCardComponent>;
   let mockResourceTitle = 'resource title';
   let mockSvc: DeploymentsService;
-  let cpuStatMock = Observable.of({ used: 1, total: 2 } as CpuStat);
-  let memoryStatMock = Observable.of({ used: 3, total: 4, units: 'GB' } as MemoryStat);
+  let cpuStatMock = Observable.of({ used: 1, quota: 2 } as CpuStat);
+  let memoryStatMock = Observable.of({ used: 3, quota: 4, units: 'GB' } as MemoryStat);
 
   beforeEach(() => {
     mockSvc = {

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -26,7 +26,7 @@ export class ResourceCardComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environment.environmentId)
+    this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environment.name)
       .first()
       .map(stat => stat.units);
   }

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -8,6 +8,8 @@ import { Observable } from 'rxjs';
 
 import { DeploymentsService } from '../services/deployments.service';
 
+import { Environment } from '../models/environment';
+
 @Component({
   selector: 'resource-card',
   templateUrl: 'resource-card.component.html'
@@ -15,7 +17,7 @@ import { DeploymentsService } from '../services/deployments.service';
 export class ResourceCardComponent implements OnInit {
 
   @Input() spaceId: string;
-  @Input() environmentId: string;
+  @Input() environment: Environment;
 
   memUnit: Observable<string>;
 
@@ -24,7 +26,7 @@ export class ResourceCardComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environmentId)
+    this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environment.environmentId)
       .first()
       .map(stat => stat.units);
   }

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -30,7 +30,7 @@ describe('UtilizationBarComponent', () => {
 
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
-      component.stat = Observable.of({ used: 1, total: 4 } as Stat);
+      component.stat = Observable.of({ used: 1, quota: 4 } as Stat);
 
       fixture.detectChanges();
     });
@@ -72,7 +72,7 @@ describe('UtilizationBarComponent', () => {
 
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
-      component.stat = Observable.of({ used: 2, total: 0 } as Stat);
+      component.stat = Observable.of({ used: 2, quota: 0 } as Stat);
 
       fixture.detectChanges();
     });

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -28,7 +28,7 @@ export class UtilizationBarComponent implements OnInit {
   ngOnInit(): void {
     this.stat.subscribe(val => {
       this.used = val.used;
-      this.total = val.total;
+      this.total = val.quota;
       this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
       this.unusedPercent = 100 - this.usedPercent;
     });

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -4,6 +4,8 @@ import {
   tick
 } from '@angular/core/testing';
 
+import { Environment } from '../models/environment';
+
 import { DeploymentsService } from './deployments.service';
 
 describe('DeploymentsService', () => {
@@ -30,8 +32,8 @@ describe('DeploymentsService', () => {
       svc.getEnvironments('foo')
         .subscribe(val => {
           expect(val).toEqual([
-            { environmentId: 'envId-stage', name: 'stage' },
-            { environmentId: 'envId-run', name: 'run' }
+            { name: 'stage' } as Environment,
+            { name: 'run' } as Environment
           ]);
         });
       tick(DeploymentsService.POLL_RATE_MS + 10);

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -52,10 +52,10 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getCpuStat', () => {
-    it('should return a "total" value of 10', fakeAsync(() => {
+    it('should return a "quota" value of 10', fakeAsync(() => {
       svc.getCpuStat('foo', 'bar')
         .subscribe(val => {
-          expect(val.total).toBe(10);
+          expect(val.quota).toBe(10);
         });
       tick(DeploymentsService.POLL_RATE_MS + 10);
       discardPeriodicTasks();
@@ -73,10 +73,10 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getMemoryStat', () => {
-    it('should return a "total" value of 256', fakeAsync(() => {
+    it('should return a "quota" value of 256', fakeAsync(() => {
       svc.getMemoryStat('foo', 'bar')
         .subscribe(val => {
-          expect(val.total).toBe(256);
+          expect(val.quota).toBe(256);
         });
       tick(DeploymentsService.POLL_RATE_MS + 10);
       discardPeriodicTasks();

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -44,16 +44,16 @@ export class DeploymentsService {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 9) + 1, total: 10 } as CpuStat))
-      .startWith({ used: 3, total: 10 } as CpuStat);
+      .map(() => ({ used: Math.floor(Math.random() * 9) + 1, quota: 10 } as CpuStat))
+      .startWith({ used: 3, quota: 10 } as CpuStat);
   }
 
   getMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, total: 256, units: 'MB' } as MemoryStat))
-      .startWith({ used: 200, total: 256, units: 'MB' } as MemoryStat);
+      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, quota: 256, units: 'MB' } as MemoryStat))
+      .startWith({ used: 200, quota: 256, units: 'MB' } as MemoryStat);
   }
 
   getLogsUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -18,8 +18,8 @@ export class DeploymentsService {
 
   getEnvironments(spaceId: string): Observable<Environment[]> {
     return Observable.of([
-      { environmentId: 'envId-stage', name: 'stage' } as Environment,
-      { environmentId: 'envId-run', name: 'run' } as Environment
+      { name: 'stage' } as Environment,
+      { name: 'run' } as Environment
     ]);
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -23,24 +23,24 @@ export class DeploymentsService {
     ]);
   }
 
-  getVersion(spaceId: string, environmentId: string): Observable<string> {
+  getVersion(spaceId: string, environmentName: string): Observable<string> {
     return Observable.of('1.0.2');
-  }
-
-  getPods(spaceId: string, environmentId: string, applicationId: string): Observable<Pods> {
-    return Observable.of({ pods: [['Running', 2], ['Terminating', 1]], total: 3 } as Pods);
   }
 
   scalePods(
     spaceId: string,
-    environmentId: string,
+    environmentName: string,
     applicationId: string,
     desiredReplicas: number
   ): Observable<string> {
-    return Observable.of(`Scaled ${applicationId} in ${spaceId}/${environmentId} to ${desiredReplicas} replicas`);
+    return Observable.of(`Scaled ${applicationId} in ${spaceId}/${environmentName} to ${desiredReplicas} replicas`);
   }
 
-  getCpuStat(spaceId: string, environmentId: string): Observable<CpuStat> {
+  getPods(spaceId: string, applicationId: string, environmentName: string): Observable<Pods> {
+    return Observable.of({ pods: [['Running', 2], ['Terminating', 1]], total: 3 } as Pods);
+  }
+
+  getCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
@@ -48,7 +48,7 @@ export class DeploymentsService {
       .startWith({ used: 3, total: 10 } as CpuStat);
   }
 
-  getMemoryStat(spaceId: string, environmentId: string): Observable<MemoryStat> {
+  getMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
@@ -56,15 +56,15 @@ export class DeploymentsService {
       .startWith({ used: 200, total: 256, units: 'MB' } as MemoryStat);
   }
 
-  getLogsUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+  getLogsUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
     return Observable.of('http://example.com/');
   }
 
-  getConsoleUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+  getConsoleUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
     return Observable.of('http://example.com/');
   }
 
-  getAppUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
+  getAppUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
     if (Math.random() > 0.5) {
       return Observable.of('http://example.com/');
     } else {
@@ -72,8 +72,8 @@ export class DeploymentsService {
     }
   }
 
-  deleteApplication(spaceId: string, applicationId: string, environmentId: string): Observable<string> {
-    return Observable.of(`Deleted ${applicationId} in ${spaceId} (${environmentId})`);
+  deleteApplication(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
+    return Observable.of(`Deleted ${applicationId} in ${spaceId} (${environmentName})`);
   }
 
 }


### PR DESCRIPTION
This PR does some cleanup and refactoring to get the Deployments page code in shape so that a future PR can swap the DeploymentsService implementation to performing HTTP requests and returning data as formatted by the backend.