### PR TITLE
fix(codebases): fix alignment of icon in list

### DIFF
--- a/src/app/space/create/codebases/codebases.component.less
+++ b/src/app/space/create/codebases/codebases.component.less
@@ -3,6 +3,14 @@
 .codebase-item {
   display: inline-flex;
   width: 100%;
+  // return display property back to PatternFly default
+  .list-pf-icon {
+    display: flex;
+  }
+  // return font-size back to PatternFly default
+  .list-pf-icon-small {
+    font-size: 1.4em;
+  }
 }
 .pfng-list-heading {
   /* stylelint-disable */


### PR DESCRIPTION
reset the styles of the icon in the codebases list to fit according to spec

fixes https://github.com/openshiftio/openshift.io/issues/1867

