### PR TITLE
Add check for null Che input

### DIFF
--- a/src/app/space/create/codebases/codebases-item-heading/codebases-item-heading.component.ts
+++ b/src/app/space/create/codebases/codebases-item-heading/codebases-item-heading.component.ts
@@ -30,8 +30,8 @@ export class CodebasesItemHeadingComponent implements OnInit {
    * @returns {string}
    */
   getNotificationMessage(): string {
-    if (this.cheState !== undefined) {
-      if (this.cheState.multiTenant) {
+    if (this.cheState !== undefined && this.cheState !== null) {
+      if (this.cheState.multiTenant !== undefined && this.cheState.multiTenant === true) {
         return this.cheState.running
           ? this.cheFinishedMultiTenantMigrationMessage : this.chePerformingMultiTenantMigrationMessage;
       } else {


### PR DESCRIPTION
Added check for null Che input. This fixes the error below seen on prod-preview -- this is not seen locally, tho.

patternfly.min.css:1 ERROR TypeError: Cannot read property 'multiTenant' of null
    at CodebasesItemHeadingComponent.getNotificationMessage ...

FYI, the Che input is now being set to null via the codebases component.