### PR TITLE
fix(stylesheets): fix order of PatternFly stylesheets imports

### DIFF
--- a/src/vendor.browser.ts
+++ b/src/vendor.browser.ts
@@ -25,8 +25,9 @@ import 'ngx-bootstrap';
 //
 
 // import PatternFly CSS
-import '../node_modules/patternfly/dist/css/patternfly-additions.min.css';
+/* tslint:disable:ordered-imports */
 import '../node_modules/patternfly/dist/css/patternfly.min.css';
+import '../node_modules/patternfly/dist/css/patternfly-additions.min.css';
 
 if ('production' === ENV) {
   // Production


### PR DESCRIPTION
This PR fixes [osio issue 1798](https://github.com/openshiftio/openshift.io/issues/1798)[0], in which the toast notifications were not displaying correctly on the screen. After some digging and comparing toast notification styling between the pf-ng demo page and f8, I noticed that we have the correct stylesheet content, but it's being applied in an unintended way. This is a side-effect of [a patch to fix ordered imports](https://github.com/fabric8-ui/fabric8-ui/commit/a9be12292445457803d301d47de8b885e65617c7#diff-3185ad9424adad7e8fb4bd4815e81d5d)[1], and this PR simply reverts the order of the PatternFly imports so they apply correctly to components, like so:
![fix-toast](https://user-images.githubusercontent.com/10425301/35394560-13647850-01b6-11e8-9425-d31a847d3d1a.png)

[0] https://github.com/openshiftio/openshift.io/issues/1798
[1] https://github.com/fabric8-ui/fabric8-ui/commit/a9be12292445457803d301d47de8b885e65617c7#diff-3185ad9424adad7e8fb4bd4815e81d5d