### PR TITLE
feat(deployments): display toast notification on Delete success/failure

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -24,6 +24,8 @@ import {
 } from 'ngx-bootstrap/dropdown';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 
+import { NotificationsService } from 'app/shared/notifications.service';
+
 import { DeploymentCardComponent } from './deployment-card.component';
 import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
@@ -58,6 +60,7 @@ describe('DeploymentCardComponent', () => {
   let component: DeploymentCardComponent;
   let fixture: ComponentFixture<DeploymentCardComponent>;
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
+  let notifications: any;
 
   beforeEach(fakeAsync(() => {
     mockSvc = createMock(DeploymentsService);
@@ -69,10 +72,16 @@ describe('DeploymentCardComponent', () => {
     mockSvc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
     mockSvc.deleteApplication.and.returnValue(Observable.of('mockDeletedMessage'));
 
+    notifications = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
+
     TestBed.configureTestingModule({
       imports: [ BsDropdownModule.forRoot(), CollapseModule.forRoot(), ChartModule ],
       declarations: [ DeploymentCardComponent, FakeDeploymentsDonutComponent, FakeDeploymentGraphLabelComponent ],
-      providers: [ BsDropdownConfig, { provide: DeploymentsService, useValue: mockSvc } ]
+      providers: [
+        BsDropdownConfig,
+        { provide: NotificationsService, useValue: notifications },
+        { provide: DeploymentsService, useValue: mockSvc }
+      ]
     });
 
     fixture = TestBed.createComponent(DeploymentCardComponent);
@@ -214,6 +223,7 @@ describe('DeploymentCardComponent', () => {
       fixture.detectChanges();
 
       expect(mockSvc.deleteApplication).toHaveBeenCalled();
+      expect(notifications.message).toHaveBeenCalled();
     }));
   });
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -11,6 +11,13 @@ import {
 } from 'rxjs';
 import { uniqueId } from 'lodash';
 
+import {
+  Notification,
+  NotificationType
+} from 'ngx-base';
+
+import { NotificationsService } from 'app/shared/notifications.service';
+
 import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
 import { CpuStat } from '../models/cpu-stat';
@@ -73,7 +80,8 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   subscriptions: Array<Subscription> = [];
 
   constructor(
-    private deploymentsService: DeploymentsService
+    private deploymentsService: DeploymentsService,
+    private notifications: NotificationsService
   ) { }
 
   ngOnDestroy(): void {
@@ -123,7 +131,20 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   delete(): void {
     this.subscriptions.push(
       this.deploymentsService.deleteApplication(this.spaceId, this.applicationId, this.environment.name)
-        .subscribe(alert)
+        .subscribe(
+          success => {
+            this.notifications.message({
+              type: NotificationType.SUCCESS,
+              message: success
+            });
+          },
+          error => {
+            this.notifications.message({
+              type: NotificationType.INFO,
+              message: error
+            });
+          }
+        )
     );
   }
 }

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -140,7 +140,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
           },
           error => {
             this.notifications.message({
-              type: NotificationType.INFO,
+              type: NotificationType.WARNING,
               message: error
             });
           }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -73,7 +73,11 @@ export class DeploymentsService {
   }
 
   deleteApplication(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
-    return Observable.of(`Deleted ${applicationId} in ${spaceId} (${environmentName})`);
+    if (Math.random() > 0.5) {
+      return Observable.of(`Deleted ${applicationId} in ${spaceId} (${environmentName})`);
+    } else {
+      return Observable.throw(`Failed to delete ${applicationId} in ${spaceId} (${environmentName})`);
+    }
   }
 
 }


### PR DESCRIPTION
closes https://github.com/openshiftio/openshift.io/issues/1728

note: doesn't use createMock test util because the tests error with `this._stream` being undefined - I think the util doesn't work well with property getters. I'll look at that separately later on. This test uses a "shallow" mock instead, but the end result is the same if you know exactly which function(s) will and should be used.