### PR TITLE
fix(deployments): fix sorting and filtering toolbar

### DIFF
--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -52,12 +52,18 @@ export class DeploymentsAppsComponent implements OnInit, OnDestroy {
   filterChange($event: FilterEvent): void {
     this.currentFilters = $event.appliedFilters;
     this.applyFilters();
+
+    this.sortApplications();
   }
 
   sortChange($event: SortEvent): void {
     this.currentSortField = $event.field;
     this.isAscendingSort = $event.isAscending;
 
+    this.sortApplications();
+  }
+
+  sortApplications(): void {
     this.filteredApplicationsList.sort((a: string, b: string) => {
       let v: number = a.localeCompare(b);
       if (!this.isAscendingSort) {


### PR DESCRIPTION
This fixes an issue seen when combining the sort and filtering functionality of the toolbar. When a filter operation occurs, a sort now also occurs.

See [1] for a description of a similar issue and [2] for it's respective fix. Though it's for a different component, the same problem occurs here.

[1] https://github.com/openshiftio/openshift.io/issues/1884
[2] https://github.com/fabric8-ui/fabric8-ui/pull/2392