### PR TITLE
Add null checks before accessing space references

### DIFF
--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -10,7 +10,7 @@
               *ngIf="isEditing && (isEditable() | async)"
               (keyup.enter)="onUpdateDescription(description.value)"
               (keydown.enter)="preventDef($event)"
-              #description>{{space.attributes.description}}</textarea>
+              #description>{{space?.attributes.description}}</textarea>
     <div *ngIf="isEditing">
       <button id="_btn_cancel"
               class="pull-right btn btn-default edit-space-description-btn"
@@ -25,7 +25,7 @@
       </button>
     </div>
     <span *ngIf="!isEditing || !(isEditable() | async)" (click)="startEditingDescription()" class="edit-space-description-span">
-      {{space.attributes.description || "Enter a description"}}
+      {{space?.attributes.description || "Enter a description"}}
     </span>
   </div>
 </div>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
@@ -48,8 +48,8 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit {
         let patch = {
           attributes: {
             description: description,
-            name: this.space.attributes.name,
-            version: this.space.attributes.version
+            name: this.space ? this.space.attributes.name : '',
+            version: this.space ? this.space.attributes.version : ''
           },
           type: 'spaces',
           id: this.space.id
@@ -62,7 +62,9 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit {
         .do(val => {
           console.log('updatedspace', val);
           this.isEditing = false;
-          this.space.attributes.description = val.attributes.description;
+          if (this.space && val) {
+            this.space.attributes.description = val.attributes.description;
+          }
         })
         .do(updated => this.broadcaster.broadcast('spaceUpdated', updated))
         .switchMap(updated => this.spaceNamespaceService.updateConfigMap(Observable.of(updated)))

--- a/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
+++ b/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
@@ -217,14 +217,13 @@ export class EnvironmentWidgetComponent extends AbstractWatchComponent  implemen
   }
 
   private filterDeploymentViews(deploymentViews: DeploymentViews): DeploymentViews {
-    let spaceId = this.currentContext.space.attributes.name;
-    if (!spaceId) {
+    if (!this.currentContext.space || !this.currentContext.space.attributes.name) {
       return deploymentViews;
     }
     let answer = new DeploymentViews();
     deploymentViews.forEach(dep => {
       let depSpace = dep.labels['space'];
-      if (!depSpace || depSpace === spaceId) {
+      if (!depSpace || depSpace === this.currentContext.space.attributes.name) {
         answer.push(dep);
       }
     });

--- a/src/app/shared/runtime-console/fabric8-ui-space-namespace.service.ts
+++ b/src/app/shared/runtime-console/fabric8-ui-space-namespace.service.ts
@@ -25,7 +25,7 @@ export class Fabric8UISpaceNamespace implements SpaceNamespace {
   get labelSpace(): Observable<string> {
     return this.fabric8RuntimeConsoleService
       .loading()
-      .switchMap(() => this.spaces.current.map(space => space.attributes.name))
+      .switchMap(() => this.spaces.current.map(space => space ? space.attributes.name : ''))
       .do(val => console.log('labelSpaceStr', val));
   }
 

--- a/src/app/shared/runtime-console/space-namespace.service.ts
+++ b/src/app/shared/runtime-console/space-namespace.service.ts
@@ -91,14 +91,16 @@ export class SpaceNamespaceService {
       }
     )
       .do(val => {
-        val.data[val.space.attributes.name] = val.data.get(val.space.attributes.name) || {};
-        val.data[val.space.attributes.name]['name'] = val.space.attributes.name;
-        if (val.space.attributes.description) {
-          val.data[val.space.attributes.name]['description'] = val.space.attributes.description;
+        if (val.space) {
+          val.data[val.space.attributes.name] = val.data.get(val.space.attributes.name) || {};
+          val.data[val.space.attributes.name]['name'] = val.space.attributes.name;
+          if (val.space.attributes.description) {
+            val.data[val.space.attributes.name]['description'] = val.space.attributes.description;
+          }
+          val.data[val.space.attributes.name]['creator'] = val.space.relationalData.creator.attributes.username;
+          val.data[val.space.attributes.name]['id'] = val.space.id;
+          val.data[val.space.attributes.name]['version'] = 'v1';
         }
-        val.data[val.space.attributes.name]['creator'] = val.space.relationalData.creator.attributes.username;
-        val.data[val.space.attributes.name]['id'] = val.space.id;
-        val.data[val.space.attributes.name]['version'] = 'v1';
       })
       .switchMap(val => {
         let cm = val.configMap;


### PR DESCRIPTION
This adds some null checks to code that accesses space references. The space can become null when Context changes (e.g. in the process of routing to a non-space related page). The code may still run before the component gets cleaned up, so they should be robust against a null space.

The commit `fix(runtime-console-f8ui-space-service): add null check to space references` is the direct fix for the issue [1] of accessing the Profile page from the Environments page. The rest do not fix any known issues (afaik) but should increase safety regardless. I'm open to separating into various PRs if needed. Addressing [1] is a main concern.

[1] https://github.com/openshiftio/openshift.io/issues/1940

Note: Tested with local instance targeting production. I verified this by clicking the Profile button in the top left username dropdown after visiting the Environments page.