### PR TITLE
Add icon statuses to deployment charts

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -3,7 +3,7 @@
     <div class="card-pf-body">
       <div class="row mini-card-content">
         <div class="col-sm-2">
-          <span class="pficon pficon-ok fa-lg" tooltip="Everything looks okay" placement="top"></span>
+          <deployment-status-icon [cpuDataStream]='cpuStat'></deployment-status-icon>
         </div>
         <div class="col-sm-7">
           <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="true"></deployments-donut>

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -33,6 +33,7 @@ import { NotificationsService } from 'app/shared/notifications.service';
 import { DeploymentCardComponent } from './deployment-card.component';
 import { DeploymentsService } from '../services/deployments.service';
 import { Environment } from '../models/environment';
+import { CpuStat } from '../models/cpu-stat';
 
 // Makes patternfly charts available
 import { ChartModule } from 'patternfly-ng';
@@ -57,6 +58,14 @@ class FakeDeploymentGraphLabelComponent {
   @Input() dataMeasure: any;
   @Input() value: any;
   @Input() valueUpperBound: any;
+}
+
+@Component({
+  selector: 'deployment-status-icon',
+  template: ''
+})
+class FakeDeploymentStatusIconComponent {
+  @Input() cpuDataStream: Observable<CpuStat>;
 }
 
 @Component({
@@ -94,13 +103,14 @@ describe('DeploymentCardComponent', () => {
     notifications = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
 
     TestBed.configureTestingModule({
-      imports: [ BsDropdownModule.forRoot(), CollapseModule.forRoot(), ChartModule ],
       declarations: [
         DeploymentCardComponent,
         FakeDeploymentsDonutComponent,
         FakeDeploymentGraphLabelComponent,
-        FakeDeploymentDetailsComponent
+        FakeDeploymentDetailsComponent,
+        FakeDeploymentStatusIconComponent
       ],
+      imports: [ BsDropdownModule.forRoot(), CollapseModule.forRoot(), ChartModule ],
       providers: [
         BsDropdownConfig,
         { provide: NotificationsService, useValue: notifications },

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.html
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.html
@@ -1,1 +1,1 @@
-<span [ngClass]="[icon, 'pficon', 'fa-lg']" title="{{ toolTip }}" placement="top"></span>
+<span [ngClass]="[iconClass, 'pficon', 'fa-lg']" title="{{ toolTip }}" placement="top"></span>

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.html
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.html
@@ -1,0 +1,1 @@
+<span [ngClass]="[icon, 'pficon', 'fa-lg']" title="{{ toolTip }}" placement="top"></span>

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.less
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.less
@@ -1,0 +1,1 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.spec.ts
@@ -10,9 +10,11 @@ import {
   Input
 } from '@angular/core';
 
+import { initContext, TestContext } from '../../../../../testing/test-context';
+
 import { Subject, Observable } from 'rxjs';
 import { DeploymentStatusIconComponent } from './deployment-status-icon.component';
-import { BehaviorSubject } from "rxjs/BehaviorSubject";
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { CpuStat } from '../models/cpu-stat';
 
@@ -21,29 +23,27 @@ const ICON_WARN = 'pficon-warning-triangle-o';
 const ICON_ERR = 'pficon-error-circle-o';
 const MSG_OK = 'Everything is ok.';
 
+@Component({
+  template: '<deployment-status-icon></deployment-status-icon>'
+})
+class HostComponent { }
+
 describe('DeploymentStatusIconComponent', () => {
+  type Context = TestContext<DeploymentStatusIconComponent, HostComponent>;
 
   let component: DeploymentStatusIconComponent;
   let fixture: ComponentFixture<DeploymentStatusIconComponent>;
   let stat: CpuStat;
   let mockCpuData: Subject<CpuStat> = new BehaviorSubject({ used: 1, quota: 5 } as CpuStat);
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [
-        DeploymentStatusIconComponent
-      ]
-    });
+  initContext(DeploymentStatusIconComponent, HostComponent,
+    { declarations: [DeploymentStatusIconComponent] },
+    (component) => {component.cpuDataStream = mockCpuData;}
+  );
 
-    fixture = TestBed.createComponent(DeploymentStatusIconComponent);
-    component = fixture.componentInstance;
-    component.cpuDataStream = mockCpuData;
-    fixture.detectChanges()
-  });
-
-  it('should set the button\'s initial value to ok', () => {
-    expect(component.icon).toBe('pficon-ok');
-    expect(component.toolTip).toBe('Everything is ok.');
+  it('should set the button\'s initial value to ok', function (this: Context) {
+    expect(this.testedDirective.iconClass).toBe('pficon-ok');
+    expect(this.testedDirective.toolTip).toBe('Everything is ok.');
   });
 
   it('should change the button\'s value to warning if capacity changes', function (this: Context) {

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.spec.ts
@@ -1,0 +1,62 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import { By } from '@angular/platform-browser';
+import {
+  Component,
+  DebugElement,
+  Input
+} from '@angular/core';
+
+import { Subject, Observable } from 'rxjs';
+import { DeploymentStatusIconComponent } from './deployment-status-icon.component';
+import { BehaviorSubject } from "rxjs/BehaviorSubject";
+
+import { CpuStat } from '../models/cpu-stat';
+
+const ICON_OK = 'pficon-ok';
+const ICON_WARN = 'pficon-warning-triangle-o';
+const ICON_ERR = 'pficon-error-circle-o';
+const MSG_OK = 'Everything is ok.';
+
+describe('DeploymentStatusIconComponent', () => {
+
+  let component: DeploymentStatusIconComponent;
+  let fixture: ComponentFixture<DeploymentStatusIconComponent>;
+  let stat: CpuStat;
+  let mockCpuData: Subject<CpuStat> = new BehaviorSubject({ used: 1, quota: 5 } as CpuStat);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        DeploymentStatusIconComponent
+      ]
+    });
+
+    fixture = TestBed.createComponent(DeploymentStatusIconComponent);
+    component = fixture.componentInstance;
+    component.cpuDataStream = mockCpuData;
+    fixture.detectChanges()
+  });
+
+  it('should set the button\'s initial value to ok', () => {
+    expect(component.icon).toBe('pficon-ok');
+    expect(component.toolTip).toBe('Everything is ok.');
+  });
+
+  it('should change the button\'s value to warning if capacity changes', function (this: Context) {
+    mockCpuData.next({ used: 4, quota: 5 } as CpuStat);
+    this.detectChanges();
+    expect(this.testedDirective.iconClass).toBe(ICON_WARN);
+    expect(this.testedDirective.toolTip).toBe('CPU usage is approaching or at capacity.');
+  });
+
+  it('should change the button\s value to error if capacity is exceeded', function (this: Context) {
+    mockCpuData.next({ used: 6, quota: 5 } as CpuStat);
+    this.detectChanges();
+    expect(this.testedDirective.iconClass).toBe(ICON_ERR);
+    expect(this.testedDirective.toolTip).toBe('CPU usage has exceeded capacity.');
+  });
+});

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.ts
@@ -1,0 +1,60 @@
+import {
+  Component,
+  Input,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
+
+import {
+  Observable,
+  Subscription
+} from 'rxjs';
+
+import { CpuStat } from '../models/cpu-stat';
+
+const ICON_OK = 'pficon-ok';
+const ICON_WARN = 'pficon-warning-triangle-o';
+const ICON_ERR = 'pficon-error-circle-o';
+const MSG_OK = 'Everything is ok.';
+const STAT_THRESHOLD = .6;
+@Component({
+  selector: 'deployment-status-icon',
+  templateUrl: 'deployment-status-icon.component.html',
+  styleUrls: ['./deployment-status-icon.component.less']
+})
+export class DeploymentStatusIconComponent implements OnDestroy, OnInit {
+  @Input() cpuDataStream: Observable<CpuStat>;
+
+  icon: String;
+  toolTip: String;
+  subscriptions: Array<Subscription> = [];
+
+  constructor() {
+    this.icon = ICON_OK;
+    this.toolTip = MSG_OK;
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
+
+  ngOnInit(): void {
+    this.subscriptions.push(this.cpuDataStream.subscribe((stat) => {
+      this.changeStatus(stat);
+    }));
+  }
+
+  changeStatus(stat: CpuStat) {
+    this.icon = ICON_OK;
+    this.toolTip = MSG_OK;
+    if (stat.used / stat.quota > STAT_THRESHOLD) {
+      this.iconClass = ICON_WARN;
+      this.toolTip = 'CPU usage is approaching or at capacity.';
+    }
+
+    if (stat.used > stat.quota) {
+      this.iconClass = ICON_ERR;
+      this.toolTip = 'CPU usage has exceeded capacity.';
+    }
+  }
+}

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.ts
@@ -25,12 +25,12 @@ const STAT_THRESHOLD = .6;
 export class DeploymentStatusIconComponent implements OnDestroy, OnInit {
   @Input() cpuDataStream: Observable<CpuStat>;
 
-  icon: String;
+  iconClass: String;
   toolTip: String;
   subscriptions: Array<Subscription> = [];
 
   constructor() {
-    this.icon = ICON_OK;
+    this.iconClass = ICON_OK;
     this.toolTip = MSG_OK;
   }
 
@@ -45,7 +45,7 @@ export class DeploymentStatusIconComponent implements OnDestroy, OnInit {
   }
 
   changeStatus(stat: CpuStat) {
-    this.icon = ICON_OK;
+    this.iconClass = ICON_OK;
     this.toolTip = MSG_OK;
     if (stat.used / stat.quota > STAT_THRESHOLD) {
       this.iconClass = ICON_WARN;

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -14,6 +14,7 @@ import { DeploymentsResourceUsageComponent } from '../deployments/resource-usage
 import { DeploymentCardContainerComponent } from '../deployments/apps/deployment-card-container.component';
 import { DeploymentCardComponent } from '../deployments/apps/deployment-card.component';
 import { DeploymentGraphLabelComponent } from '../deployments/apps/deployment-graph-label.component';
+import { DeploymentStatusIconComponent } from '../deployments/apps/deployment-status-icon.component';
 import { DeploymentsDonutComponent } from './deployments-donut/deployments-donut.component';
 import {
   DeploymentsDonutChartComponent
@@ -44,6 +45,7 @@ import { ChartModule, ToolbarModule } from 'patternfly-ng';
     DeploymentCardContainerComponent,
     DeploymentCardComponent,
     DeploymentGraphLabelComponent,
+    DeploymentStatusIconComponent,
     DeploymentsAppsComponent,
     DeploymentDetailsComponent,
     DeploymentsResourceUsageComponent,


### PR DESCRIPTION
This patch adds a basic functionality providing changing icon statuses (and tooltips) to our deployment charts. Currently only mock CPU data triggers the changes in what is meant to be a first step towards a more general solution. 