### PR TITLE
fix(codebases): show correct results when filtering codebases

### DIFF
--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.spec.ts
@@ -1,0 +1,64 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output
+} from '@angular/core';
+
+import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+  FilterEvent,
+  SortEvent
+} from 'patternfly-ng';
+
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { CodebasesToolbarComponent } from './codebases-toolbar.component';
+
+@Component({
+  template: `<codebases-toolbar
+  (onFilterChange)="filterChange($event)"
+  (onSortChange)="sortChange($event)"
+  [resultsCount]="resultsCount">
+  </codebases-toolbar>`
+})
+class HostComponent {
+  public resultsCount = 0;
+  public filterChange($event : FilterEvent) { }
+  public sortChange($event : SortEvent) { }
+}
+
+@Component({
+  selector: 'pfng-toolbar',
+  template: ''
+})
+class FakePfngToolbarComponent {
+  @Input() config: any;
+  @Input() viewTemplate: any;
+  @Output() onFilterChange = new EventEmitter<FilterEvent>();
+  @Output() onSortChange = new EventEmitter<SortEvent>();
+}
+
+describe('CodebasesToolbarComponent', () => {
+  type Context = TestContext<CodebasesToolbarComponent, HostComponent>;
+  initContext(CodebasesToolbarComponent, HostComponent,
+  {
+    declarations: [FakePfngToolbarComponent],
+    imports: [RouterTestingModule]
+  });
+
+  it('should update filterConfig resultsCount', function (this: Context) {
+    let initialCount = 0;
+    expect(this.testedDirective.filterConfig.resultsCount).toBe(initialCount);
+
+    let nextCount = 5;
+    this.hostComponent.resultsCount = nextCount;
+    this.detectChanges();
+
+    expect(this.testedDirective.filterConfig.resultsCount).toBe(nextCount);
+  });
+});

--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
@@ -2,8 +2,10 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   TemplateRef,
   ViewChild,
   ViewEncapsulation
@@ -24,7 +26,7 @@ import {
   templateUrl: './codebases-toolbar.component.html',
   styleUrls: ['./codebases-toolbar.component.less']
 })
-export class CodebasesToolbarComponent implements OnInit {
+export class CodebasesToolbarComponent implements OnChanges, OnInit {
   @Input() resultsCount: number = 0;
 
   @Output('onFilterChange') onFilterChange = new EventEmitter();
@@ -38,6 +40,12 @@ export class CodebasesToolbarComponent implements OnInit {
   toolbarConfig: ToolbarConfig;
 
   constructor() {
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.resultsCount && this.filterConfig) {
+      this.filterConfig.resultsCount = changes.resultsCount.currentValue;
+    }
   }
 
   // Initialization
@@ -61,7 +69,7 @@ export class CodebasesToolbarComponent implements OnInit {
         type: 'text'
       }] as FilterField[],
       appliedFilters: [],
-      resultsCount: this.resultsCount,
+      resultsCount: 0,
       selectedCount: 0,
       totalCount: 0
     } as FilterConfig;


### PR DESCRIPTION
This makes the results count show the correct number when users filter codebases via the toolbar. A test is added to verify this.

This addresses https://github.com/openshiftio/openshift.io/issues/1346

The image below shows the fixed version which has a correct Results count.

![codebase-fix](https://user-images.githubusercontent.com/5430520/34576282-5cd124b4-f14b-11e7-8f27-dd4c2a67491b.png)

