### PR TITLE
fix(codebases): fix filter by creation date and last commit

### DIFF
--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.html
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.html
@@ -5,10 +5,10 @@
 <div class="list-pf-content-wrapper">
   <div class="list-pf-main-content">
     <div class="list-pf-title">
-      <a [href]="htmlUrl" target="_blank">{{fullName}}</a>
+      <a [href]="codebase.gitHubRepo.htmlUrl" target="_blank">{{codebase.gitHubRepo.fullName}}</a>
     </div>
-    <div class="list-pf-description">{{createdDate | date:'medium'}}</div>
-    <div class="list-pf-description">{{lastCommitDate | date:'medium'}}</div>
+    <div class="list-pf-description">{{codebase.gitHubRepo.createdAt | date:'medium'}}</div>
+    <div class="list-pf-description">{{codebase.gitHubRepo.pushedAt | date:'medium'}}</div>
   </div>
   <div class="list-pf-additional-content">
     <codebases-item-workspaces [codebase]="codebase" [index]="index" *ngIf="cheState && cheState.running"></codebases-item-workspaces>

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
@@ -13,14 +13,10 @@ import { CodebasesItemComponent } from './codebases-item.component';
 
 describe('Codebases Item Component', () => {
   let broadcasterMock: any;
-  let gitHubServiceMock: any;
-  let notificationMock: any;
   let fixture, codebases, codebase;
 
   beforeEach(() => {
     broadcasterMock = jasmine.createSpyObj('Broadcaster', ['on']);
-    gitHubServiceMock = jasmine.createSpyObj('GitHubService', ['getRepoDetailsByUrl']);
-    notificationMock = jasmine.createSpyObj('Notifications', ['message']);
 
     TestBed.configureTestingModule({
       imports: [FormsModule, HttpModule],
@@ -28,12 +24,6 @@ describe('Codebases Item Component', () => {
       providers: [
         {
           provide: Broadcaster, useValue: broadcasterMock
-        },
-        {
-          provide: GitHubService, useValue: gitHubServiceMock
-        },
-        {
-          provide: Notifications, useValue: notificationMock
         }
       ],
       // Tells the compiler not to error on unknown elements and attributes
@@ -46,6 +36,10 @@ describe('Codebases Item Component', () => {
         'stackId': '',
         'type': 'git',
         'url': 'https://github.com/fabric8-services/fabric8-wit.git'
+      },
+      'gitHubRepo': {
+        'htmlUrl': 'https://github.com/fabric8-services/fabric8-wit',
+        'fullName': 'fabric8-services/fabric8-wit'
       },
       'id': '6f5b6738-170e-490e-b3bb-d10f56b587c8',
       'links': {
@@ -67,11 +61,10 @@ describe('Codebases Item Component', () => {
       'name': 'https://github.com/fabric8-services/fabric8-wit',
       'url': 'https///github.com/fabric8-services/fabric8-wit'
     };
-    gitHubServiceMock.getRepoDetailsByUrl.and.returnValue(Observable.of(expectedGitHubRepoDetails));
     fixture = TestBed.createComponent(CodebasesItemComponent);
   });
 
-  it('Init component succesfully', async(() => {
+  it('Init component successfully', async(() => {
     // given
     let comp = fixture.componentInstance;
     let debug = fixture.debugElement;

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.ts
@@ -1,11 +1,7 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { Notification, Notifications, NotificationType } from 'ngx-base';
-import { Subscription } from 'rxjs';
-
 import { Che } from '../services/che';
 import { Codebase } from '../services/codebase';
-import { GitHubService } from '../services/github.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -17,87 +13,12 @@ export class CodebasesItemComponent implements OnDestroy, OnInit {
   @Input() codebase: Codebase;
   @Input() index: number = -1;
 
-  createdDate: string;
-  fullName: string;
-  lastCommitDate: string;
-  htmlUrl: string;
-  subscriptions: Subscription[] = [];
-
-  constructor(
-      private gitHubService: GitHubService,
-      private notifications: Notifications) {
+  constructor() {
   }
 
   ngOnDestroy(): void {
-    this.subscriptions.forEach(sub => {
-      sub.unsubscribe();
-    });
   }
 
   ngOnInit(): void {
-    if (this.codebase === undefined || this.codebase.attributes === undefined) {
-      return;
-    }
-    if (this.codebase.attributes.type === 'git') {
-      if (!this.isGitHubHtmlUrlInvalid()) {
-        this.updateGitHubRepoDetails();
-      } else {
-        this.handleError(`Invalid URL: ${this.codebase.attributes.url}`, NotificationType.WARNING);
-      }
-    }
-  }
-
-  // Private
-
-  /**
-   * Helper to test if codebase contains a valid GitHub HTML URL
-   *
-   * @returns {boolean}
-   */
-  private isGitHubHtmlUrlInvalid(): boolean {
-    return (this.codebase.attributes.url === undefined
-      || this.codebase.attributes.url.trim().length === 0
-      || this.codebase.attributes.url.indexOf('https://github.com') === -1
-      || this.codebase.attributes.url.indexOf('.git') === -1);
-  }
-
-  /**
-   * Helper to test if codebase contains a valid HTML URL based on type
-   *
-   * @returns {boolean}
-   */
-  private isHtmlUrlInvalid(): boolean {
-    if (this.codebase.attributes.type === 'git') {
-      return this.isGitHubHtmlUrlInvalid();
-    } else {
-      return false;
-    }
-  }
-
-  /**
-   * Helper to update GitHub repo details
-   */
-  private updateGitHubRepoDetails(): void {
-    this.subscriptions.push(this.gitHubService.getRepoDetailsByUrl(this.codebase.attributes.url)
-      .subscribe(gitHubRepoDetails => {
-        this.createdDate = gitHubRepoDetails.created_at;
-        this.fullName = gitHubRepoDetails.full_name;
-        this.lastCommitDate = gitHubRepoDetails.pushed_at;
-        this.htmlUrl = gitHubRepoDetails.html_url;
-
-        // Save for filter
-        this.codebase.gitHubRepo = {};
-        this.codebase.gitHubRepo.createdAt = gitHubRepoDetails.created_at;
-        this.codebase.gitHubRepo.pushedAt = gitHubRepoDetails.pushed_at;
-      }, error => {
-        this.handleError(`Failed to retrieve GitHub repo: ${this.codebase.attributes.url}`, NotificationType.WARNING);
-      }));
-  }
-
-  private handleError(error: string, type: NotificationType) {
-    this.notifications.message({
-      message: error,
-      type: type
-    } as Notification);
   }
 }

--- a/src/app/space/create/codebases/services/codebase.ts
+++ b/src/app/space/create/codebases/services/codebase.ts
@@ -49,5 +49,7 @@ export class GenericLinks {
 // For filtering GitHub repo details
 export class GitHubRepo {
   createdAt?: string;
+  fullName?: string;
+  htmlUrl?: string;
   pushedAt?: string;
 }


### PR DESCRIPTION
fixes openshiftio/openshift.io#1346

There is an error on filtering codebase details by creation date and last commit:
![screenshot from 2018-01-17 12-44-40](https://user-images.githubusercontent.com/1611939/35039115-90b7d37e-fb85-11e7-8c49-e6193501953b.png)

because the codebase-item.component and codebases.component use different instances on codebase object, thus Github details fetched by one - is not accessed by another. To solve the problem - the GitHub data retrieval was moved to the codebases.component and this also solves that we keep fetching GitHub data each time on filtering.


