### PR TITLE
fix(profile): Fix double scroll bar in profile

### DIFF
--- a/src/app/profile/overview/spaces/spaces.component.html
+++ b/src/app/profile/overview/spaces/spaces.component.html
@@ -25,7 +25,7 @@
       </div>
     </ng-template>
     <ng-template #showSpaces>
-      <div class="col-xs-12 f8-card-list">
+      <div class="no-vertical-scroll col-xs-12 f8-card-list">
         <div class="spaces-list-scroll" almInfiniteScroll
              (fetchMore)='fetchMoreSpaces($event)'>
           <ul class="list-group list-view-pf list-view-pf-view list-view-pf-striped">

--- a/src/assets/stylesheets/shared/osio.less
+++ b/src/assets/stylesheets/shared/osio.less
@@ -29,3 +29,6 @@
 
 // General layout information
 @import '_layout.less';
+
+// General layout tweaks
+@import '_scrollbars.less';


### PR DESCRIPTION
This patch remedies a bug in the profile space's view, in which
two scrollbars are loaded if the list of users' spaces is sufficiently
long. It removes scrolling from a parent div in favour of our
infinite scroll component.

Issue: https://github.com/openshiftio/openshift.io/issues/1885 
