### PR TITLE
fix(deployments): hide empty statuses from pod legend

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -18,7 +18,9 @@
   </div>
 </div>
 <div class="deployments-donut-legend" *ngIf="!mini">
-  <div *ngFor="let column of (pods | async)?.pods">
-    <div class="deployments-donut-square" [style.background]='colors[column[0]]'></div>{{ column[1] > 0 ? column[1] + ' ' + column[0] : '' }}
-  </div>
+  <ng-container *ngFor="let column of (pods | async)?.pods">
+    <div *ngIf="column[1] > 0">
+      <div class="deployments-donut-square" [style.background]='colors[column[0]]'></div>{{ column[1] + ' ' + column[0] }}
+    </div>
+  </ng-container>
 </div>


### PR DESCRIPTION
This fixes the pod legend to not display statuses that have 0 pods. For example, if data comes back as 1 running, 0 stopped, it no longer shows 0 stopped.

Before:
![legend-broken](https://user-images.githubusercontent.com/5430520/35159844-89789762-fd09-11e7-976a-5bfd76075fc7.png)

After:
![legend-fixed](https://user-images.githubusercontent.com/5430520/35159848-8d1fc8c2-fd09-11e7-8d54-126f2d6bff7d.png)
