### PR TITLE
fix(header): apply truncation to recent spaces dropdown

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -63,19 +63,19 @@
             <!-- current Space and recent items dropdown -->
             <ul class="dropdown-menu recent-items" *dropdownMenu>
               <li class="recent-items-toggle" *ngFor="let m of recent">
-                <a class="recent-items-text-dropdown"
+                <a class="recent-items-toggle-text-dropdown"
                   [routerLink]="[m.path]"
                   *ngIf="m.path !== null && m.path != context.path"
                   data-toggle="tooltip" title="{{m.name}}">
-                <span class="nav-item-icon">
-                  <span class=" {{m.type.icon}}"></span>
-                </span>
+                  <span class="nav-item-icon">
+                    <span class=" {{m.type.icon}}"></span>
+                  </span>
                   <span>{{m.name}}</span>
                 </a>
                 <a *ngIf="m.path === null">
-                <span class="nav-item-icon">
-                  <span class=" {{m.type.icon}}"></span>
-                </span>
+                  <span class="nav-item-icon">
+                    <span class=" {{m.type.icon}}"></span>
+                  </span>
                   <span>{{m.name}}</span>
                 </a>
               </li>

--- a/src/app/layout/header/header.component.less
+++ b/src/app/layout/header/header.component.less
@@ -96,7 +96,9 @@
     overflow: hidden;
     white-space: nowrap;
     &-dropdown {
-      @extend: {.recent-items-toggle-text};
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
       margin-right: 2px;
     }
   }


### PR DESCRIPTION
Apply missing truncation to the recent spaces dropdown. Class extensions were not being recognized.

related to https://github.com/openshiftio/openshift.io/issues/1911

