### PR TITLE
fix(link): multi-cluster:start using native openshift linking service

### DIFF
--- a/src/app/getting-started/getting-started.component.ts
+++ b/src/app/getting-started/getting-started.component.ts
@@ -48,7 +48,6 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
       private notifications: Notifications,
       private router: Router,
       private userService: UserService) {
-
     if (fabric8UIConfig) {
       let flag = fabric8UIConfig['kubernetesMode'];
       if (flag === 'true') {
@@ -76,6 +75,18 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
+
+    // when both github and openshift is being linked together,
+    // openshift is linked first and then user is redirected
+    // to the https://openshift.io/_gettingstarted?link=https://github.com
+    // the following code will 'read' the link param and then
+    // call the auth service's LINK API with the required authorization header.
+    let linkRedirect = this.getRequestParam('link');
+    if !(linkRedirect === null) && (linkRedirect === 'https://github.com') {
+      this.providerService.linkGitHub(window.location.origin + '/_gettingstarted?wait=true');
+    }
+
+
     // Route to home if registration is complete.
     this.userService.loggedInUser
       .map(user => {
@@ -146,11 +157,11 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
    */
   connectAccounts(): void {
     if (this.authGitHub && !this.gitHubLinked && this.authOpenShift && !this.openShiftLinked) {
-      this.providerService.linkAll(window.location.origin + '/_gettingstarted?wait=true');
+      this.providerService.linkAll(this.loggedInUser.attributes.cluster , window.location.origin + '/_gettingstarted?wait=true');
     } else if (this.authGitHub && !this.gitHubLinked) {
       this.providerService.linkGitHub(window.location.origin + '/_gettingstarted?wait=true');
     } else if (this.authOpenShift && !this.openShiftLinked) {
-      this.providerService.linkOpenShift(window.location.origin + '/_gettingstarted?wait=true');
+      this.providerService.linkOpenShift(this.loggedInUser.attributes.cluster, window.location.origin + '/_gettingstarted?wait=true');
     }
   }
 

--- a/src/app/shared/account/provider.service.ts
+++ b/src/app/shared/account/provider.service.ts
@@ -25,13 +25,14 @@ export class ProviderService {
   /**
    * Link an OpenShift.com account to the user account
    *
+   * @param cluster URL of the openshift cluster the user is associated with
    * @param redirect URL to be redirected to after successful account linking
    */
-  linkAll(redirect: string): void {
-        let openShiftLinkingRedirectUrl = this.getLegacyLinkingUrl('openshift-v3', redirect);
+  linkAll(cluster: string, redirect: string): void {
+        let redirectToGithubLinkURL = window.location.origin + '/_gettingstarted?wait=true&link=' + encodeURIComponent('https://github.com');
         // after linking github, proceed with linking openshift-v3,
         // hence passing openshift linking url as a redirect.
-        this.linkGitHub(openShiftLinkingRedirectUrl);
+        this.linkOpenShift(cluster, redirectToGithubLinkURL);
   }
 
   /**
@@ -40,23 +41,7 @@ export class ProviderService {
    * @param redirect URL to be redirected to after successful account linking
    */
   linkGitHub(next: string): void {
-    // let tokenUrl = this.apiUrl + 'token/link?for=https://github.com&redirect=' + encodeURIComponent(redirectUrl);
-    let githubLinkURL = this.linkUrl + '?for=https://github.com&redirect=' +  encodeURIComponent(next) ;
-    console.log('attempting to connect github ' + githubLinkURL);
-    this.http
-    .get(githubLinkURL)
-    .map(response => {
-      // TODO: what happens to this when the response is not a pure json
-      let redirectInfo = response.json() as Link;
-      this.redirectToAuth(redirectInfo.redirect_location);
-
-      // todo - handle redirect info?
-      console.log(redirectInfo);
-    })
-    .catch((error) => {
-      console.log('error while linking github ' + githubLinkURL);
-      return this.handleError(error);
-    }).subscribe();
+    this.link('https://github.com', next);
   }
 
   disconnectGitHub(): Observable<any> {
@@ -99,13 +84,18 @@ export class ProviderService {
     return url;
   }
 
+  getLinkingURL(provider: string, redirect: string): string {
+    let linkURL = this.linkUrl + '?for=' + provider + '&redirect=' +  encodeURIComponent(redirect) ;
+    return linkURL;
+  }
+
   /**
    * Link an OpenShift.com account to the user account
    *
    * @param redirect URL to be redirected to after successful account linking
    */
-  linkOpenShift(redirect: string): void {
-    this.link('openshift-v3', redirect);
+  linkOpenShift(cluster: string, redirect: string): void {
+    this.link(cluster, redirect);
   }
 
   /**
@@ -115,8 +105,22 @@ export class ProviderService {
    * @param redirect URL to be redirected to after successful account linking
    */
   link(provider: string, redirect: string): void {
-    let url = this.getLegacyLinkingUrl(provider, redirect);
-    this.redirectToAuth(url);
+    let linkURL = this.linkUrl + '?for=' + provider + '&redirect=' +  encodeURIComponent(redirect) ;
+    console.log('attempting to connect ' + provider + ' using ' + linkURL);
+    this.http
+    .get(linkURL)
+    .map(response => {
+      // TODO: what happens to this when the response is not a pure json
+      let redirectInfo = response.json() as Link;
+      this.redirectToAuth(redirectInfo.redirect_location);
+
+      // todo - handle redirect info?
+      console.log(redirectInfo);
+    })
+    .catch((error) => {
+      console.log('error while linking ' + linkURL);
+      return this.handleError(error);
+    }).subscribe();
   }
 
   // Private


### PR DESCRIPTION
**--- do not merge  ---**

**Depends on**

1. https://github.com/fabric8-ui/ngx-login-client/pull/98

2. The `Getting Started` page currently uses the `https://sso.prod-preview.openshift.io/auth/realms/fabric8/broker/openshift-v3/token` url to determine if the user is connected. This has to be changed to `GET /api/token?for=<user's cluster url` . 

@dgutride , I see that we have helper methods to fetch tokens in the Provider service as well as the `ngx-login-client`'s AuthenticationService . 

the method called here https://github.com/fabric8-ui/ngx-login-client/blob/master/src/app/auth/authentication.service.ts#L41 now needs the user's cluster url too.
Do we make changes in that method? Or shall we get the helper methods in provider ts ?

**What this PR accomplishes**
Previously, we linked Github using the Auth service & OpenShift using keycloak.
In this PR, we are linking OpenShift using Auth - this would be critical for multi-cluster support.