### PR TITLE
Make choice about experimental features persistent

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,7 +9,7 @@
   <div class="">
     <router-outlet name="action"></router-outlet>
     <div [hidden]="!isExperimentalFeature"> <!--if not exp feature, hide-->
-      <f8-feature-banner level="{{featureEnablementLevel}}">
+      <f8-feature-banner level="{{featureEnablementLevel}}" [featureName]="featureName">
       </f8-feature-banner>
       <div [hidden]="experimentalFeatureEnabled"> <!-- not enable for this user -->
         <f8-feature-warning-page level="{{featureEnablementLevel}}">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,7 @@ import { NotificationsService } from './shared/notifications.service';
 })
 export class AppComponent {
   public experimentalFeatureEnabled: boolean;
+  public featureName: string;
   public isExperimentalFeature: boolean;
   public featureEnablementLevel: string;
   public disconnectedStateConfig: EmptyStateConfig;
@@ -73,6 +74,7 @@ export class AppComponent {
         this.experimentalFeatureEnabled = false;
         this.isExperimentalFeature = false;
         this.featureEnablementLevel = '';
+        this.featureName = undefined;
         while (route.firstChild) {
           route = route.firstChild;
         }
@@ -96,6 +98,7 @@ export class AppComponent {
           this.experimentalFeatureEnabled = featureFlagConfig.enabled;
           this.isExperimentalFeature = true;
           this.featureEnablementLevel = featureFlagConfig.showBanner;
+          this.featureName = featureFlagConfig.name;
         }
         let title = event['title'] ? `${event['title']} - ${this.brandingService.name}` : this.brandingService.name;
         this.titleService.setTitle(title);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { AppState, InternalStateType } from './app.service';
 // Footer & Header
 import { FeatureBannerComponent } from './feature-flag/banner/feature-banner.component';
 import { FeatureFlagResolver } from './feature-flag/resolver/feature-flag.resolver';
+import { FeatureAcknowledgementService } from './feature-flag/service/feature-acknowledgement.service';
 import { FeatureTogglesService } from './feature-flag/service/feature-toggles.service';
 import { FeatureWarningPageComponent } from './feature-flag/warning-page/feature-warning-page.component';
 
@@ -209,6 +210,7 @@ export type StoreType = {
       provide: OnLogin,
       useClass: Fabric8UIOnLogin
     },
+    FeatureAcknowledgementService,
     forgeApiUrlProvider,
     GettingStartedService,
     HttpService,

--- a/src/app/feature-flag/banner/feature-banner.component.ts
+++ b/src/app/feature-flag/banner/feature-banner.component.ts
@@ -1,28 +1,35 @@
 import {
   Component,
   Input,
+  OnChanges,
   OnDestroy,
-  OnInit
+  OnInit,
+  SimpleChanges
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthenticationService, UserService } from 'ngx-login-client';
 import { Subscription } from 'rxjs';
+
+import { FeatureAcknowledgementService } from '../service/feature-acknowledgement.service';
 
 @Component({
   selector: 'f8-feature-banner',
   templateUrl: './feature-banner.component.html',
   styleUrls: ['./feature-banner.component.less']
 })
-export class FeatureBannerComponent implements OnInit, OnDestroy {
+export class FeatureBannerComponent implements OnInit, OnChanges, OnDestroy {
+
+  @Input() featureName: string;
+  @Input() level: string;
 
   public hideBanner: boolean;
   public profileLink: string;
   private userSubscription: Subscription;
-  @Input() level: string;
 
   constructor(public router: Router,
-              userService: UserService,
-              authService: AuthenticationService) {
+              private authService: AuthenticationService,
+              private featureAcknowledgementService: FeatureAcknowledgementService,
+              private userService: UserService) {
 
     if (authService.isLoggedIn()) {
       this.userSubscription = userService.loggedInUser.subscribe(val => {
@@ -39,6 +46,14 @@ export class FeatureBannerComponent implements OnInit, OnDestroy {
     this.hideBanner = false;
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['featureName']) {
+      if (this.featureName !== undefined) {
+        this.hideBanner = this.featureAcknowledgementService.getAcknowledgement(this.featureName);
+      }
+    }
+  }
+
   ngOnDestroy() {
     if (this.userSubscription) {
       this.userSubscription.unsubscribe();
@@ -47,5 +62,6 @@ export class FeatureBannerComponent implements OnInit, OnDestroy {
 
   acknowledgeWarning() {
     this.hideBanner = true;
+    this.featureAcknowledgementService.setAcknowledgement(this.featureName, true);
   }
 }

--- a/src/app/feature-flag/service/feature-acknowledgement.service.ts
+++ b/src/app/feature-flag/service/feature-acknowledgement.service.ts
@@ -1,0 +1,90 @@
+import { Inject, Injectable, OnDestroy } from '@angular/core';
+import { Http } from '@angular/http';
+import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
+
+import { Logger } from 'ngx-base';
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { AuthenticationService, UserService } from 'ngx-login-client';
+import { Observable, Subscription } from 'rxjs';
+
+/**
+ * A service to manage the user acknowledgement to dismiss the warning displayed by the experimental feature banner
+ */
+@Injectable()
+export class FeatureAcknowledgementService extends GettingStartedService implements OnDestroy {
+  subscriptions: Subscription[] = [];
+
+  constructor(
+      protected auth: AuthenticationService,
+      protected http: Http,
+      protected logger: Logger,
+      protected userService: UserService,
+      @Inject(WIT_API_URL) apiUrl: string) {
+    super(auth, http, logger, userService, apiUrl);
+  }
+
+  ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.subscriptions.forEach(sub => {
+      sub.unsubscribe();
+    });
+  }
+
+  /**
+   * Returns user acknowledgement
+   *
+   * @param {string} featureName The name of the experimental feature
+   * @returns {boolean} True if the user acknowledged a warning for the given feature
+   */
+  getAcknowledgement(featureName: string): boolean {
+    if (featureName === undefined || featureName.length === 0) {
+      return;
+    }
+    let acknowledged: boolean = false;
+    let profile = this.getTransientProfile();
+    if (profile.contextInformation === undefined) {
+      return acknowledged;
+    }
+    if (profile.contextInformation.featureAcknowledgement !== undefined) {
+      acknowledged = Boolean(profile.contextInformation.featureAcknowledgement[featureName]);
+    }
+    return acknowledged;
+  }
+
+  /**
+   * Save user acknowledgement
+   *
+   * @param {string} featureName The name of the experimental feature
+   * @param {boolean} acknowledged True if the user acknowledged a warning for the given feature
+   */
+  setAcknowledgement(featureName: string, acknowledged: boolean): void {
+    if (featureName === undefined || featureName.length === 0) {
+      return;
+    }
+    let profile = this.getTransientProfile();
+    if (profile.contextInformation.featureAcknowledgement === undefined) {
+      profile.contextInformation.featureAcknowledgement = {};
+    }
+    profile.contextInformation.featureAcknowledgement[featureName] = acknowledged;
+
+    this.subscriptions.push(this.update(profile).subscribe(user => {
+      // Do nothing
+    }, error => {
+      this.logger.error('Failed to save acknowledge state');
+    }));
+  }
+
+  // Private
+
+  /**
+   * Get transient profile with updated properties
+   *
+   * @returns {ExtProfile} The updated transient profile
+   */
+  private getTransientProfile(): ExtProfile {
+    let profile = this.createTransientProfile();
+    delete profile.username;
+
+    return profile;
+  }
+}

--- a/src/app/getting-started/services/getting-started.service.ts
+++ b/src/app/getting-started/services/getting-started.service.ts
@@ -26,10 +26,10 @@ export class GettingStartedService implements OnDestroy {
   private usersUrl: string;
 
   constructor(
-      private auth: AuthenticationService,
-      private http: Http,
-      private logger: Logger,
-      private userService: UserService,
+      protected auth: AuthenticationService,
+      protected http: Http,
+      protected logger: Logger,
+      protected userService: UserService,
       @Inject(WIT_API_URL) apiUrl: string) {
     if (this.auth.getToken() != undefined) {
       this.headers.set('Authorization', 'Bearer ' + this.auth.getToken());
@@ -49,13 +49,13 @@ export class GettingStartedService implements OnDestroy {
     this.userService.loggedInUser
       .map(user => {
         profile = cloneDeep(user) as ExtUser;
-        if (profile.attributes != undefined) {
+        if (profile.attributes !== undefined) {
           profile.attributes.contextInformation = (user as ExtUser).attributes.contextInformation || {};
         }
       })
       .publish().connect();
 
-    return profile.attributes;
+    return (profile !== undefined) ? profile.attributes : {} as ExtProfile;
   }
 
   /**
@@ -101,7 +101,7 @@ export class GettingStartedService implements OnDestroy {
 
   // Private
 
-  private handleError(error: any) {
+  protected handleError(error: any) {
     this.logger.error(error);
     return Observable.throw(error.message || error);
   }


### PR DESCRIPTION
This PR introduces a service to manage the user's acknowledgement when dismissing the warning displayed by the experimental feature banner. This flag is stored the user's contextInformation property, under featureAcknowledgement['feature name']. Placed this service under src/app/feature-flag/service directory in anticipation of upcoming feat flag changes.

Fixes: https://github.com/openshiftio/openshift.io/issues/1557