### PR TITLE
Units scaling

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -51,10 +51,10 @@
 
       <div class="deployment-chart">
         <div class="chart-column">
-            <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
-          </div>
+          <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
+        </div>
         <div class="chart-column chart-text">
-            <deployment-graph-label type="Memory" dataMeasure="GB" [value]="memVal" valueUpperBound="500"></deployment-graph-label>
+          <deployment-graph-label type="Memory" [dataMeasure]="memUnits" [value]="memVal" valueUpperBound="500"></deployment-graph-label>
         </div>
       </div>
     </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -64,7 +64,8 @@ describe('DeploymentCardComponent', () => {
       scalePods: (spaceId: string, appId: string, envId: string, desired: number) => { throw 'NotImplemented'; },
       getVersion: () => Observable.of('1.2.3'),
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as CpuStat),
-      getMemoryStat: (spaceId: string, envId: string) => Observable.of({ used: 1, total: 2 } as MemoryStat),
+      getMemoryStat: (spaceId: string, envId: string) =>
+        Observable.of({ used: 1, total: 2, units: 'GB' } as MemoryStat),
       getAppUrl: () => Observable.of('mockAppUrl'),
       getConsoleUrl: () => Observable.of('mockConsoleUrl'),
       getLogsUrl: () => Observable.of('mockLogsUrl'),
@@ -120,6 +121,21 @@ describe('DeploymentCardComponent', () => {
     it('should be set from mockSvc.getVersion result', () => {
       expect(mockSvc.getVersion).toHaveBeenCalledWith('mockAppId', 'mockEnvironmentId');
       expect(el.textContent).toEqual('1.2.3');
+    });
+  });
+
+  describe('memory label', () => {
+    let de: DebugElement;
+
+    beforeEach(() => {
+      let charts = fixture.debugElement.queryAll(By.css('.deployment-chart'));
+      let memoryChart = charts[1];
+      de = charts[1].query(By.directive(FakeDeploymentGraphLabelComponent));
+    });
+
+    it('should use units from service result', () => {
+      expect(mockSvc.getMemoryStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironmentId');
+      expect(de.componentInstance.dataMeasure).toEqual('GB');
     });
   });
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -64,6 +64,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   memTime: number;
   cpuVal: number;
   memVal: number;
+  memUnits: string;
 
   logsUrl: Observable<string>;
   consoleUrl: Observable<string>;
@@ -117,6 +118,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
       this.memVal = stat.used;
       this.memData.yData.push(stat.used);
       this.memData.xData.push(this.cpuTime++);
+      this.memUnits = stat.units;
     });
   }
 

--- a/src/app/space/create/deployments/models/memory-stat.ts
+++ b/src/app/space/create/deployments/models/memory-stat.ts
@@ -1,3 +1,5 @@
 import { Stat } from './stat';
 
-export declare interface MemoryStat extends Stat {}
+export declare interface MemoryStat extends Stat {
+  readonly units: 'B' | 'KB' | 'MB' | 'GB';
+}

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,6 +1,6 @@
 <div class="card-pf">
   <div class="card-pf-body resource-card-body">
-    <utilization-bar [resourceTitle]="'CPU (Cores)'" [stat]="deploymentsService.getCpuStat(spaceId, environmentId)"></utilization-bar>
-    <utilization-bar [resourceTitle]="'Memory (MB)'" [stat]="deploymentsService.getMemoryStat(spaceId, environmentId)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environmentId)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environmentId)"></utilization-bar>
   </div>
 </div>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -26,6 +26,7 @@ import { ResourceCardComponent } from './resource-card.component';
 })
 class FakeUtilizationBarComponent {
   @Input() resourceTitle: string;
+  @Input() resourceUnit: string;
   @Input() stat: Observable<Stat>;
 }
 
