### PR TITLE
Deployments Http impls

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -273,7 +273,7 @@ describe('DeploymentCardComponent', () => {
     });
 
     it('should be set from mockSvc.getVersion result', () => {
-      expect(mockSvc.getVersion).toHaveBeenCalledWith('mockAppId', 'mockEnvironment');
+      expect(mockSvc.getVersion).toHaveBeenCalledWith('mockSpaceId', 'mockAppId', 'mockEnvironment');
       expect(el.textContent).toEqual('1.2.3');
     });
   });

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -66,7 +66,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
 
           if (active) {
             this.version =
-              this.deploymentsService.getVersion(this.applicationId, this.environment.name);
+              this.deploymentsService.getVersion(this.spaceId, this.applicationId, this.environment.name);
 
             this.logsUrl =
               this.deploymentsService.getLogsUrl(this.spaceId, this.applicationId, this.environment.name);

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -33,9 +33,8 @@ export class DeploymentDetailsComponent {
 
   public cpuData: any = {
     dataAvailable: true,
-    total: 100,
-    xData: ['time', 0],
-    yData: ['used', 1]
+    xData: ['time'],
+    yData: ['used']
   };
 
   public memData: any = {
@@ -100,6 +99,7 @@ export class DeploymentDetailsComponent {
     this.subscriptions.push(this.cpuStat.subscribe(stat => {
       this.cpuVal = stat.used;
       this.cpuMax = stat.quota;
+      this.cpuData.total = stat.quota;
       this.cpuData.yData.push(stat.used);
       this.cpuData.xData.push(this.cpuTime++);
       this.trimSparklineData(this.cpuData);

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -40,9 +40,8 @@ export class DeploymentDetailsComponent {
 
   public memData: any = {
     dataAvailable: true,
-    total: 100,
-    xData: ['time', 0],
-    yData: ['used', 1]
+    xData: ['time'],
+    yData: ['used']
   };
 
   public netData: DeploymentsLinechartData = {
@@ -109,6 +108,7 @@ export class DeploymentDetailsComponent {
     this.subscriptions.push(this.memStat.subscribe(stat => {
       this.memVal = stat.used;
       this.memMax = stat.quota;
+      this.memData.total = stat.quota;
       this.memData.yData.push(stat.used);
       this.memData.xData.push(this.cpuTime++);
       this.memUnits = stat.units;

--- a/src/app/space/create/deployments/deployments.component.html
+++ b/src/app/space/create/deployments/deployments.component.html
@@ -1,4 +1,4 @@
 <div id="apps" class="container-fluid">
   <deployments-apps [spaceId]="spaceId" [environments]="environments" [applications]="applications"></deployments-apps>
-  <deployments-resource-usage [environments]="environments"></deployments-resource-usage>
+  <deployments-resource-usage [spaceId]="spaceId" [environments]="environments"></deployments-resource-usage>
 </div>

--- a/src/app/space/create/deployments/deployments.component.spec.ts
+++ b/src/app/space/create/deployments/deployments.component.spec.ts
@@ -16,8 +16,8 @@ import { DeploymentsService } from './services/deployments.service';
   selector: 'deployments-resource-usage',
   template: ''
 })
-
 class FakeDeploymentsResourceUsageComponent {
+  @Input() spaceId: Observable<string>;
   @Input() environments: Observable<Environment[]>;
 }
 

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -119,6 +119,13 @@ describe('DeploymentsService', () => {
       };
       doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);
     });
+
+    it('should return empty array for null environments response', (done: DoneFn) => {
+      const expectedResponse = {
+        data: null
+      };
+      doMockHttpTest(expectedResponse, [], svc.getEnvironments('foo-spaceId'), done);
+    });
   });
 
   describe('#isApplicationDeployedInEnvironment', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -59,7 +59,7 @@ describe('DeploymentsService', () => {
           provide: AuthenticationService, useValue: mockAuthService
         },
         {
-          provide: WIT_API_URL, useValue: 'http://example.com'
+          provide: WIT_API_URL, useValue: 'http://example.com/'
         },
         DeploymentsService
       ]
@@ -268,6 +268,20 @@ describe('DeploymentsService', () => {
           }
         }
       };
+      const deploymentResponse = {
+        data: {
+          applications: [
+            {
+              name: 'foo-app',
+              pipeline: [
+                {
+                  name: 'foo-env'
+                }
+              ]
+            }
+          ]
+        }
+      };
       const quotaResponse = {
         data: [{
           name: 'foo-env',
@@ -282,10 +296,13 @@ describe('DeploymentsService', () => {
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
         const timeseriesRegex: RegExp = /\/apps\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const deploymentRegex: RegExp = /\/apps\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
         if (timeseriesRegex.test(requestUrl)) {
           responseBody = timeseriesResponse;
+        } else if (deploymentRegex.test(requestUrl)) {
+          responseBody = deploymentResponse;
         } else {
           responseBody = quotaResponse;
         }
@@ -316,6 +333,20 @@ describe('DeploymentsService', () => {
           }
         }
       };
+      const deploymentResponse = {
+        data: {
+          applications: [
+            {
+              name: 'foo-app',
+              pipeline: [
+                {
+                  name: 'foo-env'
+                }
+              ]
+            }
+          ]
+        }
+      };
       const quotaResponse = {
         data: [{
           name: 'foo-env',
@@ -330,10 +361,13 @@ describe('DeploymentsService', () => {
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
         const timeseriesRegex: RegExp = /\/apps\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const deploymentRegex: RegExp = /\/apps\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
         if (timeseriesRegex.test(requestUrl)) {
           responseBody = timeseriesResponse;
+        } else if (deploymentRegex.test(requestUrl)) {
+          responseBody = deploymentResponse;
         } else {
           responseBody = quotaResponse;
         }

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -231,13 +231,25 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getVersion', () => {
-    it('should return 1.0.2', fakeAsync(() => {
-      svc.getVersion('foo', 'bar').subscribe(val => {
-        expect(val).toEqual('1.0.2');
-      });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
+    it('should return 1.0.2', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'stage',
+                  version: '1.0.2'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, expectedResponse.data.applications[0].pipeline[0].version,
+        svc.getVersion('foo-spaceId', 'vertx-hello', 'stage'), done);
+    });
   });
 
   describe('#getDeploymentCpuStat', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -100,6 +100,28 @@ describe('DeploymentsService', () => {
         svc.getApplications('foo-spaceId'), done);
     });
 
+    it('should return empty array if no applications', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: []
+        }
+      };
+      doMockHttpTest(expectedResponse, [],
+        svc.getApplications('foo-spaceId'), done);
+    });
+
+    it('should return singleton array result', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            { name: 'vertx-hello' }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, ['vertx-hello'],
+        svc.getApplications('foo-spaceId'), done);
+    });
+
     it('should return empty array for null applications response', (done: DoneFn) => {
       const expectedResponse = {
         data: {
@@ -118,6 +140,22 @@ describe('DeploymentsService', () => {
         ]
       };
       doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);
+    });
+
+    it('should return singleton array result', (done: DoneFn) => {
+      const expectedResponse = {
+        data: [
+          { name: 'stage' }
+        ]
+      };
+      doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);
+    });
+
+    it('should return empty array if no environments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: []
+      };
+      doMockHttpTest(expectedResponse, [], svc.getEnvironments('foo-spaceId'), done);
     });
 
     it('should return empty array for null environments response', (done: DoneFn) => {
@@ -148,6 +186,28 @@ describe('DeploymentsService', () => {
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'run'), done);
     });
 
+    it('should be true if included in multiple deployments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                },
+                {
+                  name: 'stage'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, true,
+        svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'run'), done);
+    });
+
     it('should be false for excluded deployments', (done: DoneFn) => {
       const expectedResponse = {
         data: {
@@ -167,13 +227,35 @@ describe('DeploymentsService', () => {
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
 
+    it('should be false if excluded in multiple deployments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                },
+                {
+                  name: 'test'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, false,
+        svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
+    });
+
     it('should be false if no deployments', (done: DoneFn) => {
       const expectedResponse = {
         data: {
           applications: [
             {
               name: 'vertx-hello',
-              pipeline: [ ]
+              pipeline: []
             }
           ]
         }
@@ -217,6 +299,38 @@ describe('DeploymentsService', () => {
       doMockHttpTest(expectedResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
     });
 
+    it('should be true if included in multiple applications and environments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                },
+                {
+                  name: 'test'
+                }
+              ]
+            },
+            {
+              name: 'vertx-wiki',
+              pipeline: [
+                {
+                  name: 'run'
+                },
+                {
+                  name: 'stage'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
+    });
+
     it('should be false for excluded environments', (done: DoneFn) => {
       const expectedResponse = {
         data: {
@@ -226,6 +340,14 @@ describe('DeploymentsService', () => {
               pipeline: [
                 {
                   name: 'run'
+                }
+              ]
+            },
+            {
+              name: 'vertx-wiki',
+              pipeline: [
+                {
+                  name: 'test'
                 }
               ]
             }
@@ -241,7 +363,11 @@ describe('DeploymentsService', () => {
           applications: [
             {
               name: 'vertx-hello',
-              pipeline: [ ]
+              pipeline: []
+            },
+            {
+              name: 'vertx-wiki',
+              pipeline: []
             }
           ]
         }
@@ -252,7 +378,7 @@ describe('DeploymentsService', () => {
     it('should be false if no applications exist', (done: DoneFn) => {
       const expectedResponse = {
         data: {
-          applications: [ ]
+          applications: []
         }
       };
       doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -99,6 +99,15 @@ describe('DeploymentsService', () => {
       doMockHttpTest(expectedResponse, expectedResponse.data.applications.map(app => app.name),
         svc.getApplications('foo-spaceId'), done);
     });
+
+    it('should return empty array for null applications response', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: null
+        }
+      };
+      doMockHttpTest(expectedResponse, [], svc.getApplications('foo-spaceId'), done);
+    });
   });
 
   describe('#getEnvironments', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -96,9 +96,8 @@ describe('DeploymentsService', () => {
           ]
         }
       };
-      // skip the first result since it will be a BehaviorSubject default value
       doMockHttpTest(expectedResponse, expectedResponse.data.applications.map(app => app.name),
-        svc.getApplications('foo-spaceId').skip(1), done);
+        svc.getApplications('foo-spaceId'), done);
     });
   });
 
@@ -109,8 +108,7 @@ describe('DeploymentsService', () => {
           { name: 'stage' }, { name: 'run' }, { name: 'test' }
         ]
       };
-      // skip the first result since it will be a BehaviorSubject default value
-      doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId').skip(1), done);
+      doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);
     });
   });
 
@@ -185,14 +183,11 @@ describe('DeploymentsService', () => {
           ]
         }
       };
-      // skip the first result since it will be a BehaviorSubject default value
-      doMockHttpTest(expectedResponse, true,
-        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1), done);
+      doMockHttpTest(expectedResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
     });
 
     it('should be false for excluded environments', (done: DoneFn) => {
-      // prep the service first to avoid "distinctUntilChanged" emission block
-      let expectedResponse = {
+      const expectedResponse = {
         data: {
           applications: [
             {
@@ -206,47 +201,11 @@ describe('DeploymentsService', () => {
           ]
         }
       };
-      // skip the first result since it will be a BehaviorSubject default value
-      doMockHttpTest(expectedResponse, true,
-        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1));
-      expectedResponse = {
-        data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
-                }
-              ]
-            }
-          ]
-        }
-      };
-      doMockHttpTest(expectedResponse, false,
-        svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if no environments are deployed', (done: DoneFn) => {
-      // prep the service first to avoid "distinctUntilChanged" emission block
-      let expectedResponse = {
-        data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
-                }
-              ]
-            }
-          ]
-        }
-      };
-      // skip the first result since it will be a BehaviorSubject default value
-      doMockHttpTest(expectedResponse, true,
-        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1));
-      expectedResponse = {
+      const expectedResponse = {
         data: {
           applications: [
             {
@@ -256,36 +215,16 @@ describe('DeploymentsService', () => {
           ]
         }
       };
-      doMockHttpTest(expectedResponse, false,
-        svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if no applications exist', (done: DoneFn) => {
-      // prep the service first to avoid "distinctUntilChanged" emission block
-      let expectedResponse = {
-        data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
-                }
-              ]
-            }
-          ]
-        }
-      };
-      // skip the first result since it will be a BehaviorSubject default value
-      doMockHttpTest(expectedResponse, true,
-        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1));
-      expectedResponse = {
+      const expectedResponse = {
         data: {
           applications: [ ]
         }
       };
-      doMockHttpTest(expectedResponse, false,
-        svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
   });
 

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -363,4 +363,38 @@ describe('DeploymentsService', () => {
     }));
   });
 
