### PR TITLE
fix(deployments): destroy sparkline charts if collapsed, save memory

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -1,22 +1,24 @@
 <div [collapse]="collapsed">
-  <hr>
-  <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="false"></deployments-donut>
+  <ng-container *ngIf="!collapsed">
+    <hr>
+    <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="false"></deployments-donut>
 
-  <div class="deployment-chart">
-    <div class="chart-column">
-      <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
+    <div class="deployment-chart">
+      <div class="chart-column">
+        <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
+      </div>
+      <div class="chart-column">
+        <deployment-graph-label type="CPU" dataMeasure="Cores" [value]="cpuVal" [valueUpperBound]="cpuMax"></deployment-graph-label>
+      </div>
     </div>
-    <div class="chart-column">
-      <deployment-graph-label type="CPU" dataMeasure="Cores" [value]="cpuVal" [valueUpperBound]="cpuMax"></deployment-graph-label>
-    </div>
-  </div>
 
-  <div class="deployment-chart">
-    <div class="chart-column">
-      <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
+    <div class="deployment-chart">
+      <div class="chart-column">
+        <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
+      </div>
+      <div class="chart-column">
+        <deployment-graph-label type="Memory" [dataMeasure]="memUnits" [value]="memVal" [valueUpperBound]="memMax"></deployment-graph-label>
+      </div>
     </div>
-    <div class="chart-column">
-      <deployment-graph-label type="Memory" [dataMeasure]="memUnits" [value]="memVal" [valueUpperBound]="memMax"></deployment-graph-label>
-    </div>
-  </div>
+  </ng-container>
 </div>


### PR DESCRIPTION
From https://github.com/openshiftio/openshift.io/issues/1516 it was found that using ngIf will contribute significantly towards stopping memory from being used (which is the primary goal of this PR). It also helps with https://github.com/openshiftio/openshift.io/issues/1709 as it causes the charts to be resized immediately when expanding the card.