@@ -36,7 +37,7 @@ describe('ResourceCardComponent', () => {
   let mockResourceTitle = 'resource title';
   let mockSvc: DeploymentsService;
   let cpuStatMock = Observable.of({ used: 1, total: 2 } as CpuStat);
-  let memoryStatMock = Observable.of({ used: 3, total: 4 } as MemoryStat);
+  let memoryStatMock = Observable.of({ used: 3, total: 4, units: 'GB' } as MemoryStat);
 
   beforeEach(() => {
     mockSvc = {
@@ -89,11 +90,13 @@ describe('ResourceCardComponent', () => {
     expect(arrayOfComponents.length).toEqual(2);
 
     let cpuUtilBar = arrayOfComponents[0].componentInstance;
-    expect(cpuUtilBar.resourceTitle).toEqual('CPU (Cores)');
+    expect(cpuUtilBar.resourceTitle).toEqual('CPU');
+    expect(cpuUtilBar.resourceUnit).toEqual('Cores');
     expect(cpuUtilBar.stat).toEqual(cpuStatMock);
 
     let memoryUtilBar = arrayOfComponents[1].componentInstance;
-    expect(memoryUtilBar.resourceTitle).toEqual('Memory (MB)');
+    expect(memoryUtilBar.resourceTitle).toEqual('Memory');
+    expect(memoryUtilBar.resourceUnit).toEqual('GB');
     expect(memoryUtilBar.stat).toEqual(memoryStatMock);
   });
 

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -1,20 +1,32 @@
 import {
   Component,
-  Input
+  Input,
+  OnInit
 } from '@angular/core';
 
+import { Observable } from 'rxjs';
+
 import { DeploymentsService } from '../services/deployments.service';
+
 @Component({
   selector: 'resource-card',
   templateUrl: 'resource-card.component.html'
 })
-export class ResourceCardComponent {
+export class ResourceCardComponent implements OnInit {
 
   @Input() spaceId: string;
   @Input() environmentId: string;
 
+  memUnit: Observable<string>;
+
   constructor(
     private deploymentsService: DeploymentsService
   ) { }
+
+  ngOnInit(): void {
+    this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environmentId)
+      .first()
+      .map(stat => stat.units);
+  }
 
 }

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
@@ -1,6 +1,6 @@
 <div class="progress-container progress-description-left progress-label-right">
   <div class="progress-description">
-    {{ resourceTitle }}
+    {{ resourceTitle }} ({{ resourceUnit }})
   </div>
   <div class="progress">
     <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -13,83 +13,87 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { UtilizationBarComponent } from './utilization-bar.component';
 import { Stat } from '../models/stat';
 
-describe('UtilizationBarComponent with valid Stat', () => {
+describe('UtilizationBarComponent', () => {
+  describe('with valid Stat', () => {
 
-  let component: UtilizationBarComponent;
-  let fixture: ComponentFixture<UtilizationBarComponent>;
+    let component: UtilizationBarComponent;
+    let fixture: ComponentFixture<UtilizationBarComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot() ],
-      declarations: [ UtilizationBarComponent ],
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [CollapseModule.forRoot()],
+        declarations: [UtilizationBarComponent]
+      });
+
+      fixture = TestBed.createComponent(UtilizationBarComponent);
+      component = fixture.componentInstance;
+
+      component.resourceTitle = 'someTitle';
+      component.resourceUnit = 'someUnit';
+      component.stat = Observable.of({ used: 1, total: 4 } as Stat);
+
+      fixture.detectChanges();
     });
 
-    fixture = TestBed.createComponent(UtilizationBarComponent);
-    component = fixture.componentInstance;
-
-    component.resourceTitle = 'someTitle';
-    component.stat = Observable.of({ used: 1, total: 4 } as Stat);
-
-    fixture.detectChanges();
-  });
-
-  it('should have proper stat fields set', () => {
-    expect(component.used).toEqual(1);
-    expect(component.total).toEqual(4);
-    expect(component.usedPercent).toEqual(25);
-    expect(component.unusedPercent).toEqual(75);
-  });
-
-  it('should have a properly set title', () => {
-    let de = fixture.debugElement.query(By.css('.progress-description'));
-    let el = de.nativeElement;
-    expect(el.textContent.trim()).toEqual('someTitle');
-  });
-
-  it('should have properly set card label information', () => {
-    let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
-    let el = de.nativeElement;
-    expect(el.textContent.trim()).toEqual('1 of 4');
-  });
-
-});
-
-describe('UtilizationBarComponent with invalid Stat', () => {
-
-  let component: UtilizationBarComponent;
-  let fixture: ComponentFixture<UtilizationBarComponent>;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot() ],
-      declarations: [ UtilizationBarComponent ],
+    it('should have proper stat fields set', () => {
+      expect(component.used).toEqual(1);
+      expect(component.total).toEqual(4);
+      expect(component.usedPercent).toEqual(25);
+      expect(component.unusedPercent).toEqual(75);
     });
 
-    fixture = TestBed.createComponent(UtilizationBarComponent);
-    component = fixture.componentInstance;
+    it('should have a properly set title', () => {
+      let de = fixture.debugElement.query(By.css('.progress-description'));
+      let el = de.nativeElement;
+      expect(el.textContent.trim()).toEqual('someTitle (someUnit)');
+    });
 
-    component.resourceTitle = 'someTitle';
-    component.stat = Observable.of({ used: 2, total: 0 } as Stat);
+    it('should have properly set card label information', () => {
+      let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
+      let el = de.nativeElement;
+      expect(el.textContent.trim()).toEqual('1 of 4');
+    });
 
-    fixture.detectChanges();
   });
 
-  it('should have backup values in case it has a zero total', () => {
-    expect(component.used).toEqual(2);
-    expect(component.total).toEqual(0);
-    expect(component.usedPercent).toEqual(0);
-    expect(component.unusedPercent).toEqual(100);
-  });
+  describe('with invalid Stat', () => {
 
-  it('should have a properly set title', () => {
-    let de = fixture.debugElement.query(By.css('.progress-description'));
-    let el = de.nativeElement;
-    expect(el.textContent.trim()).toEqual('someTitle');
-  });
+    let component: UtilizationBarComponent;
+    let fixture: ComponentFixture<UtilizationBarComponent>;
 
-  it('should have properly set card label information', () => {
-    let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
-    let el = de.nativeElement;
-    expect(el.textContent.trim()).toEqual('2 of 0');
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [CollapseModule.forRoot()],
+        declarations: [UtilizationBarComponent]
+      });
+
+      fixture = TestBed.createComponent(UtilizationBarComponent);
+      component = fixture.componentInstance;
+
+      component.resourceTitle = 'someTitle';
+      component.resourceUnit = 'someUnit';
+      component.stat = Observable.of({ used: 2, total: 0 } as Stat);
+
+      fixture.detectChanges();
+    });
+
+    it('should have backup values in case it has a zero total', () => {
+      expect(component.used).toEqual(2);
+      expect(component.total).toEqual(0);
+      expect(component.usedPercent).toEqual(0);
+      expect(component.unusedPercent).toEqual(100);
+    });
+
+    it('should have a properly set title', () => {
+      let de = fixture.debugElement.query(By.css('.progress-description'));
+      let el = de.nativeElement;
+      expect(el.textContent.trim()).toEqual('someTitle (someUnit)');
+    });
+
+    it('should have properly set card label information', () => {
+      let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
+      let el = de.nativeElement;
+      expect(el.textContent.trim()).toEqual('2 of 0');
+    });
   });
 });

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -15,6 +15,7 @@ import { Observable } from 'rxjs';
 export class UtilizationBarComponent implements OnInit {
 
   @Input() resourceTitle: string;
+  @Input() resourceUnit: string;
   @Input() stat: Observable<Stat>;
 
   used: number;

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -89,6 +89,15 @@ describe('DeploymentsService', () => {
       tick(DeploymentsService.POLL_RATE_MS + 10);
       discardPeriodicTasks();
     }));
+
+    it('should return a value in MB', fakeAsync(() => {
+      svc.getMemoryStat('foo', 'bar')
+        .subscribe(val => {
+          expect(val.units).toEqual('MB');
+        });
+        tick(DeploymentsService.POLL_RATE_MS + 10);
+        discardPeriodicTasks();
+    }));
   });
 
 });

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -52,8 +52,8 @@ export class DeploymentsService {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, total: 256 } as MemoryStat))
-      .startWith({ used: 200, total: 256 } as MemoryStat);
+      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, total: 256, units: 'MB' } as MemoryStat))
+      .startWith({ used: 200, total: 256, units: 'MB' } as MemoryStat);
   }
 
   getLogsUrl(spaceId: string, applicationId: string, environmentId: string): Observable<string> {


### PR DESCRIPTION
These commits address https://github.com/openshiftio/openshift.io/issues/1711 . The MemoryStat interface gains a "units" property and this is propagated to the resource usage utilization bar and deployment card sparkline label so that the correct unit is displayed. The mock service currently only sends units as "MB", but this is now easily changed in the future when the service implementation is adapted to pull real data, so that the used/total of the MemoryStat can be scaled down and the units set to match.