### PR TITLE
Deployments page expects JSON-API response format

### DIFF
--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -588,8 +588,8 @@ describe('DeploymentsService', () => {
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/apps\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
-        const deploymentRegex: RegExp = /\/apps\/spaces\/foo-space$/;
+        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
         if (timeseriesRegex.test(requestUrl)) {
@@ -653,8 +653,8 @@ describe('DeploymentsService', () => {
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/apps\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
-        const deploymentRegex: RegExp = /\/apps\/spaces\/foo-space$/;
+        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
         if (timeseriesRegex.test(requestUrl)) {
@@ -712,8 +712,8 @@ describe('DeploymentsService', () => {
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/apps\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
-        const deploymentRegex: RegExp = /\/apps\/spaces\/foo-space$/;
+        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
         if (timeseriesRegex.test(requestUrl)) {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -114,46 +114,68 @@ describe('DeploymentsService', () => {
 
   describe('#getApplications', () => {
     it('should publish faked application names', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            { name: 'vertx-hello' }, { name: 'vertx-paint' }, { name: 'vertx-wiki' }
-          ]
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello'
+                }
+              },
+              {
+                attributes: {
+                  name: 'vertx-paint'
+                }
+              },
+              {
+                attributes: {
+                  name: 'vertx-wiki'
+                }
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, expectedResponse.data.applications.map(app => app.name),
+      doMockHttpTest(httpResponse, ['vertx-hello', 'vertx-paint', 'vertx-wiki'],
         svc.getApplications('foo-spaceId'), done);
     });
 
     it('should return empty array if no applications', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: []
+          attributes: {
+            applications: []
+          }
         }
       };
-      doMockHttpTest(expectedResponse, [],
+      doMockHttpTest(httpResponse, [],
         svc.getApplications('foo-spaceId'), done);
     });
 
     it('should return singleton array result', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            { name: 'vertx-hello' }
-          ]
+          attributes: {
+            applications: [{
+              attributes: { name: 'vertx-hello' }
+            }]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, ['vertx-hello'],
+      doMockHttpTest(httpResponse, ['vertx-hello'],
         svc.getApplications('foo-spaceId'), done);
     });
 
     it('should return empty array for null applications response', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: null
+          attributes: {
+            applications: null
+          }
         }
       };
-      doMockHttpTest(expectedResponse, [], svc.getApplications('foo-spaceId'), done);
+      doMockHttpTest(httpResponse, [], svc.getApplications('foo-spaceId'), done);
     });
   });
 
@@ -161,7 +183,19 @@ describe('DeploymentsService', () => {
     it('should publish faked, filtered and sorted environments', (done: DoneFn) => {
       const httpResponse = {
         data: [
-          { name: 'run' }, { name: 'test' }, { name: 'stage'}
+          {
+            attributes: {
+              name: 'run'
+            }
+          }, {
+            attributes: {
+              name: 'test'
+            }
+          }, {
+            attributes: {
+              name: 'stage'
+            }
+          }
         ]
       };
       const expectedResponse = [{ name: 'stage' }, { name: 'run' }];
@@ -169,289 +203,379 @@ describe('DeploymentsService', () => {
     });
 
     it('should return singleton array result', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: [
-          { name: 'stage' }
+          {
+            attributes: {
+              name: 'stage'
+            }
+          }
         ]
       };
-      doMockHttpTest(expectedResponse, expectedResponse.data, svc.getEnvironments('foo-spaceId'), done);
+      doMockHttpTest(httpResponse, [{ name: 'stage' }], svc.getEnvironments('foo-spaceId'), done);
     });
 
     it('should return empty array if no environments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: []
       };
-      doMockHttpTest(expectedResponse, [], svc.getEnvironments('foo-spaceId'), done);
+      doMockHttpTest(httpResponse, [], svc.getEnvironments('foo-spaceId'), done);
     });
 
     it('should return empty array for null environments response', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: null
       };
-      doMockHttpTest(expectedResponse, [], svc.getEnvironments('foo-spaceId'), done);
+      doMockHttpTest(httpResponse, [], svc.getEnvironments('foo-spaceId'), done);
     });
   });
 
   describe('#isApplicationDeployedInEnvironment', () => {
     it('should be true for included deployments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, true,
+      doMockHttpTest(httpResponse, true,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'run'), done);
     });
 
     it('should be true if included in multiple deployments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
-                },
-                {
-                  name: 'stage'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    },
+                    {
+                      attributes: {
+                        name: 'stage'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, true,
+      doMockHttpTest(httpResponse, true,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'run'), done);
     });
 
     it('should be false for excluded deployments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false,
+      doMockHttpTest(httpResponse, false,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
 
     it('should be false if excluded in multiple deployments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
-                },
-                {
-                  name: 'test'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    },
+                    {
+                      attributes: {
+                        name: 'test'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false,
+      doMockHttpTest(httpResponse, false,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
 
     it('should be false if no deployments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: []
-            }
-          ]
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: []
+                }
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false,
+      doMockHttpTest(httpResponse, false,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
 
     it('should be false if deployments is null', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: null
-            }
-          ]
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: null
+                }
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false,
+      doMockHttpTest(httpResponse, false,
         svc.isApplicationDeployedInEnvironment('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
   });
 
   describe('#isDeployedInEnvironment', () => {
     it('should be true for included environments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
+      doMockHttpTest(httpResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
     });
 
     it('should be true if included in multiple applications and environments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
-                },
-                {
-                  name: 'test'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    },
+                    {
+                      attributes: {
+                        name: 'test'
+                      }
+                    }
+                  ]
                 }
-              ]
-            },
-            {
-              name: 'vertx-wiki',
-              pipeline: [
-                {
-                  name: 'run'
-                },
-                {
-                  name: 'stage'
+              },
+              {
+                attributes: {
+                  name: 'vertx-wiki',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    },
+                    {
+                      attributes: {
+                        name: 'stage'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
+      doMockHttpTest(httpResponse, true, svc.isDeployedInEnvironment('foo-spaceId', 'run'), done);
     });
 
     it('should be false for excluded environments', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'run'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run'
+                      }
+                    }
+                  ]
                 }
