### PR TITLE
fix(deployments): tweak css for deployments page to fit page

### DIFF
--- a/src/app/space/create/deployments/deployments.component.html
+++ b/src/app/space/create/deployments/deployments.component.html
@@ -1,4 +1,4 @@
-<div id="apps">
+<div id="apps" class="container-fluid">
   <deployments-apps [spaceId]="spaceId" [environments]="environments" [applications]="applications"></deployments-apps>
   <deployments-resource-usage [environments]="environments"></deployments-resource-usage>
 </div>

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.html
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.html
@@ -1,4 +1,4 @@
-<div class="row panel panel-default">
+<div class="row panel panel-default resource-panel">
   <div class="panel-body cards-pf resource-card">
     <div class="container-fluid container-cards-pf">
       <div class="row row-cards-pf">

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.less
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.less
@@ -1,7 +1,12 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 
-.resource-title {
-  &:hover {
-    text-decoration: none;
+.resource {
+  &-title {
+    &:hover {
+      text-decoration: none;
+    }
+  }
+  &-panel {
+    margin-bottom: 0px;
   }
 }


### PR DESCRIPTION
This tweaks the deployments page to fit within the body and not stretch out and require scrolling when it doesn't need to. See before and after screenshots below.

Before:
![css-unfixed](https://user-images.githubusercontent.com/5430520/34882720-7268d764-f785-11e7-9a01-65a35538567b.png)
After:
![css-fixed](https://user-images.githubusercontent.com/5430520/34882721-7390273c-f785-11e7-902d-d3bb74305357.png)

