### PR TITLE
fix(deployments): tweak deployments toolbar width

### DIFF
--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.less
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.less
@@ -1,0 +1,5 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+deployments-toolbar pfng-filter-fields .filter-pf.filter-fields .form-group {
+  width: 100%;
+}

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
@@ -22,7 +22,8 @@ import {
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'deployments-toolbar',
-  templateUrl: './deployments-toolbar.component.html'
+  templateUrl: './deployments-toolbar.component.html',
+  styleUrls: ['./deployments-toolbar.component.less']
 })
 export class DeploymentsToolbarComponent implements OnChanges, OnInit {
 


### PR DESCRIPTION
This PR extends the width of the deployments toolbar in an attempt to more closely follow the UX design [0].

There was a line in the patternfly css that was fixing the width of the toolbar to 275px. Because of this, the default text inside of the toolbar ("Filter by Application Name ...") gets cut-off inside of the input box.

Here is what the toolbar looks like currently:
![tweak-toolbar-width-1](https://user-images.githubusercontent.com/10425301/35171323-69bc32d0-fd31-11e7-8853-4c85656b70e3.png)

And here's what the toolbar would look like after this PR:
![tweak-toolbar-width-2](https://user-images.githubusercontent.com/10425301/35171362-98b79692-fd31-11e7-854b-001143e65ba0.png)

[0] https://redhat.invisionapp.com/share/YSDL0KRKW#/screens/260764293