+  describe('#getPods', () => {
+    it('should return pods array', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'stage',
+                  pods: {
+                    total: 6,
+                    running: 1,
+                    starting: 2,
+                    stopping: 3
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, {
+        total: 6,
+        pods: [
+          [ 'Running', 1 ],
+          [ 'Starting', 2 ],
+          [ 'Stopping', 3 ]
+        ]
+      },
+        svc.getPods('foo-spaceId', 'vertx-hello', 'stage'), done);
+    });
+  });
+
 });

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -181,6 +181,21 @@ describe('DeploymentsService', () => {
       doMockHttpTest(expectedResponse, false,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
+
+    it('should be false if deployments is null', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: null
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, false,
+        svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
+    });
   });
 
   describe('#isDeployedInEnvironment', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -304,24 +304,21 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getEnvironmentCpuStat', () => {
-    it('should return a "quota" value of 10', fakeAsync(() => {
-      svc.getEnvironmentCpuStat('foo', 'bar')
-        .subscribe(val => {
-          expect(val.quota).toBe(10);
-        });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
-
-    it('should return a "used" value between 1 and 10', fakeAsync(() => {
-      svc.getEnvironmentCpuStat('foo', 'bar')
-        .subscribe(val => {
-          expect(val.used).toBeGreaterThanOrEqual(1);
-          expect(val.used).toBeLessThanOrEqual(10);
-        });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
+    it('should return a "used" value of 8 and a "quota" value of 10', (done: DoneFn) => {
+      const expectedResponse = {
+        data: [{
+          name: 'stage',
+          quota: {
+            cpucores: {
+              quota: 10,
+              used: 8
+            }
+          }
+        }]
+      };
+      doMockHttpTest(expectedResponse, expectedResponse.data[0].quota.cpucores,
+        svc.getEnvironmentCpuStat('foo-spaceId', 'stage'), done);
+    });
   });
 
   describe('#getEnvironmentMemoryStat', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -68,7 +68,7 @@ describe('DeploymentsService', () => {
     mockBackend = TestBed.get(XHRBackend);
   });
 
-  function doMockHttpTest<U>(response: any, expected: U, obs: Observable<U>, done: DoneFn): void {
+  function doMockHttpTest<U>(response: any, expected: U, obs: Observable<U>, done?: DoneFn): void {
     const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
       connection.mockRespond(new Response(
         new ResponseOptions({
@@ -81,7 +81,9 @@ describe('DeploymentsService', () => {
     obs.subscribe((data: U) => {
       expect(data).toEqual(expected);
       subscription.unsubscribe();
-      done();
+      if (done) {
+        done();
+      }
     });
   }
 
@@ -189,7 +191,8 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false for excluded environments', (done: DoneFn) => {
-      const expectedResponse = {
+      // prep the service first to avoid "distinctUntilChanged" emission block
+      let expectedResponse = {
         data: {
           applications: [
             {
@@ -204,12 +207,46 @@ describe('DeploymentsService', () => {
         }
       };
       // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, true,
+        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1));
+      expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                }
+              ]
+            }
+          ]
+        }
+      };
       doMockHttpTest(expectedResponse, false,
-        svc.isDeployedInEnvironment('foo-spaceId', 'stage').skip(1), done);
+        svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if no environments are deployed', (done: DoneFn) => {
-      const expectedResponse = {
+      // prep the service first to avoid "distinctUntilChanged" emission block
+      let expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, true,
+        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1));
+      expectedResponse = {
         data: {
           applications: [
             {
@@ -219,20 +256,36 @@ describe('DeploymentsService', () => {
           ]
         }
       };
-      // skip the first result since it will be a BehaviorSubject default value
       doMockHttpTest(expectedResponse, false,
-        svc.isDeployedInEnvironment('foo-spaceId', 'stage').skip(1), done);
+        svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if no applications exist', (done: DoneFn) => {
-      const expectedResponse = {
+      // prep the service first to avoid "distinctUntilChanged" emission block
+      let expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, true,
+        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1));
+      expectedResponse = {
         data: {
           applications: [ ]
         }
       };
-      // skip the first result since it will be a BehaviorSubject default value
       doMockHttpTest(expectedResponse, false,
-        svc.isDeployedInEnvironment('foo-spaceId', 'stage').skip(1), done);
+        svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
   });
 

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -144,17 +144,90 @@ describe('DeploymentsService', () => {
       doMockHttpTest(expectedResponse, false,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
+
+    it('should be false if no deployments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [ ]
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, false,
+        svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
+    });
   });
 
   describe('#isDeployedInEnvironment', () => {
-    it('should be true', fakeAsync(() => {
-      svc.isDeployedInEnvironment('foo', 'stage')
-        .subscribe((active: boolean) => {
-          expect(active).toBeTruthy();
-        });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
+    it('should be true for included environments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, true,
+        svc.isDeployedInEnvironment('foo-spaceId', 'run').skip(1), done);
+    });
+
+    it('should be false for excluded environments', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [
+                {
+                  name: 'run'
+                }
+              ]
+            }
+          ]
+        }
+      };
+      // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, false,
+        svc.isDeployedInEnvironment('foo-spaceId', 'stage').skip(1), done);
+    });
+
+    it('should be false if no environments are deployed', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: [ ]
+            }
+          ]
+        }
+      };
+      // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, false,
+        svc.isDeployedInEnvironment('foo-spaceId', 'stage').skip(1), done);
+    });
+
+    it('should be false if no applications exist', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [ ]
+        }
+      };
+      // skip the first result since it will be a BehaviorSubject default value
+      doMockHttpTest(expectedResponse, false,
+        svc.isDeployedInEnvironment('foo-spaceId', 'stage').skip(1), done);
+    });
   });
 
   describe('#getVersion', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -257,6 +257,29 @@ describe('DeploymentsService', () => {
       };
       doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
+
+    it('should be false if applications are null', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: null
+        }
+      };
+      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+    });
+
+    it('should be false if pipeline is null', (done: DoneFn) => {
+      const expectedResponse = {
+        data: {
+          applications: [
+            {
+              name: 'vertx-hello',
+              pipeline: null
+            }
+          ]
+        }
+      };
+      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+    });
   });
 
   describe('#getVersion', () => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -322,33 +322,23 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getEnvironmentMemoryStat', () => {
-    it('should return a "quota" value of 256', fakeAsync(() => {
-      svc.getEnvironmentMemoryStat('foo', 'bar')
-        .subscribe(val => {
-          expect(val.quota).toBe(256);
-        });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
-
-    it('should return a "used" value between 100 and 256', fakeAsync(() => {
-      svc.getEnvironmentMemoryStat('foo', 'bar')
-        .subscribe(val => {
-          expect(val.used).toBeGreaterThanOrEqual(100);
-          expect(val.used).toBeLessThanOrEqual(256);
-        });
-      tick(DeploymentsService.POLL_RATE_MS + 10);
-      discardPeriodicTasks();
-    }));
-
-    it('should return a value in bytes', fakeAsync(() => {
-      svc.getEnvironmentMemoryStat('foo', 'bar')
-        .subscribe(val => {
-          expect(val.units).toEqual('bytes');
-        });
-        tick(DeploymentsService.POLL_RATE_MS + 10);
-        discardPeriodicTasks();
-    }));
+    it('should return a "used" value of 512 and a "quota" value of 1024 with units in "MB"', (done: DoneFn) => {
+      const GB = Math.pow(1024, 3);
+      const expectedResponse = {
+        data: [{
+          name: 'stage',
+          quota: {
+            memory: {
+              used: 0.5 * GB,
+              quota: 1 * GB,
+              units: 'bytes'
+            }
+          }
+        }]
+      };
+      doMockHttpTest(expectedResponse, new ScaledMemoryStat(0.5 * GB, 1 * GB),
+        svc.getEnvironmentMemoryStat('foo-spaceId', 'stage'), done);
+    });
   });
 
   describe('#getDeploymentNetworkStat', () => {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -133,6 +133,7 @@ export class DeploymentsService {
 
   getEnvironments(spaceId: string): Observable<ModelEnvironment[]> {
     return this.getEnvironmentsResponse(spaceId)
+      .map((envs: EnvironmentStat[]) => envs || [])
       .map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => ({ name: env.name} as ModelEnvironment)))
       .distinctUntilChanged((p: ModelEnvironment[], q: ModelEnvironment[]) =>
         deepEqual(new Set<string>(p.map(v => v.name)), new Set<string>(q.map(v => v.name))));

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -21,6 +21,7 @@ import { AuthenticationService } from 'ngx-login-client';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 
 import {
+  flatten,
   includes,
   isEqual as deepEqual
 } from 'lodash';
@@ -110,7 +111,12 @@ export class DeploymentsService {
 
   isDeployedInEnvironment(spaceId: string, environmentName: string):
     Observable<boolean> {
-    return Observable.of(true);
+    return this.getApplicationsResponse(spaceId)
+      .map((apps: Applications) => apps.applications)
+      .map((apps: Application[]) => apps.map((app: Application) => app.pipeline))
+      .map((pipes: Environment[][]) => pipes.map((pipe: Environment[]) => pipe.map((env: Environment) => env.name)))
+      .map((pipeEnvNames: string[][]) => flatten(pipeEnvNames))
+      .map((envNames: string[]) => includes(envNames, environmentName));
   }
 
   getVersion(spaceId: string, environmentName: string): Observable<string> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -66,6 +66,7 @@ export interface EnvironmentStat {
 
 export interface Quota {
   cpucores: CpuStat;
+  memory: MemoryStat;
 }
 
 @Injectable()
@@ -173,11 +174,8 @@ export class DeploymentsService {
   }
 
   getEnvironmentMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
-    return Observable
-      .interval(DeploymentsService.POLL_RATE_MS)
-      .distinctUntilChanged()
-      .map(() => (new ScaledMemoryStat(Math.floor(Math.random() * 156) + 100, 256)))
-      .startWith(new ScaledMemoryStat(200, 256));
+    return this.getEnvironment(spaceId, environmentName)
+      .map((env: EnvironmentStat) => new ScaledMemoryStat(env.quota.memory.used, env.quota.memory.quota));
   }
 
   getLogsUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -125,7 +125,9 @@ export class DeploymentsService {
 
   getApplications(spaceId: string): Observable<string[]> {
     return this.getApplicationsResponse(spaceId)
-      .map((resp: Applications) => resp.applications.map((app: Application) => app.name))
+      .map((resp: Applications) => resp.applications)
+      .map((apps: Application[]) => apps || [])
+      .map((apps: Application[]) => apps.map((app: Application) => app.name))
       .distinctUntilChanged(deepEqual);
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -183,11 +183,13 @@ export class DeploymentsService {
   }
 
   getDeploymentCpuStat(spaceId: string, applicationName: string, environmentName: string): Observable<CpuStat> {
-    return Observable
-      .interval(DeploymentsService.POLL_RATE_MS)
-      .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 9) + 1, quota: 10 } as CpuStat))
-      .startWith({ used: 3, quota: 10 } as CpuStat);
+    const series = this.getTimeseriesData(spaceId, applicationName, environmentName)
+      .map((t: TimeseriesData) => t.cores);
+    const quota = this.getEnvironmentCpuStat(spaceId, environmentName)
+      .map((stat: CpuStat) => stat.quota);
+
+      // TODO: propagate CoresSeries timestamp to caller
+      return Observable.combineLatest(series, quota, (series: CoresSeries, quota: number) => ({ used: series.value, quota: quota }));
   }
 
   getDeploymentMemoryStat(spaceId: string, applicationName: string, environmentName: string): Observable<MemoryStat> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -276,9 +276,10 @@ export class DeploymentsService {
   }
 
   private getDeployment(spaceId: string, applicationName: string, environmentName: string): Observable<Environment> {
+    // does not emit if there are no applications or environments matching the specified names
     return this.getApplication(spaceId, applicationName)
-      .map((app: Application) => app.pipeline)
-      .map((envs: Environment[]) => envs.filter((env: Environment) => env.name === environmentName)[0]);
+      .flatMap((app: Application) => app.pipeline || [])
+      .filter((env: Environment) => env.name === environmentName);
   }
 
   private getEnvironmentsResponse(spaceId: string): Observable<EnvironmentStat[]> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -269,8 +269,9 @@ export class DeploymentsService {
   }
 
   private getApplication(spaceId: string, applicationName: string): Observable<Application> {
+    // does not emit if there are no applications matching the specified name
     return this.getApplicationsResponse(spaceId)
-      .flatMap((apps: Applications) => apps.applications)
+      .flatMap((apps: Applications) => apps.applications || [])
       .filter((app: Application) => app.name === applicationName);
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -154,6 +154,14 @@ export class DeploymentsService {
       .startWith(new ScaledMemoryStat(200, 256));
   }
 
+  getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {
+    return Observable
+      .interval(DeploymentsService.POLL_RATE_MS)
+      .distinctUntilChanged()
+      .map(() => ({ sent: round(Math.random() * 100, 1), received: round(Math.random() * 100, 1) }))
+      .startWith({ sent: 0, received: 0});
+  }
+
   getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
     return Observable
       .interval(DeploymentsService.POLL_RATE_MS)
@@ -168,14 +176,6 @@ export class DeploymentsService {
       .distinctUntilChanged()
       .map(() => (new ScaledMemoryStat(Math.floor(Math.random() * 156) + 100, 256)))
       .startWith(new ScaledMemoryStat(200, 256));
-  }
-
-  getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {
-    return Observable
-      .interval(DeploymentsService.POLL_RATE_MS)
-      .distinctUntilChanged()
-      .map(() => ({ sent: round(Math.random() * 100, 1), received: round(Math.random() * 100, 1) }))
-      .startWith({ sent: 0, received: 0});
   }
 
   getLogsUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -61,6 +61,11 @@ export interface Environment {
 
 export interface EnvironmentStat {
   name: string;
+  quota: Quota;
+}
+
+export interface Quota {
+  cpucores: CpuStat;
 }
 
 @Injectable()
@@ -163,11 +168,8 @@ export class DeploymentsService {
   }
 
   getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
-    return Observable
-      .interval(DeploymentsService.POLL_RATE_MS)
-      .distinctUntilChanged()
-      .map(() => ({ used: Math.floor(Math.random() * 9) + 1, quota: 10 } as CpuStat))
-      .startWith({ used: 3, quota: 10 } as CpuStat);
+    return this.getEnvironment(spaceId, environmentName)
+      .map((env: EnvironmentStat) => env.quota.cpucores);
   }
 
   getEnvironmentMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
@@ -244,6 +246,12 @@ export class DeploymentsService {
       this.envsObservables.set(spaceId, subject);
     }
     return this.envsObservables.get(spaceId);
+  }
+
+  private getEnvironment(spaceId: string, environmentName: string): Observable<EnvironmentStat> {
+    return this.getEnvironmentsResponse(spaceId)
+      .concatMap((envs: EnvironmentStat[]) => Observable.from(envs))
+      .filter((env: EnvironmentStat) => env.name === environmentName);
   }
 
 }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -298,8 +298,9 @@ export class DeploymentsService {
   }
 
   private getEnvironment(spaceId: string, environmentName: string): Observable<EnvironmentStat> {
+    // does not emit if there are no environments matching the specified name
     return this.getEnvironmentsResponse(spaceId)
-      .concatMap((envs: EnvironmentStat[]) => Observable.from(envs))
+      .flatMap((envs: EnvironmentStat[]) => envs || [])
       .filter((env: EnvironmentStat) => env.name === environmentName);
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -143,6 +143,7 @@ export class DeploymentsService {
     Observable<boolean> {
     return this.getApplication(spaceId, applicationName)
       .map((app: Application) => app.pipeline)
+      .map((pipe: Environment[]) => pipe || [])
       .map((pipe: Environment[]) => includes(pipe.map((p: Environment) => p.name), environmentName))
       .distinctUntilChanged();
   }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -152,7 +152,8 @@ export class DeploymentsService {
     Observable<boolean> {
     return this.getApplicationsResponse(spaceId)
       .map((apps: Applications) => apps.applications)
-      .map((apps: Application[]) => apps.map((app: Application) => app.pipeline))
+      .map((apps: Application[]) => apps || [])
+      .map((apps: Application[]) => apps.map((app: Application) => app.pipeline || []))
       .map((pipes: Environment[][]) => pipes.map((pipe: Environment[]) => pipe.map((env: Environment) => env.name)))
       .map((pipeEnvNames: string[][]) => flatten(pipeEnvNames))
       .map((envNames: string[]) => includes(envNames, environmentName))

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -140,7 +140,8 @@ export class DeploymentsService {
     Observable<boolean> {
     return this.getApplication(spaceId, applicationName)
       .map((app: Application) => app.pipeline)
-      .map((pipe: Environment[]) => includes(pipe.map((p: Environment) => p.name), environmentName));
+      .map((pipe: Environment[]) => includes(pipe.map((p: Environment) => p.name), environmentName))
+      .distinctUntilChanged();
   }
 
   isDeployedInEnvironment(spaceId: string, environmentName: string):
@@ -150,12 +151,14 @@ export class DeploymentsService {
       .map((apps: Application[]) => apps.map((app: Application) => app.pipeline))
       .map((pipes: Environment[][]) => pipes.map((pipe: Environment[]) => pipe.map((env: Environment) => env.name)))
       .map((pipeEnvNames: string[][]) => flatten(pipeEnvNames))
-      .map((envNames: string[]) => includes(envNames, environmentName));
+      .map((envNames: string[]) => includes(envNames, environmentName))
+      .distinctUntilChanged();
   }
 
   getVersion(spaceId: string, applicationName: string, environmentName: string): Observable<string> {
     return this.getDeployment(spaceId, applicationName, environmentName)
-      .map((env: Environment) => env.version);
+      .map((env: Environment) => env.version)
+      .distinctUntilChanged();
   }
 
   scalePods(
@@ -179,7 +182,8 @@ export class DeploymentsService {
             [ 'Stopping', pods.stopping ]
           ]
         } as ModelPods;
-      });
+      })
+      .distinctUntilChanged(deepEqual);
   }
 
   getDeploymentCpuStat(spaceId: string, applicationName: string, environmentName: string): Observable<CpuStat> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -316,8 +316,11 @@ export class DeploymentsService {
 
             const url = `${this.apiUrl}${spaceId}/applications/${applicationId}/deployments/${environmentName}/stats`;
             const observable = Observable.concat(Observable.of(0), this.pollTimer)
-              .concatMap(() => this.http.get(url, { headers: this.headers }))
-              .map((response: Response) => (response.json() as TimeseriesResponse).data);
+              .concatMap(() =>
+                this.http.get(url, { headers: this.headers })
+                  .map((response: Response) => (response.json() as TimeseriesResponse).data)
+                  .catch(() => Observable.of(emptyResult))
+              );
             observable.subscribe(subject);
             this.timeseriesObservables.set(key, subject);
           }


### PR DESCRIPTION
This set of commits replaces most of the DeploymentsServices functions with implementations that perform queries to the backend WIT endpoint, rather than returning mock data. This brings the UI up to speed with the current state of the API provided by the endpoint as of the time of writing.

Notable bugs:
- network sparkline is still mocked - no backend support
- dropdown menu items (View logs, Open Application, etc.) are still mocked - no backend support
- pods donut does not support all possible pod states, and can incorrectly display legend items for pod states that are not actually represented in the data. The next version of the backend API has a more suitable response format, so I've simply taken a "good enough" shortcut for the time being
- memory sparkline does not seem to respect the "total" amount on the graph. For my own personal example deployment, the sparkline is pegged at 100% even though the data shows 151.4/1024 MB.