### PR TITLE
Deployments chart uses real network stats

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -26,7 +26,7 @@
         <f8-deployments-linechart [config]="netConfig" [chartData]="netData"></f8-deployments-linechart>
       </div>
       <div class="chart-column">
-        <deployment-graph-label type="Network" [dataMeasure]="'KiB/s'" [value]="netVal"></deployment-graph-label>
+        <deployment-graph-label type="Network" [dataMeasure]="netUnits + '/s'" [value]="netVal"></deployment-graph-label>
       </div>
     </div>
   </ng-container>

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -10,6 +10,7 @@ import { Observable, Subscription } from 'rxjs';
 import { CpuStat } from '../models/cpu-stat';
 import { Environment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
+import { ScaledNetworkStat } from '../models/scaled-network-stat';
 import { DeploymentsService } from '../services/deployments.service';
 
 import { DeploymentsLinechartConfig } from '../deployments-linechart/deployments-linechart-config';
@@ -63,6 +64,7 @@ export class DeploymentDetailsComponent {
 
   public netConfig: DeploymentsLinechartConfig = {
     chartId: uniqueId('net-chart'),
+    units: 'bytes',
     showXAxis: true
   };
 
@@ -76,6 +78,7 @@ export class DeploymentDetailsComponent {
   memUnits: string;
   memMax: number;
   netVal: number;
+  netUnits: string;
 
   sparklineMaxElements: number;
 
@@ -118,10 +121,12 @@ export class DeploymentDetailsComponent {
     this.subscriptions.push(
       this.deploymentsService.getDeploymentNetworkStat(this.spaceId, this.applicationId, this.environment.name)
         .subscribe(stat => {
-          this.netVal = round(stat.received + stat.sent, 1);
+          const netTotal: ScaledNetworkStat = new ScaledNetworkStat(stat.received.raw + stat.sent.raw);
+          this.netVal = round(netTotal.used, 1);
+          this.netUnits = netTotal.units;
           this.netData.xData.push(+new Date());
-          this.netData.yData[0].push(stat.sent);
-          this.netData.yData[1].push(stat.received);
+          this.netData.yData[0].push(stat.sent.raw);
+          this.netData.yData[1].push(stat.received.raw);
           this.trimLinechartData(this.netData);
         })
     );

--- a/src/app/space/create/deployments/models/scaled-network-stat.spec.ts
+++ b/src/app/space/create/deployments/models/scaled-network-stat.spec.ts
@@ -1,0 +1,27 @@
+import { ScaledNetworkStat } from './scaled-network-stat';
+
+describe('ScaledNetworkStat', () => {
+
+  it('should not scale 500 bytes', () => {
+    let stat = new ScaledNetworkStat(500);
+    expect(stat.raw).toEqual(500);
+    expect(stat.used).toEqual(500);
+    expect(stat.units).toEqual('bytes');
+  });
+
+  it('should scale 2048 bytes', () => {
+    let stat = new ScaledNetworkStat(2048);
+    expect(stat.raw).toEqual(2048);
+    expect(stat.used).toEqual(2);
+    expect(stat.units).toEqual('KB');
+  });
+
+  it('should scale 5.5GB', () => {
+    let gb = Math.pow(1024, 3);
+    let stat = new ScaledNetworkStat(5.5 * gb);
+    expect(stat.raw).toEqual(5.5 * gb);
+    expect(stat.used).toEqual(5.5);
+    expect(stat.units).toEqual('GB');
+  });
+
+});

--- a/src/app/space/create/deployments/models/scaled-network-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-network-stat.ts
@@ -1,0 +1,24 @@
+import { MemoryUnit } from './memory-stat';
+
+import { round } from 'lodash';
+
+export class ScaledNetworkStat {
+
+  private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
+
+  public raw: number;
+  public units: MemoryUnit;
+
+  constructor(
+    public used: number
+  ) {
+    this.raw = used;
+    let scale = 0;
+    while (this.used > 1024 && scale < ScaledNetworkStat.UNITS.length) {
+      this.used /= 1024;
+      scale++;
+    }
+    this.used = round(this.used, 1);
+    this.units = ScaledNetworkStat.UNITS[scale] as MemoryUnit;
+  }
+}

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -40,6 +40,7 @@ import {
   DeploymentsService,
   NetworkStat
 } from './deployments.service';
+import { ScaledNetworkStat } from 'app/space/create/deployments/models/scaled-network-stat';
 
 describe('DeploymentsService', () => {
 
@@ -563,16 +564,16 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getDeploymentNetworkStat', () => {
-    it('should return timeseries data', (done: DoneFn) => {
+    it('should return scaled timeseries data', (done: DoneFn) => {
       const timeseriesResponse = {
         data: {
           net_tx: {
             time: 0,
-            value: 1
+            value: 1.7
           },
           net_rx: {
             time: 2,
-            value: 3
+            value: 3.1
           }
         }
       };
@@ -612,7 +613,7 @@ describe('DeploymentsService', () => {
 
       svc.getDeploymentNetworkStat('foo-space', 'foo-app', 'foo-env')
         .subscribe((stat: NetworkStat) => {
-          expect(stat).toEqual({ sent: 1, received: 3 });
+          expect(stat).toEqual({ sent: new ScaledNetworkStat(1.7), received: new ScaledNetworkStat(3.1) });
           subscription.unsubscribe();
           done();
         });

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -37,7 +37,8 @@ import { MemoryStat } from '../models/memory-stat';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 import {
   Application,
-  DeploymentsService
+  DeploymentsService,
+  NetworkStat
 } from './deployments.service';
 
 describe('DeploymentsService', () => {
@@ -561,6 +562,63 @@ describe('DeploymentsService', () => {
     });
   });
 
+  describe('#getDeploymentNetworkStat', () => {
+    it('should return timeseries data', (done: DoneFn) => {
+      const timeseriesResponse = {
+        data: {
+          net_tx: {
+            time: 0,
+            value: 1
+          },
+          net_rx: {
+            time: 2,
+            value: 3
+          }
+        }
+      };
+
+      const deploymentResponse = {
+        data: {
+          applications: [
+            {
+              name: 'foo-app',
+              pipeline: [
+                {
+                  name: 'foo-env'
+                }
+              ]
+            }
+          ]
+        }
+      };
+
+      const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+        const timeseriesRegex: RegExp = /\/apps\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const deploymentRegex: RegExp = /\/apps\/spaces\/foo-space$/;
+        const requestUrl: string = connection.request.url;
+        let responseBody: any;
+        if (timeseriesRegex.test(requestUrl)) {
+          responseBody = timeseriesResponse;
+        } else if (deploymentRegex.test(requestUrl)) {
+          responseBody = deploymentResponse;
+        }
+        connection.mockRespond(new Response(
+          new ResponseOptions({
+            body: JSON.stringify(responseBody),
+            status: 200
+          })
+        ));
+      });
+
+      svc.getDeploymentNetworkStat('foo-space', 'foo-app', 'foo-env')
+        .subscribe((stat: NetworkStat) => {
+          expect(stat).toEqual({ sent: 1, received: 3 });
+          subscription.unsubscribe();
+          done();
+        });
+    });
+  });
+
   describe('#getEnvironmentCpuStat', () => {
     it('should return a "used" value of 8 and a "quota" value of 10', (done: DoneFn) => {
       const expectedResponse = {
@@ -597,28 +655,6 @@ describe('DeploymentsService', () => {
       doMockHttpTest(expectedResponse, new ScaledMemoryStat(0.5 * GB, 1 * GB),
         svc.getEnvironmentMemoryStat('foo-spaceId', 'stage'), done);
     });
-  });
-
-  describe('#getDeploymentNetworkStat', () => {
-    it('should return a "sent" value between 0 and 100', fakeAsync(() => {
-      svc.getDeploymentNetworkStat('foo', 'bar', 'baz')
-        .subscribe(val => {
-          expect(val.sent).toBeGreaterThanOrEqual(0);
-          expect(val.sent).toBeLessThanOrEqual(100);
-        });
-        tick(DeploymentsService.POLL_RATE_MS + 10);
-        discardPeriodicTasks();
-    }));
-
-    it('should return a "received" value between 0 and 100', fakeAsync(() => {
-      svc.getDeploymentNetworkStat('foo', 'bar', 'baz')
-        .subscribe(val => {
-          expect(val.received).toBeGreaterThanOrEqual(0);
-          expect(val.received).toBeLessThanOrEqual(100);
-        });
-        tick(DeploymentsService.POLL_RATE_MS + 10);
-        discardPeriodicTasks();
-    }));
   });
 
   describe('#getPods', () => {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -84,11 +84,17 @@ export interface Pods {
 export interface TimeseriesData {
   cores: CoresSeries;
   memory: MemorySeries;
+  net_tx: NetworkSentSeries;
+  net_rx: NetworkReceivedSeries;
 }
 
 export interface CoresSeries extends SeriesData { }
 
 export interface MemorySeries extends SeriesData { }
+
+export interface NetworkSentSeries extends SeriesData { }
+
+export interface NetworkReceivedSeries extends SeriesData { }
 
 export interface SeriesData {
   time: number;
@@ -220,11 +226,9 @@ export class DeploymentsService {
   }
 
   getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {
-    return Observable
-      .interval(DeploymentsService.POLL_RATE_MS)
-      .distinctUntilChanged()
-      .map(() => ({ sent: round(Math.random() * 100, 1), received: round(Math.random() * 100, 1) }))
-      .startWith({ sent: 0, received: 0});
+    // TODO: propagate timestamps to caller
+    return this.getTimeseriesData(spaceId, applicationId, environmentName)
+      .map((t: TimeseriesData) => ({ sent: t.net_tx.value, received: t.net_rx.value } as NetworkStat));
   }
 
   getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
@@ -320,6 +324,14 @@ export class DeploymentsService {
         value: 0
       },
       memory: {
+        time: currentTime,
+        value: 0
+      },
+      net_tx: {
+        time: currentTime,
+        value: 0
+      },
+      net_rx: {
         time: currentTime,
         value: 0
       }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -31,10 +31,11 @@ import { Environment as ModelEnvironment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
 import { Pods as ModelPods } from '../models/pods';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
+import { ScaledNetworkStat } from '../models/scaled-network-stat';
 
 export interface NetworkStat {
-  sent: number;
-  received: number;
+  sent: ScaledNetworkStat;
+  received: ScaledNetworkStat;
 }
 
 export interface ApplicationsResponse {
@@ -228,7 +229,12 @@ export class DeploymentsService {
   getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {
     // TODO: propagate timestamps to caller
     return this.getTimeseriesData(spaceId, applicationId, environmentName)
-      .map((t: TimeseriesData) => ({ sent: t.net_tx.value, received: t.net_rx.value } as NetworkStat));
+      .map((t: TimeseriesData) =>
+        ({
+          sent: new ScaledNetworkStat(t.net_tx.value),
+          received: new ScaledNetworkStat(t.net_rx.value)
+        } as NetworkStat)
+      );
   }
 
   getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {


### PR DESCRIPTION
This is the UI counterpart to the WIT PR here: https://github.com/fabric8-services/fabric8-wit/pull/1851 . This PR should not be merged until after that one is merged and deployed.

This replaces the mock implementation of DeploymentsService#getDeploymentNetworkStat with a real implementation that pulls timeseries data provided by the backend. The data is also autoscaled similar to the Memory stat chart.