### PR TITLE
fix(deployments): fix deployments donut chart to properly apply c3js css

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -5,7 +5,8 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
-  SimpleChanges
+  SimpleChanges,
+  ViewEncapsulation
 } from '@angular/core';
 
 import * as c3 from 'c3';
@@ -15,6 +16,7 @@ import { debounce, isEqual, uniqueId } from 'lodash';
 import { Pods } from '../../models/pods';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'deployments-donut-chart',
   templateUrl: './deployments-donut-chart.component.html',
   styleUrls: ['./deployments-donut-chart.component.less']

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { debounce, isNumber } from 'lodash';
 import { NotificationType } from 'ngx-base';
@@ -11,6 +11,7 @@ import { Pods } from '../models/pods';
 import { DeploymentsService } from '../services/deployments.service';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'deployments-donut',
   templateUrl: './deployments-donut.component.html',
   styleUrls: ['./deployments-donut.component.less']


### PR DESCRIPTION
This PR addresses [osio issue 1939](https://github.com/openshiftio/openshift.io/issues/1939) [0], in which the donut chart css gets masked due to Angular's stylesheet encapsulation.

This patch changes the ViewEncapsulation of both the deployments donut component and donut chart component to be 'none'. As a result, the stylesheet values for the donut chart are now visible and applied.

For example, here is the current stylesheet applied to the c3 tooltip:
![head](https://user-images.githubusercontent.com/10425301/35353691-fb43d3f6-0115-11e8-9bb4-b90e0d14d4db.png)

And here it is if only the chart component is given view encapsulation none:
![chart-only](https://user-images.githubusercontent.com/10425301/35353704-062db476-0116-11e8-8a7a-10163ddecd41.png)

And here is the result of having both the donut and chart components having view encapsulation none:
![both](https://user-images.githubusercontent.com/10425301/35353710-0a8f1e7e-0116-11e8-983f-03275af1235a.png)

This allows for the c3 tooltip-container values[1] to be applied.

[0] https://github.com/openshiftio/openshift.io/issues/1939
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.less#L25