### PR TITLE
fix(deployments): clicking details does not collapse cards

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -38,8 +38,8 @@
           </div>
         </div>
       </div>
-      <deployment-details [collapsed]="collapsed" [applicationId]="applicationId"
-        [environment]="environment" [spaceId]="spaceId"></deployment-details>
+      <deployment-details (click)="$event.stopPropagation()" [collapsed]="collapsed"
+        [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId"></deployment-details>
     </div>
   </div>
 </ng-container>


### PR DESCRIPTION
prevent click even propagation on deployment-details child component, so that
the "collapsed" property is not toggled, which causes the details to be hidden
when attempting to select card text or click on charts

closes https://github.com/openshiftio/openshift.io/issues/1967
