### PR TITLE
fix(deployments): sort and filter environments to only show stage and…

### DIFF
--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -134,12 +134,13 @@ describe('DeploymentsService', () => {
 
   describe('#getEnvironments', () => {
     it('should publish faked, filtered and sorted environments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: [
-          { name: 'stage' }, { name: 'run' }
+          { name: 'run' }, { name: 'test' }, { name: 'stage'}
         ]
       };
-      doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);
+      const expectedResponse = [{ name: 'stage' }, { name: 'run' }];
+      doMockHttpTest(httpResponse, expectedResponse, svc.getEnvironments('foo-spaceId'), done);
     });
 
     it('should return singleton array result', (done: DoneFn) => {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -133,10 +133,10 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getEnvironments', () => {
-    it('should publish faked environments', (done: DoneFn) => {
+    it('should publish faked, filtered and sorted environments', (done: DoneFn) => {
       const expectedResponse = {
         data: [
-          { name: 'stage' }, { name: 'run' }, { name: 'test' }
+          { name: 'stage' }, { name: 'run' }
         ]
       };
       doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -132,6 +132,7 @@ export class DeploymentsService {
   }
 
   getEnvironments(spaceId: string): Observable<ModelEnvironment[]> {
+    // Note: Sorting and filtering out test should ideally be moved to the backend
     return this.getEnvironmentsResponse(spaceId)
       .map((envs: EnvironmentStat[]) => envs || [])
       .map((envs: EnvironmentStat[]) => envs.sort((a, b) =>  -1 * a.name.localeCompare(b.name)))

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -133,8 +133,11 @@ export class DeploymentsService {
 
   getEnvironments(spaceId: string): Observable<ModelEnvironment[]> {
     return this.getEnvironmentsResponse(spaceId)
-      .map((envs: EnvironmentStat[]) => envs || [])
-      .map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => ({ name: env.name} as ModelEnvironment)))
+      .map((envs: EnvironmentStat[]) => envs ? envs.sort((a, b) =>  -1 * a.name.localeCompare(b.name)) : [])
+      .map((envs: EnvironmentStat[]) => envs
+        .filter((env: EnvironmentStat) => env.name !== 'test')
+        .map((env: EnvironmentStat) => ({ name: env.name} as ModelEnvironment))
+      )
       .distinctUntilChanged((p: ModelEnvironment[], q: ModelEnvironment[]) =>
         deepEqual(new Set<string>(p.map(v => v.name)), new Set<string>(q.map(v => v.name))));
   }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -133,7 +133,8 @@ export class DeploymentsService {
 
   getEnvironments(spaceId: string): Observable<ModelEnvironment[]> {
     return this.getEnvironmentsResponse(spaceId)
-      .map((envs: EnvironmentStat[]) => envs ? envs.sort((a, b) =>  -1 * a.name.localeCompare(b.name)) : [])
+      .map((envs: EnvironmentStat[]) => envs || [])
+      .map((envs: EnvironmentStat[]) => envs.sort((a, b) =>  -1 * a.name.localeCompare(b.name)))
       .map((envs: EnvironmentStat[]) => envs
         .filter((env: EnvironmentStat) => env.name !== 'test')
         .map((env: EnvironmentStat) => ({ name: env.name} as ModelEnvironment))


### PR DESCRIPTION
… run

This makes sure the UI only shows stage and run in the correct order. See [1] for more information.

[1] https://github.com/openshiftio/openshift.io/issues/1907
