### PR TITLE
feat(deployments): add toolbar to sort and filter deployment cards

### DIFF
--- a/src/app/space/create/deployments/apps/deployments-apps.component.html
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.html
@@ -1,3 +1,6 @@
+<deployments-toolbar (onFilterChange)="filterChange($event)" (onSortChange)="sortChange($event)" [resultsCount]="resultsCount">
+</deployments-toolbar>
+
 <div class="cards-pf">
   <div class="row row-cards-pf">
     <div class="col-xs-12 col-sm-4 col-md-2">
@@ -24,6 +27,6 @@
   </div>
 </div>
 
-<div *ngFor="let application of applications | async">
+<div *ngFor="let application of filteredApplicationsList">
   <deployment-card-container [spaceId]="spaceId | async" [application]="application" [environments]="environments"></deployment-card-container>
 </div>

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -6,8 +6,15 @@ import {
 import { By } from '@angular/platform-browser';
 import {
   Component,
-  Input
+  EventEmitter,
+  Input,
+  Output
 } from '@angular/core';
+
+import {
+  FilterEvent,
+  SortEvent
+} from 'patternfly-ng'
 
 import { Observable } from 'rxjs';
 
@@ -29,6 +36,16 @@ class FakeDeploymentCardContainerComponent {
   @Input() application: string;
 }
 
+@Component({
+  selector: 'deployments-toolbar',
+  template: ''
+})
+class FakeDeploymentsToolbarComponent {
+  @Output('onFilterChange') public onFilterChange: EventEmitter<FilterEvent> = new EventEmitter<FilterEvent>();
+  @Output('onSortChange') public onSortChange: EventEmitter<SortEvent> = new EventEmitter<SortEvent>();
+  @Input() public resultsCount: number;
+}
+
 describe('DeploymentsAppsComponent', () => {
   type Context = TestContext<DeploymentsAppsComponent, HostComponent>;
 
@@ -38,7 +55,8 @@ describe('DeploymentsAppsComponent', () => {
   let mockEnvironments = Observable.of(environments);
   let mockApplications = Observable.of(applications);
 
-  initContext(DeploymentsAppsComponent, HostComponent, { declarations: [FakeDeploymentCardContainerComponent] },
+  initContext(DeploymentsAppsComponent, HostComponent,
+    { declarations: [FakeDeploymentCardContainerComponent, FakeDeploymentsToolbarComponent] },
     component => {
       component.spaceId = spaceId;
       component.environments = mockEnvironments;

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -17,6 +17,8 @@ import {
   SortField
 } from 'patternfly-ng';
 
+import { DeploymentsToolbarComponent } from '../deployments-toolbar/deployments-toolbar.component';
+
 @Component({
   selector: 'deployments-apps',
   templateUrl: 'deployments-apps.component.html'
@@ -96,7 +98,7 @@ export class DeploymentsAppsComponent implements OnInit, OnDestroy {
 
   matchesFilter(application: string, filter: Filter): boolean {
     let match: boolean = false;
-    if (filter.field.id === 'applicationId') {
+    if (filter.field.id === DeploymentsToolbarComponent.APPLICATION_ID) {
       match = application.match(filter.value) !== null;
     }
 

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -1,22 +1,99 @@
 import {
   Component,
-  Input
+  Input,
+  OnInit
 } from '@angular/core';
 
 import { Environment } from '../models/environment';
 
+import { cloneDeep } from 'lodash';
 import { Observable } from 'rxjs';
+
+import {
+  Filter,
+  FilterEvent,
+  SortEvent,
+  SortField
+} from 'patternfly-ng';
 
 @Component({
   selector: 'deployments-apps',
   templateUrl: 'deployments-apps.component.html'
 })
-export class DeploymentsAppsComponent {
+export class DeploymentsAppsComponent implements OnInit {
 
-  @Input() spaceId: Observable<string>;
-  @Input() environments: Observable<Environment[]>;
-  @Input() applications: Observable<string[]>;
+  @Input() public applications: Observable<string[]>;
+  @Input() public environments: Observable<Environment[]>;
+  @Input() public spaceId: Observable<string>;
 
-  constructor() { }
+  public filteredApplicationsList: string[];
+  public resultsCount: number = 0;
 
+  private applicationsList: string[];
+  private currentFilters: Filter[];
+  private currentSortField: SortField;
+  private isAscendingSort: boolean = true;
+
+  public constructor() { }
+
+  ngOnInit(): void {
+    this.applications.subscribe(applications => {
+      this.applicationsList = applications;
+      this.applyFilters();
+    });
+  }
+
+  filterChange($event: FilterEvent): void {
+    this.currentFilters = $event.appliedFilters;
+    this.applyFilters();
+  }
+
+  sortChange($event: SortEvent): void {
+    this.currentSortField = $event.field;
+    this.isAscendingSort = $event.isAscending;
+
+    this.filteredApplicationsList.sort((a: string, b: string) => {
+      let v: number = a.localeCompare(b);
+      if (!this.isAscendingSort) {
+        v = v * -1;
+      }
+
+      return v;
+    });
+  }
+
+  applyFilters(): void {
+    this.filteredApplicationsList = [];
+    if (this.currentFilters && this.currentFilters.length > 0) {
+      this.applicationsList.forEach((application: string) => {
+        if (this.matchesFilters(application, this.currentFilters)) {
+          this.filteredApplicationsList.push(application);
+        }
+      });
+    } else {
+      this.filteredApplicationsList = cloneDeep(this.applicationsList);
+    }
+
+    this.resultsCount = this.filteredApplicationsList.length;
+  }
+
+  matchesFilters(application: string, filters: Filter[]): boolean {
+    let match: boolean = true;
+    filters.forEach((filter: Filter) => {
+      if (!this.matchesFilter(application, filter)) {
+        match = false;
+      }
+    });
+
+    return match;
+  }
+
+  matchesFilter(application: string, filter: Filter): boolean {
+    let match: boolean = false;
+    if (filter.field.id === 'applicationId') {
+      match = application.match(filter.value) !== null;
+    }
+
+    return match;
+  }
 }

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -1,13 +1,14 @@
 import {
   Component,
   Input,
+  OnDestroy,
   OnInit
 } from '@angular/core';
 
 import { Environment } from '../models/environment';
 
 import { cloneDeep } from 'lodash';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 import {
   Filter,
@@ -20,7 +21,7 @@ import {
   selector: 'deployments-apps',
   templateUrl: 'deployments-apps.component.html'
 })
-export class DeploymentsAppsComponent implements OnInit {
+export class DeploymentsAppsComponent implements OnInit, OnDestroy {
 
   @Input() public applications: Observable<string[]>;
   @Input() public environments: Observable<Environment[]>;
@@ -33,14 +34,19 @@ export class DeploymentsAppsComponent implements OnInit {
   private currentFilters: Filter[];
   private currentSortField: SortField;
   private isAscendingSort: boolean = true;
+  private subscriptions: Subscription[] = [];
 
   public constructor() { }
 
   ngOnInit(): void {
-    this.applications.subscribe(applications => {
+    this.subscriptions.push(this.applications.subscribe(applications => {
       this.applicationsList = applications;
       this.applyFilters();
-    });
+    }));
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
   }
 
   filterChange($event: FilterEvent): void {

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.html
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.html
@@ -1,0 +1,5 @@
+<pfng-toolbar
+  [config]="toolbarConfig"
+  (onFilterChange)="filterChange($event)"
+  (onSortChange)="sortChange($event)">
+</pfng-toolbar>

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.spec.ts
@@ -1,0 +1,74 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output
+} from '@angular/core';
+
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import {
+  FilterEvent,
+  SortEvent
+} from 'patternfly-ng';
+
+import { DeploymentsToolbarComponent } from './deployments-toolbar.component';
+
+@Component({
+  template: `
+  <deployments-toolbar
+  (onFilterChange)="filterChange($event)"
+  (onSortChange)="sortChange($event)"
+  [resultsCount]="resultsCount">
+  </deployments-toolbar>
+  `
+})
+class TestHostComponent {
+  public resultsCount: number = 0;
+
+  public filterChange($event: FilterEvent): void { }
+  public sortChange($event: SortEvent): void { }
+}
+
+@Component({
+  selector: 'pfng-toolbar',
+  template: ''
+})
+class FakePfngToolbarComponent {
+  @Input() config: any;
+  @Output() onFilterChange = new EventEmitter<FilterEvent>();
+  @Output() onSortChange = new EventEmitter<SortEvent>();
+}
+
+describe('DeploymentsToolbarComponent', () => {
+  type Context = TestContext<DeploymentsToolbarComponent, TestHostComponent>;
+  initContext(DeploymentsToolbarComponent, TestHostComponent, {
+    declarations: [FakePfngToolbarComponent]
+  });
+
+  it('should update filterConfig resultsCount', function (this: Context) {
+    const initialCount: number = 0;
+    expect(this.testedDirective.filterConfig.resultsCount).toBe(initialCount);
+
+    const nextCount: number = 5;
+    this.hostComponent.resultsCount = nextCount;
+    this.detectChanges();
+
+    expect(this.testedDirective.filterConfig.resultsCount).toBe(nextCount);
+  });
+
+  it('should emit filterChange event', function(this: Context) {
+    spyOn(this.hostComponent, 'filterChange');
+    this.testedDirective.filterChange({});
+    expect(this.hostComponent.filterChange).toHaveBeenCalledWith({});
+  });
+
+  it('should emit sortChange event', function(this: Context) {
+    spyOn(this.hostComponent, 'sortChange');
+    this.testedDirective.sortChange({field: {sortType: 'alphanumeric'}, isAscending: false});
+    expect(this.hostComponent.sortChange).toHaveBeenCalledWith({field: {sortType: 'alphanumeric'}, isAscending: false});
+  });
+});

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
@@ -1,0 +1,84 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewEncapsulation
+} from '@angular/core';
+
+import {
+  FilterConfig,
+  FilterEvent,
+  FilterField,
+  FilterType,
+  SortConfig,
+  SortEvent,
+  ToolbarConfig
+} from 'patternfly-ng';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'deployments-toolbar',
+  templateUrl: './deployments-toolbar.component.html'
+})
+export class DeploymentsToolbarComponent implements OnChanges, OnInit {
+
+  public filterConfig: FilterConfig;
+  public isAscendingSort: boolean = true;
+
+  @Output('onFilterChange') public onFilterChange: EventEmitter<FilterEvent> = new EventEmitter<FilterEvent>();
+  @Output('onSortChange') public onSortChange: EventEmitter<SortEvent> = new EventEmitter<SortEvent>();
+
+  @Input() public resultsCount: number;
+
+  private sortConfig: SortConfig;
+  private toolbarConfig: ToolbarConfig;
+
+  public constructor() { }
+
+  public filterChange($event: FilterEvent): void {
+    this.onFilterChange.emit($event);
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.resultsCount && this.filterConfig) {
+      this.filterConfig.resultsCount = changes.resultsCount.currentValue;
+    }
+  }
+
+  public ngOnInit(): void {
+    this.filterConfig = {
+      appliedFilters: [],
+      fields: [{
+        id: 'applicationId',
+        placeholder: 'Filter by Application Name...',
+        title: 'Application Name',
+        type: FilterType.TEXT
+      }] as FilterField[],
+      resultsCount: 0
+    };
+
+    this.sortConfig = {
+      fields: [{
+        id: 'applicationId',
+        sortType: 'alpha',
+        title: 'Application Name'
+      }],
+      isAscending: this.isAscendingSort
+    };
+
+    this.toolbarConfig = {
+      filterConfig: this.filterConfig,
+      sortConfig: this.sortConfig,
+      views: undefined
+    };
+  }
+
+  public sortChange($event: SortEvent): void {
+    this.onSortChange.emit($event);
+  }
+
+}

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
@@ -26,6 +26,8 @@ import {
 })
 export class DeploymentsToolbarComponent implements OnChanges, OnInit {
 
+  public static readonly APPLICATION_ID: string = 'applicationId';
+
   public filterConfig: FilterConfig;
   public isAscendingSort: boolean = true;
 
@@ -53,7 +55,7 @@ export class DeploymentsToolbarComponent implements OnChanges, OnInit {
     this.filterConfig = {
       appliedFilters: [],
       fields: [{
-        id: 'applicationId',
+        id: DeploymentsToolbarComponent.APPLICATION_ID,
         placeholder: 'Filter by Application Name...',
         title: 'Application Name',
         type: FilterType.TEXT
@@ -63,7 +65,7 @@ export class DeploymentsToolbarComponent implements OnChanges, OnInit {
 
     this.sortConfig = {
       fields: [{
-        id: 'applicationId',
+        id: DeploymentsToolbarComponent.APPLICATION_ID,
         sortType: 'alpha',
         title: 'Application Name'
       }],

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -18,6 +18,7 @@ import { DeploymentsDonutComponent } from './deployments-donut/deployments-donut
 import {
   DeploymentsDonutChartComponent
 } from './deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
+import { DeploymentsToolbarComponent } from './deployments-toolbar/deployments-toolbar.component';
 import { ResourceCardComponent } from '../deployments/resource-usage/resource-card.component';
 import { UtilizationBarComponent } from '../deployments/resource-usage/utilization-bar.component';
 
@@ -25,7 +26,7 @@ import { DeploymentsRoutingModule } from './deployments-routing.module';
 
 import { DeploymentsService } from '../deployments/services/deployments.service';
 
-import { ChartModule } from 'patternfly-ng';
+import { ChartModule, ToolbarModule } from 'patternfly-ng';
 
 @NgModule({
   imports: [
@@ -35,7 +36,8 @@ import { ChartModule } from 'patternfly-ng';
     TooltipModule.forRoot(),
     CommonModule,
     ChartModule,
-    DeploymentsRoutingModule
+    DeploymentsRoutingModule,
+    ToolbarModule
   ],
   declarations: [
     DeploymentsComponent,
@@ -47,6 +49,7 @@ import { ChartModule } from 'patternfly-ng';
     DeploymentsResourceUsageComponent,
     DeploymentsDonutComponent,
     DeploymentsDonutChartComponent,
+    DeploymentsToolbarComponent,
     ResourceCardComponent,
     UtilizationBarComponent
   ],


### PR DESCRIPTION
This addresses: https://github.com/openshiftio/openshift.io/issues/1633

A toolbar now appears where users can filter and sort their applications by name.

Filtering:

![deployments-toolbar-filter](https://user-images.githubusercontent.com/5430520/34612569-7474070a-f1f8-11e7-80a8-86fd7ded65fa.png)

Sorting:

![deployments-toolbar-sort](https://user-images.githubusercontent.com/5430520/34612564-736c8f8a-f1f8-11e7-85af-55af276fda6c.png)


