### PR TITLE
fix(button): remove fixed height from button

### DIFF
--- a/src/app/profile/update/update.component.less
+++ b/src/app/profile/update/update.component.less
@@ -13,7 +13,6 @@
   position: absolute;
   right: 0;
   bottom: 0;
-  max-height: 29px;
   white-space: normal;
 }
 .profile-wrapper {


### PR DESCRIPTION
remove the fixed height from the link button, causing text to flow outside of the button area

fixes https://github.com/openshiftio/openshift.io/issues/1877

