### PR TITLE
Deployments tests cleanup

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
@@ -1,21 +1,23 @@
-import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
   Component,
-  DebugElement,
   Input
 } from '@angular/core';
 
-import { Observable } from 'rxjs';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
 
-import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { Spaces } from 'ngx-fabric8-wit';
+import { Observable } from 'rxjs';
 
 import { DeploymentCardContainerComponent } from './deployment-card-container.component';
 import { Environment } from '../models/environment';
+
+@Component({
+  template: '<deployment-card-container></deployment-card-container>'
+})
+class HostComponent { }
 
 @Component({
   selector: 'deployment-card',
@@ -28,47 +30,34 @@ class FakeDeploymentCardComponent {
 }
 
 describe('DeploymentCardContainer', () => {
+  type Context = TestContext<DeploymentCardContainerComponent, HostComponent>;
 
-  let component: DeploymentCardContainerComponent;
-  let fixture: ComponentFixture<DeploymentCardContainerComponent>;
-  let mockEnvironments: Observable<Environment[]>;
-  let mockEnvironmentData = [
-    { name: 'envId1'} as Environment,
-    { name: 'envId2'} as Environment
+  initContext(DeploymentCardContainerComponent, HostComponent, { declarations: [FakeDeploymentCardComponent] });
+
+  const environments = [
+    { name: 'envId1' },
+    { name: 'envId2' }
   ];
 
-  beforeEach(() => {
-    mockEnvironments = Observable.of(mockEnvironmentData);
-
-    TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot() ],
-      declarations: [
-        DeploymentCardContainerComponent,
-        FakeDeploymentCardComponent
-      ]
-    });
-
-    fixture = TestBed.createComponent(DeploymentCardContainerComponent);
-    component = fixture.componentInstance;
-    component.environments = mockEnvironments;
-    component.application = 'app';
-
-    fixture.detectChanges();
+  beforeEach(function (this: Context) {
+    this.tested.componentInstance.environments = Observable.of(environments);
+    this.tested.componentInstance.application = 'app';
+    this.detectChanges();
   });
 
-  it('should created children components with proper objects', () => {
-    let arrayOfComponents = fixture.debugElement.queryAll(By.directive(FakeDeploymentCardComponent));
-    expect(arrayOfComponents.length).toEqual(mockEnvironmentData.length);
+  it('should created children components with proper objects', function (this: Context) {
+    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardComponent));
+    expect(arrayOfComponents.length).toEqual(environments.length);
 
-    mockEnvironmentData.forEach((envData, index) => {
+    environments.forEach((envData, index) => {
       let cardComponent = arrayOfComponents[index].componentInstance;
       expect(cardComponent.applicationId).toEqual('app');
-      expect(cardComponent.environment).toEqual(mockEnvironmentData[index]);
+      expect(cardComponent.environment).toEqual(environments[index]);
     });
   });
 
-  it('should set the application title properly', () => {
-    let el = fixture.debugElement.query(By.css('#deploymentCardApplicationTitle')).nativeElement;
+  it('should set the application title properly', function (this: Context) {
+    let el = this.fixture.debugElement.query(By.css('#deploymentCardApplicationTitle')).nativeElement;
     expect(el.textContent.trim()).toEqual('app');
   });
 

--- a/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
@@ -32,18 +32,17 @@ class FakeDeploymentCardComponent {
 describe('DeploymentCardContainer', () => {
   type Context = TestContext<DeploymentCardContainerComponent, HostComponent>;
 
-  initContext(DeploymentCardContainerComponent, HostComponent, { declarations: [FakeDeploymentCardComponent] });
-
   const environments = [
     { name: 'envId1' },
     { name: 'envId2' }
   ];
 
-  beforeEach(function (this: Context) {
-    this.tested.componentInstance.environments = Observable.of(environments);
-    this.tested.componentInstance.application = 'app';
-    this.detectChanges();
-  });
+  initContext(DeploymentCardContainerComponent, HostComponent, { declarations: [FakeDeploymentCardComponent] },
+    component => {
+      component.spaceId = 'space';
+      component.environments = Observable.of(environments);
+      component.application = 'app';
+    });
 
   it('should created children components with proper objects', function (this: Context) {
     let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardComponent));

--- a/src/app/space/create/deployments/apps/deployment-card-container.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.ts
@@ -1,6 +1,6 @@
 import {
   Component,
-  Input,
+  Input
 } from '@angular/core';
 
 import { Observable } from 'rxjs';

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -85,16 +85,6 @@ describe('DeploymentCardComponent', () => {
     fixture.detectChanges();
     flush();
     flushMicrotasks();
-
-    it('should generate a unique chartid for each DeploymentCardComponent instance', () => {
-      let depCard1 = new DeploymentCardComponent(null);
-      let depCard2 = new DeploymentCardComponent(null);
-      let depCard3 = new DeploymentCardComponent(null);
-
-      expect(depCard1.getChartIdNum()).not.toBe(depCard2.getChartIdNum());
-      expect(depCard1.getChartIdNum()).not.toBe(depCard3.getChartIdNum());
-      expect(depCard2.getChartIdNum()).not.toBe(depCard3.getChartIdNum());
-    });
   }));
 
   describe('versionLabel', () => {

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -6,6 +6,8 @@ import {
   TestBed
 } from '@angular/core/testing';
 
+import { createMock } from 'testing/mock';
+
 import { By } from '@angular/platform-browser';
 import {
   Component,
@@ -24,8 +26,6 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
 
 import { DeploymentCardComponent } from './deployment-card.component';
 import { DeploymentsService } from '../services/deployments.service';
-import { CpuStat } from '../models/cpu-stat';
-import { MemoryStat } from '../models/memory-stat';
 import { Environment } from '../models/environment';
 
 // Makes patternfly charts available
@@ -57,34 +57,17 @@ describe('DeploymentCardComponent', () => {
 
   let component: DeploymentCardComponent;
   let fixture: ComponentFixture<DeploymentCardComponent>;
-  let mockSvc: DeploymentsService;
+  let mockSvc: jasmine.SpyObj<DeploymentsService>;
 
   beforeEach(fakeAsync(() => {
-    mockSvc = {
-      getApplications: () => { throw 'Not Implemented'; },
-      getEnvironments: () => { throw 'Not Implemented'; },
-      getPods: (spaceId: string, applicationId: string, environmentName: string) => { throw 'NotImplemented'; },
-      scalePods: (spaceId: string, appId: string, envId: string, desired: number) => { throw 'NotImplemented'; },
-      getVersion: () => Observable.of('1.2.3'),
-      getCpuStat: (spaceId: string, envId: string) => Observable.of({ used: 1, quota: 2 } as CpuStat),
-      getMemoryStat: (spaceId: string, envId: string) =>
-        Observable.of({ used: 3, quota: 4, units: 'GB' } as MemoryStat),
-      getAppUrl: () => Observable.of('mockAppUrl'),
-      getConsoleUrl: () => Observable.of('mockConsoleUrl'),
-      getLogsUrl: () => Observable.of('mockLogsUrl'),
-      deleteApplication: () => Observable.of('mockDeletedMessage')
-    };
-
-    spyOn(mockSvc, 'getApplications').and.callThrough();
-    spyOn(mockSvc, 'getEnvironments').and.callThrough();
-    spyOn(mockSvc, 'getPods').and.callThrough();
-    spyOn(mockSvc, 'getCpuStat').and.callThrough();
-    spyOn(mockSvc, 'getMemoryStat').and.callThrough();
-    spyOn(mockSvc, 'getVersion').and.callThrough();
-    spyOn(mockSvc, 'getAppUrl').and.callThrough();
-    spyOn(mockSvc, 'getConsoleUrl').and.callThrough();
-    spyOn(mockSvc, 'getLogsUrl').and.callThrough();
-    spyOn(mockSvc, 'deleteApplication').and.callThrough();
+    mockSvc = createMock(DeploymentsService);
+    mockSvc.getVersion.and.returnValue(Observable.of('1.2.3'));
+    mockSvc.getCpuStat.and.returnValue(Observable.of({ used: 1, quota: 2 }));
+    mockSvc.getMemoryStat.and.returnValue(Observable.of({ used: 3, quota: 4, units: 'GB' }));
+    mockSvc.getAppUrl.and.returnValue(Observable.of('mockAppUrl'));
+    mockSvc.getConsoleUrl.and.returnValue(Observable.of('mockConsoleUrl'));
+    mockSvc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
+    mockSvc.deleteApplication.and.returnValue(Observable.of('mockDeletedMessage'));
 
     TestBed.configureTestingModule({
       imports: [ BsDropdownModule.forRoot(), CollapseModule.forRoot(), ChartModule ],

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -26,8 +26,6 @@ import 'patternfly/dist/js/patternfly-settings.js';
 })
 export class DeploymentCardComponent implements OnDestroy, OnInit {
 
-  static chartIdNum = 1;
-
   @Input() spaceId: string;
   @Input() applicationId: string;
   @Input() environment: Environment;
@@ -77,10 +75,6 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   constructor(
     private deploymentsService: DeploymentsService
   ) { }
-
-  getChartIdNum(): number {
-    return DeploymentCardComponent.chartIdNum;
-  }
 
   ngOnDestroy(): void {
     this.subscriptions.forEach(sub => sub.unsubscribe());

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -1,12 +1,11 @@
 import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
+  initContext,
+  TestContext
+} from 'testing/test-context';
 
 import { By } from '@angular/platform-browser';
 import {
   Component,
-  DebugElement,
   Input
 } from '@angular/core';
 
@@ -15,9 +14,10 @@ import { Observable } from 'rxjs';
 import { DeploymentsAppsComponent } from './deployments-apps.component';
 import { Environment } from '../models/environment';
 
-import { CollapseModule } from 'ngx-bootstrap/collapse';
-
-import { Spaces } from 'ngx-fabric8-wit';
+@Component({
+  template: '<deployments-apps></deployments-apps>'
+})
+class HostComponent { }
 
 @Component({
   selector: 'deployment-card-container',
@@ -30,38 +30,26 @@ class FakeDeploymentCardContainerComponent {
 }
 
 describe('DeploymentsAppsComponent', () => {
+  type Context = TestContext<DeploymentsAppsComponent, HostComponent>;
 
-  let component: DeploymentsAppsComponent;
-  let fixture: ComponentFixture<DeploymentsAppsComponent>;
-  let mockApplicationData = ['first', 'second'];
-  let mockApplications = Observable.of(mockApplicationData);
-  let mockEnvironments = Observable.of([
-    { name: 'envId1'} as Environment,
-    { name: 'envId2'} as Environment
-  ]);
+  let environments = [ { name: 'envId1' }, { name: 'envId2' } ];
+  let applications = ['first', 'second'];
+  let spaceId = Observable.of('spaceId');
+  let mockEnvironments = Observable.of(environments);
+  let mockApplications = Observable.of(applications);
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot() ],
-      declarations: [
-        DeploymentsAppsComponent,
-        FakeDeploymentCardContainerComponent
-      ]
+  initContext(DeploymentsAppsComponent, HostComponent, { declarations: [FakeDeploymentCardContainerComponent] },
+    component => {
+      component.spaceId = spaceId;
+      component.environments = mockEnvironments;
+      component.applications = mockApplications;
     });
 
-    fixture = TestBed.createComponent(DeploymentsAppsComponent);
-    component = fixture.componentInstance;
-    component.environments = mockEnvironments;
-    component.applications = mockApplications;
+  it('should created children components with proper objects', function (this: Context) {
+    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardContainerComponent));
+    expect(arrayOfComponents.length).toEqual(applications.length);
 
-    fixture.detectChanges();
-  });
-
-  it('should created children components with proper objects', () => {
-    let arrayOfComponents = fixture.debugElement.queryAll(By.directive(FakeDeploymentCardContainerComponent));
-    expect(arrayOfComponents.length).toEqual(mockApplicationData.length);
-
-    mockApplicationData.forEach((appName, index) => {
+    applications.forEach((appName, index) => {
       let container = arrayOfComponents[index].componentInstance;
       expect(container.application).toEqual(appName);
       expect(container.environments).toEqual(mockEnvironments);

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -1,6 +1,6 @@
 import {
   Component,
-  Input,
+  Input
 } from '@angular/core';
 
 import { Environment } from '../models/environment';

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
@@ -1,18 +1,20 @@
-import { Component, DebugElement, ViewChild } from '@angular/core';
 import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
+  Component,
+  ViewChild
+} from '@angular/core';
 import { By } from '@angular/platform-browser';
 
-import { isEqual } from 'lodash';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
 import { Observable } from 'rxjs';
 
 import { DeploymentsDonutChartComponent } from './deployments-donut-chart.component';
 
-describe('DeploymentsDonutChartComponent', () => {
-  @Component({
-    template: `
+@Component({
+  template: `
     <deployments-donut-chart
     [colors]="colors"
     [mini]="mini"
@@ -21,82 +23,66 @@ describe('DeploymentsDonutChartComponent', () => {
     [idled]="isIdled">
     </deployments-donut-chart>
     `
-  })
-  class TestHostComponent {
-    mini = false;
-    pods = Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 });
-    desiredReplicas = 1;
-    isIdled = false;
-    colors = {
-      'Empty': '#030303', // pf-black
-      'Running': '#00b9e4', // pf-light-blue-400
-      'Not Ready': '#beedf9', // pf-light-blue-100
-      'Warning': '#f39d3c', // pf-orange-300
-      'Error': '#cc0000', // pf-red-100
-      'Pulling': '#d1d1d1', // pf-black-300
-      'Pending': '#ededed', // pf-black-200
-      'Succeeded': '#3f9c35', // pf-green-400
-      'Terminating': '#00659c', // pf-blue-500
-      'Unknown': '#f9d67a' // pf-gold-200
-    };
+})
+class TestHostComponent {
+  mini = false;
+  pods = Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 });
+  desiredReplicas = 1;
+  isIdled = false;
+  colors = {
+    'Empty': '#030303', // pf-black
+    'Running': '#00b9e4', // pf-light-blue-400
+    'Not Ready': '#beedf9', // pf-light-blue-100
+    'Warning': '#f39d3c', // pf-orange-300
+    'Error': '#cc0000', // pf-red-100
+    'Pulling': '#d1d1d1', // pf-black-300
+    'Pending': '#ededed', // pf-black-200
+    'Succeeded': '#3f9c35', // pf-green-400
+    'Terminating': '#00659c', // pf-blue-500
+    'Unknown': '#f9d67a' // pf-gold-200
+  };
+}
 
-    @ViewChild(DeploymentsDonutChartComponent)
-    childComponent: DeploymentsDonutChartComponent;
-  }
+describe('DeploymentsDonutChartComponent', () => {
+  type Context = TestContext<DeploymentsDonutChartComponent, TestHostComponent>;
+  initContext(DeploymentsDonutChartComponent, TestHostComponent);
 
-  let hostComponent: TestHostComponent;
-  let fixture: ComponentFixture<TestHostComponent>;
-
-  let de: DebugElement;
-  let el: HTMLElement;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [DeploymentsDonutChartComponent, TestHostComponent]
-    });
-
-    fixture = TestBed.createComponent(TestHostComponent);
-    hostComponent = fixture.componentInstance;
-
-    fixture.detectChanges();
+  it('should set unique chartId', function (this: Context) {
+    expect(this.testedDirective.chartId).toMatch('deployments-donut-chart.*');
   });
 
-  it('should set unique chartId', () => {
-    expect(hostComponent.childComponent.chartId).toMatch('deployments-donut-chart.*');
-  });
-
-  it('should not show mini text', () => {
-    expect(hostComponent.childComponent.mini).toBe(false);
-    de = fixture.debugElement.query(By.css('deployments-donut-chart-mini-text'));
-    expect(de).toBeFalsy();
+  it('should not show mini text', function (this: Context) {
+    expect(this.testedDirective.mini).toBe(false);
+    let text = this.fixture.debugElement.query(By.css('deployments-donut-chart-mini-text'));
+    expect(text).toBeFalsy();
   });
 
   describe('Mini chart', () => {
-    beforeEach(() => {
-      hostComponent.mini = true;
-      fixture.detectChanges();
+    beforeEach(function (this: Context) {
+      this.hostComponent.mini = true;
+      this.detectChanges();
     });
 
-    it('should show mini text', () => {
-      expect(hostComponent.childComponent.mini).toBe(true);
-      de = fixture.debugElement.query(By.css('.deployments-donut-chart-mini-text'));
-      expect(de).toBeTruthy();
-      el = de.nativeElement;
-      expect(el.innerText).toEqual('2 pods');
+    it('should show mini text', function (this: Context) {
+      expect(this.testedDirective.mini).toBe(true);
+      let text = this.fixture.debugElement.query(By.css('.deployments-donut-chart-mini-text'));
+      expect(text).toBeTruthy();
+      let textEl = text.nativeElement;
+      expect(textEl.innerText).toEqual('2 pods');
     });
 
     describe('Mini Idle chart', () => {
-      beforeEach(() => {
-        hostComponent.isIdled = true;
-        fixture.detectChanges();
+      beforeEach(function (this: Context) {
+        this.hostComponent.isIdled = true;
+        this.detectChanges();
       });
 
-      it('should show idled text', () => {
-        expect(hostComponent.childComponent.idled).toBe(true);
-        de = fixture.debugElement.query(By.css('.deployments-donut-chart-mini-text'));
-        expect(de).toBeTruthy();
-        el = de.nativeElement;
-        expect(el.innerText).toEqual('Idle');
+      it('should show idled text', function (this: Context) {
+        expect(this.testedDirective.idled).toBe(true);
+        let idle = this.fixture.debugElement.query(By.css('.deployments-donut-chart-mini-text'));
+        expect(idle).toBeTruthy();
+        let idleEl = idle.nativeElement;
+        expect(idleEl.innerText).toEqual('Idle');
       });
     });
   });

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -1,18 +1,17 @@
 import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
-
-import {
   Component,
-  DebugElement,
   Input
 } from '@angular/core';
 
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { createMock } from 'testing/mock';
 
 import { By } from '@angular/platform-browser';
 
-import { isEqual } from 'lodash';
 import { Observable } from 'rxjs';
 
 import { DeploymentsDonutComponent } from './deployments-donut.component';
@@ -20,7 +19,10 @@ import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
 import { Pods } from '../models/pods';
 
-import { createMock } from '../../../../../testing/mock';
+@Component({
+  template: '<deployments-donut></deployments-donut>'
+})
+class HostComponent { }
 
 @Component({
   selector: 'deployments-donut-chart',
@@ -35,13 +37,9 @@ class FakeDeploymentsDonutChartComponent {
 }
 
 describe('DeploymentsDonutComponent', () => {
-  let component: DeploymentsDonutComponent;
-  let fixture: ComponentFixture<DeploymentsDonutComponent>;
+  type Context = TestContext<DeploymentsDonutComponent, HostComponent>;
+
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
-
-  let de: DebugElement;
-  let el: HTMLElement;
-
   beforeEach(() => {
     mockSvc = createMock(DeploymentsService);
     mockSvc.scalePods.and.returnValue(
@@ -50,60 +48,61 @@ describe('DeploymentsDonutComponent', () => {
     mockSvc.getPods.and.returnValue(
       Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 } as Pods)
     );
+  });
 
-    TestBed.configureTestingModule({
-      declarations: [DeploymentsDonutComponent, FakeDeploymentsDonutChartComponent],
+  initContext(DeploymentsDonutComponent, HostComponent,
+    {
+      declarations: [FakeDeploymentsDonutChartComponent],
       providers: [{ provide: DeploymentsService, useFactory: () => mockSvc }]
+    },
+    component => {
+      component.mini = false;
+      component.spaceId = 'space';
+      component.applicationId = 'application';
+      component.environment = { name: 'environmentName' } as Environment;
     });
 
-    fixture = TestBed.createComponent(DeploymentsDonutComponent);
-    component = fixture.componentInstance;
-
-    component.mini = false;
-    component.spaceId = 'space';
-    component.applicationId = 'application';
-    component.environment = { name: 'environmentName' } as Environment;
-
-    fixture.detectChanges();
+  it('should use pods data for initial desired replicas', function (this: Context) {
+    expect(this.testedDirective.desiredReplicas).toEqual(2);
   });
 
-  it('should use pods data for initial desired replicas', () => {
-    expect(component.desiredReplicas).toEqual(2);
-  });
-
-  it('should increment desired replicas on scale up by one', () => {
+  it('should increment desired replicas on scale up by one', function (this: Context) {
     let desired = 2;
-    expect(component.desiredReplicas).toBe(desired);
+    expect(this.testedDirective.desiredReplicas).toBe(desired);
 
-    component.scaleUp();
-    fixture.detectChanges();
-    expect(component.desiredReplicas).toBe(desired + 1);
+    this.testedDirective.scaleUp();
+    this.detectChanges();
+    expect(this.testedDirective.desiredReplicas).toBe(desired + 1);
   });
 
-  it('should decrement desired replicas on scale down by one', () => {
+  it('should decrement desired replicas on scale down by one', function (this: Context) {
     let desired = 2;
-    expect(component.desiredReplicas).toBe(desired);
+    expect(this.testedDirective.desiredReplicas).toBe(desired);
 
-    component.scaleDown();
-    fixture.detectChanges();
-    expect(component.desiredReplicas).toBe(desired - 1);
+    this.testedDirective.scaleDown();
+    this.detectChanges();
+    expect(this.testedDirective.desiredReplicas).toBe(desired - 1);
   });
 
-  it('should not decrement desired replicas below zero when scaling down', () => {
+  it('should not decrement desired replicas below zero when scaling down', function (this: Context) {
     let desired = 2;
-    expect(component.desiredReplicas).toBe(desired);
+    expect(this.testedDirective.desiredReplicas).toBe(desired);
 
-    component.scaleDown();
-    fixture.detectChanges();
-    expect(component.desiredReplicas).toBe(desired - 1);
+    this.testedDirective.scaleDown();
+    this.detectChanges();
+    expect(this.testedDirective.desiredReplicas).toBe(desired - 1);
 
-    component.scaleDown();
-    fixture.detectChanges();
-    expect(component.desiredReplicas).toBe(0);
+    this.testedDirective.scaleDown();
+    this.detectChanges();
+    expect(this.testedDirective.desiredReplicas).toBe(0);
+
+    this.testedDirective.scaleDown();
+    this.detectChanges();
+    expect(this.testedDirective.desiredReplicas).toBe(0);
   });
 
-  it('should acquire pods data', (done: DoneFn) => {
-    component.pods.subscribe(pods => {
+  it('should acquire pods data', function (this: Context, done: DoneFn) {
+    this.testedDirective.pods.subscribe(pods => {
       expect(pods).toEqual({
         pods: [['Running', 1], ['Terminating', 1]],
         total: 2
@@ -112,39 +111,39 @@ describe('DeploymentsDonutComponent', () => {
     });
   });
 
-  it('should call scalePods when scaling up', () => {
-    de = fixture.debugElement.query(By.css('#scaleUp'));
-    el = de.nativeElement;
+  it('should call scalePods when scaling up', function (this: Context) {
+    let de = this.fixture.debugElement.query(By.css('#scaleUp'));
+    let el = de.nativeElement;
 
     el.click();
-    component.debounceScale.flush();
+    this.testedDirective.debounceScale.flush();
     expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 3);
   });
 
-  it('should call scalePods when scaling down', () => {
-    de = fixture.debugElement.query(By.css('#scaleDown'));
-    el = de.nativeElement;
+  it('should call scalePods when scaling down', function (this: Context) {
+    let de = this.fixture.debugElement.query(By.css('#scaleDown'));
+    let el = de.nativeElement;
 
     el.click();
-    component.debounceScale.flush();
+    this.testedDirective.debounceScale.flush();
     expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 1);
   });
 
-  it('should not call scalePods when scaling below 0', () => {
-    de = fixture.debugElement.query(By.css('#scaleDown'));
-    el = de.nativeElement;
+  it('should not call scalePods when scaling below 0', function (this: Context) {
+    let de = this.fixture.debugElement.query(By.css('#scaleDown'));
+    let el = de.nativeElement;
 
     el.click();
-    component.debounceScale.flush();
+    this.testedDirective.debounceScale.flush();
     expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 1);
 
     el.click();
-    component.debounceScale.flush();
+    this.testedDirective.debounceScale.flush();
     expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 0);
 
 
     el.click();
-    component.debounceScale.flush();
+    this.testedDirective.debounceScale.flush();
     expect(mockSvc.scalePods).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
@@ -1,22 +1,26 @@
-import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
 import {
   Component,
-  DebugElement,
   Input
 } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
 import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { Spaces } from 'ngx-fabric8-wit';
 
 import { DeploymentsResourceUsageComponent } from './deployments-resource-usage.component';
 import { Environment } from '../models/environment';
-import { Stat } from '../models/stat';
+
+@Component({
+  template: '<deployments-resource-usage></deployments-resource-usage>'
+})
+class HostComponent { }
 
 @Component({
   selector: 'resource-card',
@@ -28,34 +32,27 @@ class FakeResourceCardComponent {
 }
 
 describe('DeploymentsResourceUsageComponent', () => {
+  type Context = TestContext<DeploymentsResourceUsageComponent, HostComponent>;
 
-  let component: DeploymentsResourceUsageComponent;
-  let fixture: ComponentFixture<DeploymentsResourceUsageComponent>;
-  let mockEnvironments: Observable<Environment[]>;
+  let spaceIdObservable = Observable.of('spaceId');
   let mockEnvironmentData = [
     { name: 'envId1'} as Environment,
     { name: 'envId2'} as Environment
   ];
-  let spaceIdObservable = Observable.of('spaceId');
+  let mockEnvironments = Observable.of(mockEnvironmentData);
 
-  beforeEach(() => {
-    mockEnvironments = Observable.of(mockEnvironmentData);
-
-    TestBed.configureTestingModule({
-      imports: [ CollapseModule.forRoot() ],
-      declarations: [ DeploymentsResourceUsageComponent, FakeResourceCardComponent ],
+  initContext(DeploymentsResourceUsageComponent, HostComponent,
+    {
+      imports: [CollapseModule.forRoot()],
+      declarations: [FakeResourceCardComponent]
+    },
+    component => {
+      component.environments = mockEnvironments;
+      component.spaceId = spaceIdObservable;
     });
 
-    fixture = TestBed.createComponent(DeploymentsResourceUsageComponent);
-    component = fixture.componentInstance;
-    component.environments = mockEnvironments;
-    component.spaceId = spaceIdObservable;
-
-    fixture.detectChanges();
-  });
-
-  it('should create children components with proper environment objects', () => {
-    let arrayOfComponents = fixture.debugElement.queryAll(By.directive(FakeResourceCardComponent));
+  it('should create children components with proper environment objects', function (this: Context) {
+    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeResourceCardComponent));
     expect(arrayOfComponents.length).toEqual(mockEnvironmentData.length);
 
     mockEnvironmentData.forEach((envData, index) => {

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.ts
@@ -1,6 +1,6 @@
 import {
   Component,
-  Input,
+  Input
 } from '@angular/core';
 
 import { Environment } from '../models/environment';

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -10,6 +10,8 @@ import {
 
 import { By } from '@angular/platform-browser';
 
+import { createMock } from 'testing/mock';
+
 import { Observable } from 'rxjs';
 
 import { DeploymentsService } from '../services/deployments.service';
@@ -36,38 +38,19 @@ describe('ResourceCardComponent', () => {
   let component: ResourceCardComponent;
   let fixture: ComponentFixture<ResourceCardComponent>;
   let mockResourceTitle = 'resource title';
-  let mockSvc: DeploymentsService;
+  let mockSvc: jasmine.SpyObj<DeploymentsService>;
   let cpuStatMock = Observable.of({ used: 1, quota: 2 } as CpuStat);
   let memoryStatMock = Observable.of({ used: 3, quota: 4, units: 'GB' } as MemoryStat);
 
   beforeEach(() => {
-    mockSvc = {
-      getApplications: () => Observable.of(['foo-app', 'bar-app']),
-      getEnvironments: () => Observable.of([
-        { name: 'stage' } as Environment,
-        { name: 'prod' } as Environment
-      ]),
-      getPods: () => { throw 'NotImplemented'; },
-      scalePods: (spaceId: string, envId: string, appId: string) => { throw 'Not Implemented'; },
-      getVersion: () => { throw 'NotImplemented'; },
-      getCpuStat: (spaceId: string, envId: string) => cpuStatMock,
-      getMemoryStat: (spaceId: string, envId: string) => memoryStatMock,
-      getLogsUrl: () => { throw 'Not Implemented'; },
-      getConsoleUrl: () => { throw 'Not Implemented'; },
-      getAppUrl: () => { throw 'Not Implemented'; },
-      deleteApplication: () => { throw 'Not Implemented'; }
-    };
-
-    spyOn(mockSvc, 'getApplications').and.callThrough();
-    spyOn(mockSvc, 'getEnvironments').and.callThrough();
-    spyOn(mockSvc, 'scalePods').and.callThrough();
-    spyOn(mockSvc, 'getVersion').and.callThrough();
-    spyOn(mockSvc, 'getCpuStat').and.callThrough();
-    spyOn(mockSvc, 'getMemoryStat').and.callThrough();
-    spyOn(mockSvc, 'getLogsUrl').and.callThrough();
-    spyOn(mockSvc, 'getConsoleUrl').and.callThrough();
-    spyOn(mockSvc, 'getAppUrl').and.callThrough();
-    spyOn(mockSvc, 'deleteApplication').and.callThrough();
+    mockSvc = createMock(DeploymentsService);
+    mockSvc.getApplications.and.returnValue(Observable.of(['foo-app', 'bar-app']));
+    mockSvc.getEnvironments.and.returnValue(Observable.of([
+      { name: 'stage' } as Environment,
+      { name: 'prod' } as Environment
+    ]));
+    mockSvc.getCpuStat.and.returnValue(cpuStatMock);
+    mockSvc.getMemoryStat.and.returnValue(memoryStatMock);
 
     TestBed.configureTestingModule({
       declarations: [

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -1,157 +1,120 @@
-import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
-
+import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
+
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
 
 import { Observable } from 'rxjs';
-
-import { CollapseModule } from 'ngx-bootstrap/collapse';
 
 import { UtilizationBarComponent } from './utilization-bar.component';
 import { Stat } from '../models/stat';
 
+@Component({
+  template: '<utilization-bar></utilization-bar>'
+})
+class HostComponent { }
+
 describe('UtilizationBarComponent', () => {
+  type Context = TestContext<UtilizationBarComponent, HostComponent>;
+
   describe('with valid Stat', () => {
-
-    let component: UtilizationBarComponent;
-    let fixture: ComponentFixture<UtilizationBarComponent>;
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [CollapseModule.forRoot()],
-        declarations: [UtilizationBarComponent]
-      });
-
-      fixture = TestBed.createComponent(UtilizationBarComponent);
-      component = fixture.componentInstance;
-
+    initContext(UtilizationBarComponent, HostComponent, {}, component => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
       component.stat = Observable.of({ used: 1, quota: 4 } as Stat);
-
-      fixture.detectChanges();
     });
 
-    it('should have proper stat fields set', () => {
-      expect(component.used).toEqual(1);
-      expect(component.total).toEqual(4);
-      expect(component.usedPercent).toEqual(25);
-      expect(component.unusedPercent).toEqual(75);
+    it('should have proper stat fields set', function (this: Context) {
+      expect(this.testedDirective.used).toEqual(1);
+      expect(this.testedDirective.total).toEqual(4);
+      expect(this.testedDirective.usedPercent).toEqual(25);
+      expect(this.testedDirective.unusedPercent).toEqual(75);
     });
 
-    it('should have a properly set title', () => {
-      let de = fixture.debugElement.query(By.css('.progress-description'));
+    it('should have a properly set title', function (this: Context) {
+      let de = this.fixture.debugElement.query(By.css('.progress-description'));
       let el = de.nativeElement;
       expect(el.textContent.trim()).toEqual('someTitle (someUnit)');
     });
 
-    it('should have properly set card label information', () => {
-      let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
+    it('should have properly set card label information', function (this: Context) {
+      let de = this.fixture.debugElement.query(By.css('#resourceCardLabel'));
       let el = de.nativeElement;
       expect(el.textContent.trim()).toEqual('1 of 4');
     });
 
-    it('should set state to okay when under 75% used', () => {
-      expect(component.currentState).toEqual(['utilization-okay']);
+    it('should set state to okay when under 75% used', function (this: Context) {
+      expect(this.testedDirective.currentState).toEqual(['utilization-okay']);
 
-      let de = fixture.debugElement.query(By.css('.utilization-okay'));
+      let de = this.fixture.debugElement.query(By.css('.utilization-okay'));
       expect(de).toBeTruthy();
 
-      let de2 = fixture.debugElement.query(By.css('.utilization-warning'));
+      let de2 = this.fixture.debugElement.query(By.css('.utilization-warning'));
       expect(de2).toBeFalsy();
     });
   });
 
   describe('with Warning level Stat', () => {
-
-    let component: UtilizationBarComponent;
-    let fixture: ComponentFixture<UtilizationBarComponent>;
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [CollapseModule.forRoot()],
-        declarations: [UtilizationBarComponent]
-      });
-
-      fixture = TestBed.createComponent(UtilizationBarComponent);
-      component = fixture.componentInstance;
-
+    initContext(UtilizationBarComponent, HostComponent, {}, component => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
       component.stat = Observable.of({ used: 3, quota: 4 } as Stat);
-
-      fixture.detectChanges();
     });
 
-    it('should have proper stat fields set', () => {
-      expect(component.used).toEqual(3);
-      expect(component.total).toEqual(4);
-      expect(component.usedPercent).toEqual(75);
-      expect(component.unusedPercent).toEqual(25);
+    it('should have proper stat fields set', function (this: Context) {
+      expect(this.testedDirective.used).toEqual(3);
+      expect(this.testedDirective.total).toEqual(4);
+      expect(this.testedDirective.usedPercent).toEqual(75);
+      expect(this.testedDirective.unusedPercent).toEqual(25);
     });
 
-    it('should have a properly set title', () => {
-      let de = fixture.debugElement.query(By.css('.progress-description'));
+    it('should have a properly set title', function (this: Context) {
+      let de = this.fixture.debugElement.query(By.css('.progress-description'));
       let el = de.nativeElement;
       expect(el.textContent.trim()).toEqual('someTitle (someUnit)');
     });
 
-    it('should have properly set card label information', () => {
-      let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
+    it('should have properly set card label information', function (this: Context) {
+      let de = this.fixture.debugElement.query(By.css('#resourceCardLabel'));
       let el = de.nativeElement;
       expect(el.textContent.trim()).toEqual('3 of 4');
     });
 
-    it('should set state to warning to false when 75% or higher used', () => {
-      expect(component.currentState).toEqual(['utilization-warning']);
+    it('should set state to warning to false when 75% or higher used', function (this: Context) {
+      expect(this.testedDirective.currentState).toEqual(['utilization-warning']);
 
-      let de = fixture.debugElement.query(By.css('.utilization-okay'));
+      let de = this.fixture.debugElement.query(By.css('.utilization-okay'));
       expect(de).toBeFalsy();
 
-      let de2 = fixture.debugElement.query(By.css('.utilization-warning'));
+      let de2 = this.fixture.debugElement.query(By.css('.utilization-warning'));
       expect(de2).toBeTruthy();
     });
   });
 
   describe('with invalid Stat', () => {
-
-    let component: UtilizationBarComponent;
-    let fixture: ComponentFixture<UtilizationBarComponent>;
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [CollapseModule.forRoot()],
-        declarations: [UtilizationBarComponent]
-      });
-
-      fixture = TestBed.createComponent(UtilizationBarComponent);
-      component = fixture.componentInstance;
-
+    initContext(UtilizationBarComponent, HostComponent, {}, component => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
       component.stat = Observable.of({ used: 2, quota: 0 } as Stat);
-
-      fixture.detectChanges();
     });
 
-    it('should have backup values in case it has a zero total', () => {
-      expect(component.used).toEqual(2);
-      expect(component.total).toEqual(0);
-      expect(component.usedPercent).toEqual(0);
-      expect(component.unusedPercent).toEqual(100);
+    it('should have backup values in case it has a zero total', function (this: Context) {
+      expect(this.testedDirective.used).toEqual(2);
+      expect(this.testedDirective.total).toEqual(0);
+      expect(this.testedDirective.usedPercent).toEqual(0);
+      expect(this.testedDirective.unusedPercent).toEqual(100);
     });
 
-    it('should have a properly set title', () => {
-      let de = fixture.debugElement.query(By.css('.progress-description'));
+    it('should have a properly set title', function (this: Context) {
+      let de = this.fixture.debugElement.query(By.css('.progress-description'));
       let el = de.nativeElement;
       expect(el.textContent.trim()).toEqual('someTitle (someUnit)');
     });
 
-    it('should have properly set card label information', () => {
-      let de = fixture.debugElement.query(By.css('#resourceCardLabel'));
+    it('should have properly set card label information', function (this: Context) {
+      let de = this.fixture.debugElement.query(By.css('#resourceCardLabel'));
       let el = de.nativeElement;
       expect(el.textContent.trim()).toEqual('2 of 0');
     });

--- a/src/testing/test-context.ts
+++ b/src/testing/test-context.ts
@@ -42,7 +42,8 @@ export class TestContext<T, H> {
 
 }
 
-export function initContext<T, H>(testedType: Type<T>, hostType: Type<H>, moduleMetadata: TestModuleMetadata = {}) {
+export function initContext<T, H>(testedType: Type<T>, hostType: Type<H>, moduleMetadata: TestModuleMetadata = {},
+  customizer?: (t: T) => void) {
   beforeEach(function() {
     /*
      * Jasmine creates plain objects and modifying their prototype is definitely a bad idea.
@@ -62,7 +63,6 @@ export function initContext<T, H>(testedType: Type<T>, hostType: Type<H>, module
 
   beforeEach(function(this: TestContext<T, H>) {
     this.fixture = TestBed.createComponent(hostType);
-    this.fixture.detectChanges();
     this.hostComponent = this.fixture.componentInstance;
     const testedDebugElement = this.fixture.debugElement.query(By.directive(testedType));
     if (!testedDebugElement) {
@@ -75,6 +75,11 @@ export function initContext<T, H>(testedType: Type<T>, hostType: Type<H>, module
     this.tested = testedDebugElement;
     this.testedDirective = testedDebugElement.injector.get(testedType);
     this.testedElement = testedDebugElement.nativeElement;
+
+    if (customizer) {
+      customizer(this.testedDirective);
+    }
+    this.fixture.detectChanges();
   });
 
   afterEach(function(this: TestContext<T, H>) {


### PR DESCRIPTION
This PR uses the createMock and TestContext testing utils and cleans up the specs in the Deployments area. There was a lot of boilerplate and some unused/unnecessary imports - probably copy-pasted in to save time on the boilerplate. Hopefully, using these utils to minimize the amount of test boilerplate will lead to higher-quality and larger quantity (coverage) of tests in the future.

I've also added one additional optional argument to the initContext function, which allows for tests to assign component properties before the first `detectChanges` call (which is when ngOnInit is first invoked). Without this it seems very difficult to get component `@Input` values assigned and used before the lifecycle hooks start.