### PR TITLE
fix(card): Keep Create Space icon in Card Header

### DIFF
--- a/src/app/dashboard-widgets/pipelines-widget/pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/pipelines-widget/pipelines-widget.component.html
@@ -1,5 +1,10 @@
 <div id="spacehome-pipelines-card" class="pipelines-widget card-pf f8-card">
   <div class="card-pf-heading f8-card-heading">
+    <div class="card-pf-heading-details f8-card-heading-details">
+      <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
+        <i class="pficon pficon-add-circle-o"></i>
+      </a>
+    </div>
     <h2 class="card-pf-title">
       <a id="spacehome-pipelines-title" [routerLink]="[contextPath | async, 'create', 'pipelines']">Pipelines</a>
       <span id="spacehome-pipelines-badge" class="badge f8-card-badge">{{buildConfigsCount | async}}</span>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -62,7 +62,7 @@
       <div class="col-xs-12 col-md-4">
         <div class="card-pf f8-card">
           <div class="card-pf-heading f8-card-heading">
-            <div class="card-pf-heading-details f8-card-heading-details" *ngIf="_spaces.length > 0">
+            <div class="card-pf-heading-details f8-card-heading-details">
               <a class="btn btn-link f8-card-heading-btn-link" (click)="openForgeWizard(createSpace)">
                 <i class="pficon pficon-add-circle-o"></i>
               </a>
@@ -123,4 +123,3 @@
   <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
   <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
 </ng-template>
-


### PR DESCRIPTION
Keep the Create Space icon in the Card Header for Recent Spaces card, whether the Card is in an empty state or showing Recent Spaces.

