### PR TITLE
fix(deployments): tweak donut chart with visible empty state

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -91,8 +91,9 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
           enabled: false
         },
         columns: [
-          ['Empty', 0]
-        ]
+          ['Empty', 1]
+        ],
+        unload: true
       }
     };
 
@@ -145,7 +146,11 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
 
   private updateChart(): void {
     if (this.chart && this.pods) {
-      this.config.data.columns = this.pods.pods;
+      if (this.pods.total === 0) {
+        this.config.data.columns = [['Empty', 1]];
+      } else {
+        this.config.data.columns = this.pods.pods;
+      }
       this.chart.load(this.config.data);
       this.updateCountText();
     }

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -26,7 +26,7 @@ export class DeploymentsDonutComponent implements OnInit {
   debounceScale = debounce(this.scale, 650);
 
   colors = {
-    'Empty': '#030303', // pf-black
+    'Empty': '#fafafa', // pf-black-100
     'Running': '#00b9e4', // pf-light-blue-400
     'Not Ready': '#beedf9', // pf-light-blue-100
     'Warning': '#f39d3c', // pf-orange-300


### PR DESCRIPTION
This updates the donut chart to have a visible empty state. Otherwise, the donut chart becomes invisible when there are 0 pods deployed, which is a valid state. This follows the implementation in Openshift's Web Console.