### PR TITLE
fix(deployments): hide resource cards when there are no deployed applications

### DIFF
--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,6 +1,8 @@
-<div class="card-pf">
-  <div class="card-pf-body resource-card-body">
-    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environment.name)"></utilization-bar>
-    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environment.name)"></utilization-bar>
+<ng-container *ngIf="active">
+  <div class="card-pf">
+    <div class="card-pf-body resource-card-body">
+      <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environment.name)"></utilization-bar>
+      <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environment.name)"></utilization-bar>
+    </div>
   </div>
-</div>
+</ng-container>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -6,6 +6,7 @@ import {
 
 import { Observable } from 'rxjs';
 
+import { MemoryStat } from 'app/space/create/deployments/models/memory-stat';
 import { Environment } from '../models/environment';
 import { DeploymentsService } from '../services/deployments.service';
 
@@ -19,15 +20,25 @@ export class ResourceCardComponent implements OnInit {
   @Input() environment: Environment;
 
   memUnit: Observable<string>;
+  active: boolean = false;
 
   constructor(
     private deploymentsService: DeploymentsService
   ) { }
 
   ngOnInit(): void {
-    this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environment.name)
-      .first()
-      .map(stat => stat.units);
+    this.deploymentsService
+    .isDeployedInEnvironment(this.spaceId, this.environment.name)
+    .subscribe((active: boolean) => {
+      this.active = active;
+      if (active) {
+        this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environment.name)
+        .first()
+        .map((stat: MemoryStat) => stat.units);
+      }
+    });
+
+
   }
 
 }

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -31,8 +31,9 @@ describe('DeploymentsService', () => {
       svc.getEnvironments('foo')
         .subscribe(val => {
           expect(val).toEqual([
-            { name: 'stage' } as Environment,
-            { name: 'run' } as Environment
+            { name: 'test' },
+            { name: 'stage' },
+            { name: 'run'}
           ]);
         });
       tick(DeploymentsService.POLL_RATE_MS + 10);
@@ -41,10 +42,19 @@ describe('DeploymentsService', () => {
   });
 
   describe('#isApplicationDeployedInEnvironment', () => {
-    it('should be true for vertx-hello in \'stage\'', fakeAsync(() => {
-      svc.isApplicationDeployedInEnvironment('foo', 'vertx-hello', 'stage')
+    it('should be true for vertx-hello in \'test\'', fakeAsync(() => {
+      svc.isApplicationDeployedInEnvironment('foo', 'vertx-hello', 'test')
         .subscribe((active: boolean) => {
           expect(active).toBeTruthy();
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should be false for vertx-hello in \'stage\'', fakeAsync(() => {
+      svc.isApplicationDeployedInEnvironment('foo', 'vertx-hello', 'stage')
+        .subscribe((active: boolean) => {
+          expect(active).toBeFalsy();
         });
       tick(DeploymentsService.POLL_RATE_MS + 10);
       discardPeriodicTasks();
@@ -59,8 +69,8 @@ describe('DeploymentsService', () => {
       discardPeriodicTasks();
     }));
 
-    it('should be true for vertx-paint in \'stage\'', fakeAsync(() => {
-      svc.isApplicationDeployedInEnvironment('foo', 'vertx-paint', 'stage')
+    it('should be true for vertx-paint in \'test\'', fakeAsync(() => {
+      svc.isApplicationDeployedInEnvironment('foo', 'vertx-paint', 'test')
         .subscribe((active: boolean) => {
           expect(active).toBeTruthy();
         });
@@ -68,8 +78,26 @@ describe('DeploymentsService', () => {
       discardPeriodicTasks();
     }));
 
+    it('should be false for vertx-paint in \'stage\'', fakeAsync(() => {
+      svc.isApplicationDeployedInEnvironment('foo', 'vertx-paint', 'stage')
+        .subscribe((active: boolean) => {
+          expect(active).toBeFalsy();
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
     it('should be false for vertx-paint in \'run\'', fakeAsync(() => {
       svc.isApplicationDeployedInEnvironment('foo', 'vertx-paint', 'run')
+        .subscribe((active: boolean) => {
+          expect(active).toBeFalsy();
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should be false for vertx-wiki in \'test\'', fakeAsync(() => {
+      svc.isApplicationDeployedInEnvironment('foo', 'vertx-wiki', 'test')
         .subscribe((active: boolean) => {
           expect(active).toBeFalsy();
         });
@@ -90,6 +118,35 @@ describe('DeploymentsService', () => {
       svc.isApplicationDeployedInEnvironment('foo', 'vertx-wiki', 'stage')
         .subscribe((active: boolean) => {
           expect(active).toBeFalsy();
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+  });
+
+  describe('#isDeployedInEnvironment', () => {
+    it('should be false for \'stage\'', fakeAsync(() => {
+      svc.isDeployedInEnvironment('foo', 'stage')
+        .subscribe((active: boolean) => {
+          expect(active).toBeFalsy();
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should be true for \'test\'', fakeAsync(() => {
+      svc.isDeployedInEnvironment('foo', 'test')
+        .subscribe((active: boolean) => {
+          expect(active).toBeTruthy();
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should be true for \'run\'', fakeAsync(() => {
+      svc.isDeployedInEnvironment('foo', 'run')
+        .subscribe((active: boolean) => {
+          expect(active).toBeTruthy();
         });
       tick(DeploymentsService.POLL_RATE_MS + 10);
       discardPeriodicTasks();

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -17,15 +17,19 @@ export class DeploymentsService {
 
   getEnvironments(spaceId: string): Observable<Environment[]> {
     return Observable.of([
-      { name: 'stage' } as Environment,
-      { name: 'run' } as Environment
+      { name: 'test' },
+      { name: 'stage' },
+      { name: 'run' }
     ]);
   }
 
   isApplicationDeployedInEnvironment(spaceId: string, applicationName: string, environmentName: string):
     Observable<boolean> {
+    if (environmentName === 'stage') {
+      return Observable.of(false);
+    }
     if (applicationName === 'vertx-paint') {
-      return environmentName === 'stage' ? Observable.of(true) : Observable.of(false);
+      return environmentName === 'test' ? Observable.of(true) : Observable.of(false);
     }
     if (applicationName === 'vertx-wiki') {
       return environmentName === 'run' ? Observable.of(true) : Observable.of(false);
@@ -33,6 +37,15 @@ export class DeploymentsService {
 
     return Observable.of(true);
   }
+
+  isDeployedInEnvironment(spaceId: string, environmentName: string):
+    Observable<boolean> {
+      if (environmentName === 'stage') {
+        return Observable.of(false);
+      } else {
+        return Observable.of(true);
+      }
+    }
 
   getVersion(spaceId: string, environmentName: string): Observable<string> {
     return Observable.of('1.0.2');


### PR DESCRIPTION
This addresses https://github.com/openshiftio/openshift.io/issues/1714

For testing purposes another environment is added and one of the three environments has no applications deployed. Below is a screenshot showing the result:

![hidden-resource-cards](https://user-images.githubusercontent.com/5430520/34737539-6a28d664-f544-11e7-9a86-db2eec5d0eb4.png)
