### PR TITLE
fix(menus): display deployments tab in all environments

### DIFF
--- a/src/app/layout/header/menus.service.ts
+++ b/src/app/layout/header/menus.service.ts
@@ -47,8 +47,32 @@ export class MenusService {
                 path: 'board'
               }
             ]
-          },
-          this.getCreateMenuItems()
+          }, {
+            name: 'Create',
+            path: 'create',
+            menus: [
+              {
+                name: 'Codebases',
+                path: ''
+              },
+              {
+                name: 'Pipelines',
+                path: 'pipelines'
+              },
+              {
+                name: 'Applications',
+                path: 'apps'
+              },
+              {
+                name: 'Environments',
+                path: 'environments'
+              },
+              {
+                name: 'Deployments',
+                path: 'deployments'
+              }
+            ]
+          }
         ]
       ]
     ]);
@@ -87,38 +111,5 @@ export class MenusService {
       res = res.replace(/\/*$/, '');
     }
     return res;
-  }
-
-  private getCreateMenuItems(): MenuItem {
-    const displayDeployments = (ENV === 'development');
-    let menus = [
-      {
-        name: 'Codebases',
-        path: ''
-      },
-      {
-        name: 'Pipelines',
-        path: 'pipelines'
-      },
-      {
-        name: 'Applications',
-        path: 'apps'
-      },
-      {
-        name: 'Environments',
-        path: 'environments'
-      }
-    ];
-    if (displayDeployments) {
-      menus.push({
-        name: 'Deployments',
-        path: 'deployments'
-      });
-    }
-    return {
-      name: 'Create',
-      path: 'create',
-      menus: menus
-    };
   }
 }


### PR DESCRIPTION
This makes the deployments tab visible in all environments (production, testing, dev).

Addresses https://github.com/openshiftio/openshift.io/issues/1751

Personally I don't mind waiting for the http integration before merging this. I still can't wrap my head around users seeing an experimental page with mock data that doesn't relate to anything in their project.