### PR TITLE
fix(deployments): refactor pod donut desired replica updating

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -130,7 +130,7 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
   private updateCountText(): void {
     if (!this.mini && this.pods) {
       let smallText: string;
-      if (isNaN(this.desiredReplicas) || this.desiredReplicas === this.pods.total) {
+      if (!this.desiredReplicas || this.desiredReplicas === this.pods.total) {
         smallText = (this.pods.total === 1) ? 'pod' : 'pods';
       } else {
         smallText = `scaling to ${this.desiredReplicas}...`;


### PR DESCRIPTION
This tweaks the updating code for the pod donut's `desiredReplicas` property. This addresses an issue [1] with the `desiredReplicas` being misleading when a user uses the OSO console to scale a pod, and views the pod donut in the OSIO Deployments page. The solution is different from the description in [1], but solves the issue of misleading text. There is also some code cleanup as well.

[1] https://github.com/openshiftio/openshift.io/issues/1966