### PR TITLE
fix(deployments): fix missed "total" to "quota" property rename

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -68,7 +68,7 @@ describe('DeploymentCardComponent', () => {
       getVersion: () => Observable.of('1.2.3'),
       getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, quota: 2 } as CpuStat),
       getMemoryStat: (spaceId: string, envId: string) =>
-        Observable.of({ used: 1, quota: 2, units: 'GB' } as MemoryStat),
+        Observable.of({ used: 3, quota: 4, units: 'GB' } as MemoryStat),
       getAppUrl: () => Observable.of('mockAppUrl'),
       getConsoleUrl: () => Observable.of('mockConsoleUrl'),
       getLogsUrl: () => Observable.of('mockLogsUrl'),
@@ -129,18 +129,49 @@ describe('DeploymentCardComponent', () => {
     });
   });
 
+  describe('cpu label', () => {
+    let de: DebugElement;
+
+    beforeEach(() => {
+      let charts = fixture.debugElement.queryAll(By.css('.deployment-chart'));
+      let cpuChart = charts[0];
+      de = cpuChart.query(By.directive(FakeDeploymentGraphLabelComponent));
+    });
+
+    it('should use units from service result', () => {
+      expect(mockSvc.getMemoryStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
+      expect(de.componentInstance.dataMeasure).toEqual('Cores');
+    });
+
+    it('should use value from service result', () => {
+      expect(de.componentInstance.value).toEqual(1);
+    });
+
+    it('should use upper bound from service result', () => {
+      expect(de.componentInstance.valueUpperBound).toEqual(2);
+    });
+  });
+
   describe('memory label', () => {
     let de: DebugElement;
 
     beforeEach(() => {
       let charts = fixture.debugElement.queryAll(By.css('.deployment-chart'));
       let memoryChart = charts[1];
-      de = charts[1].query(By.directive(FakeDeploymentGraphLabelComponent));
+      de = memoryChart.query(By.directive(FakeDeploymentGraphLabelComponent));
     });
 
     it('should use units from service result', () => {
       expect(mockSvc.getMemoryStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
       expect(de.componentInstance.dataMeasure).toEqual('GB');
+    });
+
+    it('should use value from service result', () => {
+      expect(de.componentInstance.value).toEqual(3);
+    });
+
+    it('should use upper bound from service result', () => {
+      expect(de.componentInstance.valueUpperBound).toEqual(4);
     });
   });
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -112,14 +112,14 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
     this.subscriptions.push(this.cpuStat.subscribe(stat => {
       this.cpuVal = stat.used;
-      this.cpuMax = stat.total;
+      this.cpuMax = stat.quota;
       this.cpuData.yData.push(stat.used);
       this.cpuData.xData.push(this.cpuTime++);
     }));
 
     this.subscriptions.push(this.memStat.subscribe(stat => {
       this.memVal = stat.used;
-      this.memMax = stat.total;
+      this.memMax = stat.quota;
       this.memData.yData.push(stat.used);
       this.memData.xData.push(this.cpuTime++);
       this.memUnits = stat.units;


### PR DESCRIPTION
related to https://github.com/openshiftio/openshift.io/issues/1370

The change to add the cpuMax/memMax properties and the change to rename "total" to "quota" were from two different PRs, so when both were merged, the cpuMax/memMax lines added were out of date wrt the desired stat property. Somehow this was either missed during rebase or did not generate a merge conflict when the two PRs were merged into master.