-              ]
-            },
-            {
-              name: 'vertx-wiki',
-              pipeline: [
-                {
-                  name: 'test'
+              },
+              {
+                attributes: {
+                  name: 'vertx-wiki',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'test'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(httpResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if no environments are deployed', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: []
-            },
-            {
-              name: 'vertx-wiki',
-              pipeline: []
-            }
-          ]
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: []
+                }
+              },
+              {
+                attributes: {
+                  name: 'vertx-wiki',
+                  deployments: []
+                }
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(httpResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if no applications exist', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: []
+          attributes: {
+            applications: []
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(httpResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
     it('should be false if applications are null', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: null
+          attributes: {
+            applications: null
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(httpResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
 
-    it('should be false if pipeline is null', (done: DoneFn) => {
-      const expectedResponse = {
+    it('should be false if deployments is null', (done: DoneFn) => {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: null
-            }
-          ]
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: null
+                }
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
+      doMockHttpTest(httpResponse, false, svc.isDeployedInEnvironment('foo-spaceId', 'stage'), done);
     });
   });
 
   describe('#getVersion', () => {
     it('should return 1.0.2', (done: DoneFn) => {
-      const expectedResponse = {
+      const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'stage',
-                  version: '1.0.2'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'stage',
+                        version: '1.0.2'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
-      doMockHttpTest(expectedResponse, expectedResponse.data.applications[0].pipeline[0].version,
+      doMockHttpTest(httpResponse, '1.0.2',
         svc.getVersion('foo-spaceId', 'vertx-hello', 'stage'), done);
     });
   });
@@ -460,36 +584,46 @@ describe('DeploymentsService', () => {
     it('should return pods for an existing deployment', (done: DoneFn) => {
       const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'stage',
-                  pods: {
-                    running: 1,
-                    starting: 0,
-                    stopping: 1,
-                    total: 2
-                  }
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'stage',
+                        pod_total: 2,
+                        pods: [
+                          ['Running', '1'],
+                          ['Starting', '0'],
+                          ['Stopping', '1']
+                        ]
+                      }
+                    }
+                  ]
                 }
-              ]
-            },
-            {
-              name: 'foo-app',
-              pipeline: [
-                {
-                  name: 'run',
-                  pods: {
-                    running: 0,
-                    starting: 0,
-                    stopping: 1,
-                    total: 1
-                  }
+              },
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'run',
+                        pod_total: 1,
+                        pods: [
+                          ['Running', '0'],
+                          ['Starting', '0'],
+                          ['Stopping', '1']
+                        ]
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
 
@@ -509,31 +643,39 @@ describe('DeploymentsService', () => {
     it('should return pods when there are multiple deployments', (done: DoneFn) => {
       const httpResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'stage',
-                  pods: {
-                    running: 1,
-                    starting: 0,
-                    stopping: 1,
-                    total: 2
-                  }
-                },
-                {
-                  name: 'run',
-                  pods: {
-                    running: 3,
-                    starting: 2,
-                    stopping: 1,
-                    total: 6
-                  }
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'stage',
+                        pod_total: 2,
+                        pods: [
+                          ['Running', '1'],
+                          ['Starting', '0'],
+                          ['Stopping', '1']
+                        ]
+                      }
+                    },
+                    {
+                      attributes: {
+                        name: 'run',
+                        pod_total: 6,
+                        pods: [
+                          ['Running', '3'],
+                          ['Starting', '2'],
+                          ['Stopping', '1']
+                        ]
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
 
@@ -555,33 +697,43 @@ describe('DeploymentsService', () => {
     it('should combine timeseries and quota data', (done: DoneFn) => {
       const timeseriesResponse = {
         data: {
-          cores: {
-            time: 1,
-            value: 2
+          attributes: {
+            cores: {
+              time: 1,
+              value: 2
+            }
           }
         }
       };
       const deploymentResponse = {
         data: {
-          applications: [
-            {
-              name: 'foo-app',
-              pipeline: [
-                {
-                  name: 'foo-env'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'foo-env'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
       const quotaResponse = {
         data: [{
-          name: 'foo-env',
-          quota: {
-            cpucores: {
-              quota: 3,
-              used: 4
+          attributes: {
+            name: 'foo-env',
+            quota: {
+              cpucores: {
+                quota: 3,
+                used: 4
+              }
             }
           }
         }]
@@ -620,33 +772,43 @@ describe('DeploymentsService', () => {
     it('should combine timeseries and quota data', (done: DoneFn) => {
       const timeseriesResponse = {
         data: {
-          memory: {
-            time: 1,
-            value: 2
+          attributes: {
+            memory: {
+              time: 1,
+              value: 2
+            }
           }
         }
       };
       const deploymentResponse = {
         data: {
-          applications: [
-            {
-              name: 'foo-app',
-              pipeline: [
-                {
-                  name: 'foo-env'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'foo-env'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
       const quotaResponse = {
         data: [{
-          name: 'foo-env',
-          quota: {
-            memory: {
-              quota: 3,
-              used: 4
+          attributes: {
+            name: 'foo-env',
+            quota: {
+              memory: {
+                quota: 3,
+                used: 4
+              }
             }
           }
         }]
@@ -742,16 +904,18 @@ describe('DeploymentsService', () => {
     it('should return a "used" value of 8 and a "quota" value of 10', (done: DoneFn) => {
       const expectedResponse = {
         data: [{
-          name: 'stage',
-          quota: {
-            cpucores: {
-              quota: 10,
-              used: 8
+          attributes: {
+            name: 'stage',
+            quota: {
+              cpucores: {
+                quota: 10,
+                used: 8
+              }
             }
           }
         }]
       };
-      doMockHttpTest(expectedResponse, expectedResponse.data[0].quota.cpucores,
+      doMockHttpTest(expectedResponse, expectedResponse.data[0].attributes.quota.cpucores,
         svc.getEnvironmentCpuStat('foo-spaceId', 'stage'), done);
     });
   });
@@ -761,12 +925,14 @@ describe('DeploymentsService', () => {
       const GB = Math.pow(1024, 3);
       const expectedResponse = {
         data: [{
-          name: 'stage',
-          quota: {
-            memory: {
-              used: 0.5 * GB,
-              quota: 1 * GB,
-              units: 'bytes'
+          attributes: {
+            name: 'stage',
+            quota: {
+              memory: {
+                used: 0.5 * GB,
+                quota: 1 * GB,
+                units: 'bytes'
+              }
             }
           }
         }]
@@ -780,22 +946,28 @@ describe('DeploymentsService', () => {
     it('should return pods array', (done: DoneFn) => {
       const expectedResponse = {
         data: {
-          applications: [
-            {
-              name: 'vertx-hello',
-              pipeline: [
-                {
-                  name: 'stage',
-                  pods: {
-                    total: 6,
-                    running: 1,
-                    starting: 2,
-                    stopping: 3
-                  }
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'stage',
+                        pod_total: 6,
+                        pods: [
+                          ['Running', '1'],
+                          ['Starting', '2'],
+                          ['Stopping', '3']
+                        ]
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
       doMockHttpTest(expectedResponse, {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -1034,4 +1034,90 @@ describe('DeploymentsService', () => {
     });
   });
 
+  describe('application links', () => {
+    it('should provide logs URL', (done: DoneFn) => {
+      const httpResponse = {
+        data: {
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'foo-env'
+                      },
+                      links: {
+                        logs: 'http://example.com/logs'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      };
+      doMockHttpTest(httpResponse, 'http://example.com/logs',
+        svc.getLogsUrl('foo-space', 'foo-app', 'foo-env'), done);
+    });
+
+    it('should provide console URL', (done: DoneFn) => {
+      const httpResponse = {
+        data: {
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'foo-env'
+                      },
+                      links: {
+                        console: 'http://example.com/console'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      };
+      doMockHttpTest(httpResponse, 'http://example.com/console',
+        svc.getConsoleUrl('foo-space', 'foo-app', 'foo-env'), done);
+    });
+
+    it('should provide application URL', (done: DoneFn) => {
+      const httpResponse = {
+        data: {
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'foo-env'
+                      },
+                      links: {
+                        application: 'http://example.com/application'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      };
+      doMockHttpTest(httpResponse, 'http://example.com/application',
+        svc.getAppUrl('foo-space', 'foo-app', 'foo-env'), done);
+    });
+  });
+
 });

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -580,6 +580,51 @@ describe('DeploymentsService', () => {
     });
   });
 
+  describe('#scalePods', () => {
+    it('should return success message on success', (done: DoneFn) => {
+      const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(
+          new ResponseOptions({ status: 200 })
+        ));
+      });
+
+      svc.scalePods('foo-spaceId', 'vertx-hello', 'stage', 2)
+        .subscribe(
+          (msg: string) => {
+            expect(msg).toEqual('Successfully scaled stage');
+            subscription.unsubscribe();
+            done();
+          },
+          (err: string) => {
+            done.fail(err);
+          }
+        );
+    });
+
+    it('should return failure message on error', (done: DoneFn) => {
+      const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Response(
+          new ResponseOptions({
+            type: ResponseType.Error,
+            status: 400
+          })
+        ) as Response & Error);
+      });
+
+      svc.scalePods('foo-spaceId', 'vertx-hello', 'stage', 2)
+        .subscribe(
+          (msg: string) => {
+            done.fail(msg);
+          },
+          (err: string) => {
+            expect(err).toEqual('Failed to scale stage');
+            subscription.unsubscribe();
+            done();
+          }
+        );
+    });
+  });
+
   describe('#getPods', () => {
     it('should return pods for an existing deployment', (done: DoneFn) => {
       const httpResponse = {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -847,29 +847,37 @@ describe('DeploymentsService', () => {
     it('should return scaled timeseries data', (done: DoneFn) => {
       const timeseriesResponse = {
         data: {
-          net_tx: {
-            time: 0,
-            value: 1.7
-          },
-          net_rx: {
-            time: 2,
-            value: 3.1
+          attributes: {
+            net_tx: {
+              time: 0,
+              value: 1.7
+            },
+            net_rx: {
+              time: 2,
+              value: 3.1
+            }
           }
         }
       };
 
       const deploymentResponse = {
         data: {
-          applications: [
-            {
-              name: 'foo-app',
-              pipeline: [
-                {
-                  name: 'foo-env'
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'foo-app',
+                  deployments: [
+                    {
+                      attributes: {
+                        name: 'foo-env'
+                      }
+                    }
+                  ]
                 }
-              ]
-            }
-          ]
+              }
+            ]
+          }
         }
       };
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -249,7 +249,7 @@ export class DeploymentsService implements OnDestroy {
     desiredReplicas: number
   ): Observable<string> {
     const url = `${this.apiUrl}${spaceId}/applications/${applicationId}/deployments/${environmentName}?podCount=${desiredReplicas}`;
-    return this.http.put(url, '')
+    return this.http.put(url, '', { headers: this.headers })
       .map((r: Response) => `Successfully scaled ${applicationId}`)
       .catch(err => Observable.throw(`Failed to scale ${applicationId}`));
   }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -313,19 +313,18 @@ export class DeploymentsService implements OnDestroy {
   }
 
   getLogsUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
-    return Observable.of('http://example.com/');
+    return this.getDeployment(spaceId, applicationId, environmentName)
+      .map((deployment: Deployment) => deployment.links.logs);
   }
 
   getConsoleUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
-    return Observable.of('http://example.com/');
+    return this.getDeployment(spaceId, applicationId, environmentName)
+      .map((deployment: Deployment) => deployment.links.console);
   }
 
   getAppUrl(spaceId: string, applicationId: string, environmentName: string): Observable<string> {
-    if (Math.random() > 0.5) {
-      return Observable.of('http://example.com/');
-    } else {
-      return Observable.of('');
-    }
+    return this.getDeployment(spaceId, applicationId, environmentName)
+      .map((deployment: Deployment) => deployment.links.application);
   }
 
   deleteApplication(spaceId: string, applicationId: string, environmentName: string): Observable<string> {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -248,9 +248,9 @@ export class DeploymentsService implements OnDestroy {
     applicationId: string,
     desiredReplicas: number
   ): Observable<string> {
-    const url = `${this.apiUrl}${spaceId}/applications/${applicationId}/deployments/${environmentName}/control?podCount=${desiredReplicas}`;
+    const url = `${this.apiUrl}${spaceId}/applications/${applicationId}/deployments/${environmentName}?podCount=${desiredReplicas}`;
     return this.http.put(url, '')
-      .map((r: Response) => { return `Successfully scaled ${applicationId}`; })
+      .map((r: Response) => `Successfully scaled ${applicationId}`)
       .catch(err => Observable.throw(`Failed to scale ${applicationId}`));
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -31,6 +31,7 @@ import {
 
 import {
   flatten,
+  has,
   includes,
   isEmpty,
   isEqual as deepEqual
@@ -271,6 +272,7 @@ export class DeploymentsService implements OnDestroy {
 
   getDeploymentCpuStat(spaceId: string, applicationName: string, environmentName: string): Observable<CpuStat> {
     const series = this.getTimeseriesData(spaceId, applicationName, environmentName)
+      .filter((t: TimeseriesData) => t && has(t, 'cores'))
       .map((t: TimeseriesData) => t.cores);
     const quota = this.getEnvironmentCpuStat(spaceId, environmentName)
       .map((stat: CpuStat) => stat.quota)
@@ -282,6 +284,7 @@ export class DeploymentsService implements OnDestroy {
 
   getDeploymentMemoryStat(spaceId: string, applicationName: string, environmentName: string): Observable<MemoryStat> {
     const series = this.getTimeseriesData(spaceId, applicationName, environmentName)
+      .filter((t: TimeseriesData) => t && has(t, 'memory'))
       .map((t: TimeseriesData) => t.memory);
     const quota = this.getEnvironment(spaceId, environmentName)
       .map((env: EnvironmentStat) => env.attributes.quota.memory.quota)
@@ -294,6 +297,7 @@ export class DeploymentsService implements OnDestroy {
   getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {
     // TODO: propagate timestamps to caller
     return this.getTimeseriesData(spaceId, applicationId, environmentName)
+      .filter((t: TimeseriesData) => t && has(t, 'net_tx') && has(t, 'net_rx'))
       .map((t: TimeseriesData) =>
         ({
           sent: new ScaledNetworkStat(t.net_tx.value),

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -141,7 +141,7 @@ export class DeploymentsService implements OnDestroy {
     if (this.auth.getToken() != null) {
       this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
     }
-    this.apiUrl = witUrl + 'apps/spaces/';
+    this.apiUrl = witUrl + 'deployments/spaces/';
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
This is the UI side of https://github.com/fabric8-services/fabric8-wit/pull/1849 . These changes adapt the DeploymentsService to expect the JSON response format received from the WIT backend after that PR is merged.

One changeset is missing from this PR to complete the set and close out the corresponding UI issue (https://github.com/openshiftio/openshift.io/issues/1987), which is to modify the `DeploymentsService#scalePods` implementation to suit whatever changed request/response format occurs in the WIT backend, which has not yet been done. The URL is expected to change as is the method of passing the "podCount" or "desiredReplicas" parameter.