### PR TITLE
feat(deployments): automatically scale memory stats

### DIFF
--- a/src/app/space/create/deployments/models/memory-stat.ts
+++ b/src/app/space/create/deployments/models/memory-stat.ts
@@ -1,5 +1,7 @@
 import { Stat } from './stat';
 
+export type MemoryUnit = 'bytes' | 'KB' | 'MB' | 'GB';
+
 export declare interface MemoryStat extends Stat {
-  readonly units: 'B' | 'KB' | 'MB' | 'GB';
+  readonly units: MemoryUnit;
 }

--- a/src/app/space/create/deployments/models/scaled-memory-stat.spec.ts
+++ b/src/app/space/create/deployments/models/scaled-memory-stat.spec.ts
@@ -1,0 +1,35 @@
+import { ScaledMemoryStat } from './scaled-memory-stat';
+
+describe('ScaledMemoryStat', () => {
+
+  it('should not scale 500 bytes', () => {
+    let stat = new ScaledMemoryStat(500, 1024);
+    expect(stat.used).toEqual(500);
+    expect(stat.quota).toEqual(1024);
+    expect(stat.units).toEqual('bytes');
+  });
+
+  it('should scale 2048 bytes', () => {
+    let stat = new ScaledMemoryStat(2048, 4096);
+    expect(stat.used).toEqual(2);
+    expect(stat.quota).toEqual(4);
+    expect(stat.units).toEqual('KB');
+  });
+
+  it('should scale 5.5GB', () => {
+    let gb = Math.pow(1024, 3);
+    let stat = new ScaledMemoryStat(5.5 * gb, 5.9 * gb);
+    expect(stat.used).toEqual(5.5);
+    expect(stat.quota).toEqual(5.9);
+    expect(stat.units).toEqual('GB');
+  });
+
+  it('should scale quota when used is 0', () => {
+    let gb = Math.pow(1024, 3);
+    let stat = new ScaledMemoryStat(0, 2 * gb);
+    expect(stat.used).toEqual(0);
+    expect(stat.quota).toEqual(2);
+    expect(stat.units).toEqual('GB');
+  });
+
+});

--- a/src/app/space/create/deployments/models/scaled-memory-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-memory-stat.ts
@@ -1,0 +1,35 @@
+import {
+  MemoryStat,
+  MemoryUnit
+} from './memory-stat';
+
+import { round } from 'lodash';
+
+export class ScaledMemoryStat implements MemoryStat {
+
+  private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
+
+  public units: MemoryUnit;
+
+  constructor(
+    public used: number,
+    public quota: number
+  ) {
+    let scale = 0;
+    if (this.used !== 0) {
+      while (this.used > 1024 && scale < ScaledMemoryStat.UNITS.length) {
+        this.used /= 1024;
+        this.quota /= 1024;
+        scale++;
+      }
+    } else {
+      while (this.quota > 1024 && scale < ScaledMemoryStat.UNITS.length) {
+        this.quota /= 1024;
+        scale++;
+      }
+    }
+    this.used = round(this.used, 1);
+    this.quota = round(this.quota, 1);
+    this.units = ScaledMemoryStat.UNITS[scale] as MemoryUnit;
+  }
+}

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core/testing';
 
 import { Environment } from '../models/environment';
+import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 import { DeploymentsService } from './deployments.service';
 
 describe('DeploymentsService', () => {
@@ -204,10 +205,10 @@ describe('DeploymentsService', () => {
       discardPeriodicTasks();
     }));
 
-    it('should return a value in MB', fakeAsync(() => {
-      svc.getEnvironmentMemoryStat('foo', 'bar')
+    it('should return a value in bytes', fakeAsync(() => {
+      svc.getDeploymentMemoryStat('foo', 'bar', 'baz')
         .subscribe(val => {
-          expect(val.units).toEqual('MB');
+          expect(val.units).toEqual('bytes');
         });
         tick(DeploymentsService.POLL_RATE_MS + 10);
         discardPeriodicTasks();
@@ -255,10 +256,10 @@ describe('DeploymentsService', () => {
       discardPeriodicTasks();
     }));
 
-    it('should return a value in MB', fakeAsync(() => {
+    it('should return a value in bytes', fakeAsync(() => {
       svc.getEnvironmentMemoryStat('foo', 'bar')
         .subscribe(val => {
-          expect(val.units).toEqual('MB');
+          expect(val.units).toEqual('bytes');
         });
         tick(DeploymentsService.POLL_RATE_MS + 10);
         discardPeriodicTasks();

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -8,6 +8,7 @@ import { CpuStat } from '../models/cpu-stat';
 import { Environment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
 import { Pods } from '../models/pods';
+import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 
 export interface NetworkStat {
   sent: number;
@@ -83,8 +84,8 @@ export class DeploymentsService {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, quota: 256, units: 'MB' } as MemoryStat))
-      .startWith({ used: 200, quota: 256, units: 'MB' } as MemoryStat);
+      .map(() => (new ScaledMemoryStat(Math.floor(Math.random() * 156) + 100, 256)))
+      .startWith(new ScaledMemoryStat(200, 256));
   }
 
   getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
@@ -99,8 +100,8 @@ export class DeploymentsService {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
       .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 156) + 100, quota: 256, units: 'MB' } as MemoryStat))
-      .startWith({ used: 200, quota: 256, units: 'MB' } as MemoryStat);
+      .map(() => (new ScaledMemoryStat(Math.floor(Math.random() * 156) + 100, 256)))
+      .startWith(new ScaledMemoryStat(200, 256));
   }
 
   getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {


### PR DESCRIPTION
This PR adds a class "ScaledMemoryStat" which implements the existing MemoryStat interface, which when given a value for the "used" and "quota" values, will automatically scale these values down and increase the "units" through bytes -> KB -> MB -> GB for display (ex. 2048 bytes will become 2 KB). This will be useful when the UI is hooked up to live data, where the memory stat numbers will be very large compared to the current mock data due to being sent in raw bytes.