### PR TITLE
fix(deployments): add null check in deployments donut html

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -18,7 +18,7 @@
   </div>
 </div>
 <div class="deployments-donut-legend" *ngIf="!mini">
-  <div *ngFor="let column of (pods | async).pods">
+  <div *ngFor="let column of (pods | async)?.pods">
     <div class="deployments-donut-square" [style.background]='colors[column[0]]'></div>{{ column[1] > 0 ? column[1] + ' ' + column[0] : '' }}
   </div>
 </div>


### PR DESCRIPTION
This adds a null check in the deployments donut html that prevents a possible null exception when requests are slow. This was found while artificially slowing all mock http requests down.