### PR TITLE
feat(deployments): service distinguishes deployment from environment …

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -88,8 +88,8 @@ function initMockSvc(): jasmine.SpyObj<DeploymentsService> {
   let mockSvc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
 
   mockSvc.getVersion.and.returnValue(Observable.of('1.2.3'));
-  mockSvc.getCpuStat.and.returnValue(Observable.of({ used: 1, quota: 2 }));
-  mockSvc.getMemoryStat.and.returnValue(Observable.of({ used: 3, quota: 4, units: 'GB' }));
+  mockSvc.getDeploymentCpuStat.and.returnValue(Observable.of({ used: 1, quota: 2 }));
+  mockSvc.getDeploymentMemoryStat.and.returnValue(Observable.of({ used: 3, quota: 4, units: 'GB' }));
   mockSvc.getAppUrl.and.returnValue(Observable.of('mockAppUrl'));
   mockSvc.getConsoleUrl.and.returnValue(Observable.of('mockConsoleUrl'));
   mockSvc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
@@ -206,7 +206,7 @@ describe('DeploymentCardComponent', () => {
     active = new BehaviorSubject<boolean>(true);
     mockSvc = initMockSvc();
     mockSvc.isApplicationDeployedInEnvironment.and.returnValue(active);
-    mockSvc.getCpuStat.and.returnValue(mockCpuData);
+    mockSvc.getDeploymentCpuStat.and.returnValue(mockCpuData);
     notifications = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
 
     flush();

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -53,7 +53,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
     this.iconClass = DeploymentStatusIconComponent.CLASSES.ICON_OK;
     this.toolTip = 'Everything is ok';
 
-    this.cpuStat = this.deploymentsService.getCpuStat(this.spaceId, this.environment.name);
+    this.cpuStat = this.deploymentsService.getDeploymentCpuStat(this.spaceId, this.applicationId, this.environment.name);
     this.subscriptions.push(this.cpuStat.subscribe((stat) => {
       this.changeStatus(stat);
     }));

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -94,8 +94,8 @@ describe('DeploymentDetailsComponent', () => {
 
     mockSvc = createMock(DeploymentsService);
     mockSvc.getVersion.and.returnValue(Observable.of('1.2.3'));
-    mockSvc.getCpuStat.and.returnValue(cpuStatObservable);
-    mockSvc.getMemoryStat.and.returnValue(memStatObservable);
+    mockSvc.getDeploymentCpuStat.and.returnValue(cpuStatObservable);
+    mockSvc.getDeploymentMemoryStat.and.returnValue(memStatObservable);
     mockSvc.getAppUrl.and.returnValue(Observable.of('mockAppUrl'));
     mockSvc.getConsoleUrl.and.returnValue(Observable.of('mockConsoleUrl'));
     mockSvc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
@@ -139,7 +139,7 @@ describe('DeploymentDetailsComponent', () => {
     });
 
     it('should be called with the proper arguments', () => {
-      expect(mockSvc.getCpuStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
+      expect(mockSvc.getDeploymentCpuStat).toHaveBeenCalledWith('mockSpaceId', 'mockAppId', 'mockEnvironment');
     });
 
     it('should use the \'Cores\' label for its data measure', () => {
@@ -165,7 +165,7 @@ describe('DeploymentDetailsComponent', () => {
     });
 
     it('should use units from service result', () => {
-      expect(mockSvc.getMemoryStat).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
+      expect(mockSvc.getDeploymentMemoryStat).toHaveBeenCalledWith('mockSpaceId', 'mockAppId', 'mockEnvironment');
       expect(de.componentInstance.dataMeasure).toEqual('GB');
     });
 

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -93,10 +93,10 @@ export class DeploymentDetailsComponent {
     this.memTime = 1;
 
     this.cpuStat =
-      this.deploymentsService.getCpuStat(this.applicationId, this.environment.name);
+      this.deploymentsService.getDeploymentCpuStat(this.spaceId, this.applicationId, this.environment.name);
 
     this.memStat =
-      this.deploymentsService.getMemoryStat(this.applicationId, this.environment.name);
+      this.deploymentsService.getDeploymentMemoryStat(this.spaceId, this.applicationId, this.environment.name);
 
     this.subscriptions.push(this.cpuStat.subscribe(stat => {
       this.cpuVal = stat.used;

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="active">
   <div class="card-pf">
     <div class="card-pf-body resource-card-body">
-      <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getCpuStat(spaceId, environment.name)"></utilization-bar>
-      <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getMemoryStat(spaceId, environment.name)"></utilization-bar>
+      <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment.name)"></utilization-bar>
+      <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getEnvironmentMemoryStat(spaceId, environment.name)"></utilization-bar>
     </div>
   </div>
 </ng-container>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -52,8 +52,8 @@ describe('ResourceCardComponent', () => {
       { name: 'stage' } as Environment,
       { name: 'prod' } as Environment
     ]));
-    mockSvc.getCpuStat.and.returnValue(cpuStatMock);
-    mockSvc.getMemoryStat.and.returnValue(memoryStatMock);
+    mockSvc.getEnvironmentCpuStat.and.returnValue(cpuStatMock);
+    mockSvc.getEnvironmentMemoryStat.and.returnValue(memoryStatMock);
     mockSvc.isDeployedInEnvironment.and.returnValue(active);
   });
 

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -32,7 +32,7 @@ export class ResourceCardComponent implements OnInit {
     .subscribe((active: boolean) => {
       this.active = active;
       if (active) {
-        this.memUnit = this.deploymentsService.getMemoryStat(this.spaceId, this.environment.name)
+        this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment.name)
         .first()
         .map((stat: MemoryStat) => stat.units);
       }

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -163,9 +163,9 @@ describe('DeploymentsService', () => {
     }));
   });
 
-  describe('#getCpuStat', () => {
+  describe('#getDeploymentCpuStat', () => {
     it('should return a "quota" value of 10', fakeAsync(() => {
-      svc.getCpuStat('foo', 'bar')
+      svc.getDeploymentCpuStat('foo', 'bar', 'baz')
         .subscribe(val => {
           expect(val.quota).toBe(10);
         });
@@ -174,7 +174,7 @@ describe('DeploymentsService', () => {
     }));
 
     it('should return a "used" value between 1 and 10', fakeAsync(() => {
-      svc.getCpuStat('foo', 'bar')
+      svc.getDeploymentCpuStat('foo', 'bar', 'baz')
         .subscribe(val => {
           expect(val.used).toBeGreaterThanOrEqual(1);
           expect(val.used).toBeLessThanOrEqual(10);
@@ -184,9 +184,9 @@ describe('DeploymentsService', () => {
     }));
   });
 
-  describe('#getMemoryStat', () => {
+  describe('#getDeploymentMemoryStat', () => {
     it('should return a "quota" value of 256', fakeAsync(() => {
-      svc.getMemoryStat('foo', 'bar')
+      svc.getDeploymentMemoryStat('foo', 'bar', 'baz')
         .subscribe(val => {
           expect(val.quota).toBe(256);
         });
@@ -195,7 +195,7 @@ describe('DeploymentsService', () => {
     }));
 
     it('should return a "used" value between 100 and 256', fakeAsync(() => {
-      svc.getMemoryStat('foo', 'bar')
+      svc.getDeploymentMemoryStat('foo', 'bar', 'baz')
         .subscribe(val => {
           expect(val.used).toBeGreaterThanOrEqual(100);
           expect(val.used).toBeLessThanOrEqual(256);
@@ -205,7 +205,58 @@ describe('DeploymentsService', () => {
     }));
 
     it('should return a value in MB', fakeAsync(() => {
-      svc.getMemoryStat('foo', 'bar')
+      svc.getEnvironmentMemoryStat('foo', 'bar')
+        .subscribe(val => {
+          expect(val.units).toEqual('MB');
+        });
+        tick(DeploymentsService.POLL_RATE_MS + 10);
+        discardPeriodicTasks();
+    }));
+  });
+
+  describe('#getEnvironmentCpuStat', () => {
+    it('should return a "quota" value of 10', fakeAsync(() => {
+      svc.getEnvironmentCpuStat('foo', 'bar')
+        .subscribe(val => {
+          expect(val.quota).toBe(10);
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should return a "used" value between 1 and 10', fakeAsync(() => {
+      svc.getEnvironmentCpuStat('foo', 'bar')
+        .subscribe(val => {
+          expect(val.used).toBeGreaterThanOrEqual(1);
+          expect(val.used).toBeLessThanOrEqual(10);
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+  });
+
+  describe('#getEnvironmentMemoryStat', () => {
+    it('should return a "quota" value of 256', fakeAsync(() => {
+      svc.getEnvironmentMemoryStat('foo', 'bar')
+        .subscribe(val => {
+          expect(val.quota).toBe(256);
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should return a "used" value between 100 and 256', fakeAsync(() => {
+      svc.getEnvironmentMemoryStat('foo', 'bar')
+        .subscribe(val => {
+          expect(val.used).toBeGreaterThanOrEqual(100);
+          expect(val.used).toBeLessThanOrEqual(256);
+        });
+      tick(DeploymentsService.POLL_RATE_MS + 10);
+      discardPeriodicTasks();
+    }));
+
+    it('should return a value in MB', fakeAsync(() => {
+      svc.getEnvironmentMemoryStat('foo', 'bar')
         .subscribe(val => {
           expect(val.units).toEqual('MB');
         });

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -71,7 +71,7 @@ export class DeploymentsService {
     return Observable.of({ pods: [['Running', 2], ['Terminating', 1]], total: 3 } as Pods);
   }
 
-  getCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
+  getDeploymentCpuStat(spaceId: string, applicationName: string, environmentName: string): Observable<CpuStat> {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
@@ -79,7 +79,23 @@ export class DeploymentsService {
       .startWith({ used: 3, quota: 10 } as CpuStat);
   }
 
-  getMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
+  getDeploymentMemoryStat(spaceId: string, applicationName: string, environmentName: string): Observable<MemoryStat> {
+    return Observable
+      .interval(DeploymentsService.POLL_RATE_MS)
+      .distinctUntilChanged()
+      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, quota: 256, units: 'MB' } as MemoryStat))
+      .startWith({ used: 200, quota: 256, units: 'MB' } as MemoryStat);
+  }
+
+  getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
+    return Observable
+      .interval(DeploymentsService.POLL_RATE_MS)
+      .distinctUntilChanged()
+      .map(() => ({ used: Math.floor(Math.random() * 9) + 1, quota: 10 } as CpuStat))
+      .startWith({ used: 3, quota: 10 } as CpuStat);
+  }
+
+  getEnvironmentMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()


### PR DESCRIPTION
…CPU/mem usage

Currently, the DeploymentsService only provides a generic function for CPU stats and Memory stats, but it should provide a way to get CPU usage/quota for an individual deployment as well as for an entire environment separately.