### PR TITLE
fix(deployments): add missing osio.less import

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.less
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.less
@@ -1,3 +1,5 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
 .chart-text {
   padding-left: 10px;
 }


### PR DESCRIPTION
I believe all less files are supposed to import the osio.less file. This adds it to one that was missing the import.