### PR TITLE
fix(spaces): Add missing code to commit fixing double scrollbar

### DIFF
--- a/src/assets/stylesheets/shared/_scrollbars.less
+++ b/src/assets/stylesheets/shared/_scrollbars.less
@@ -1,0 +1,7 @@
+.no-vertical-scroll {
+  overflow-y: hidden;
+}
+
+.no-horizontal-scroll {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
The previous commit resolving the bug in which a double scroll bar
appears in the profile overview was missing some styling code, which
is added back in this patch. The original hash is 205aa0b4d343e2cb3da0c73cf7a19babb7830dd5

