### PR TITLE
fix(deployments): reduce chance of race condition when destroying donut chart

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -80,7 +80,7 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
         }
       },
       transition: {
-        duration: 350
+        duration: 0
       },
       data: {
         type: 'donut',
@@ -122,7 +122,7 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
 
   ngOnDestroy(): void {
     if (this.chart) {
-      this.chart = this.chart.destroy();
+      this.chart.unload({ done: () => this.chart = this.chart.destroy() });
     }
   }
 


### PR DESCRIPTION
There is a race condition in c3js when destroying the chart. The fields are being set to null but there are timers still running that try to access these fields to render transitions/animations/etc. This small patch reduces the probability of this occurring. However I am confident the race still remains and could be seen in very rare circumstances (slow machines would help). Unfortunately for the time being, I don't have a better solution.

Addresses: https://github.com/openshiftio/openshift.io/issues/1788