### PR TITLE
fix(pipelines): Remove ability to launch IDEA

### DIFF
--- a/src/a-runtime-console/kubernetes/model/buildconfig.model.ts
+++ b/src/a-runtime-console/kubernetes/model/buildconfig.model.ts
@@ -14,7 +14,6 @@ export class BuildConfig extends KubernetesSpecResource {
 
   jenkinsJobUrl: string;
   editPipelineUrl: string;
-  openInDEAUrl: string;
   openInCheUrl: string;
 
   lastBuildPath: string;
@@ -183,9 +182,6 @@ export class BuildConfig extends KubernetesSpecResource {
     }
     this.gitUrl = gitUrl;
     this.jenkinsJobUrl = this.annotations['fabric8.link.jenkins.job/url'] || '';
-    if (gitUrl) {
-      this.openInDEAUrl = 'jetbrains://idea/checkout/git?idea.required.plugins.id=Git4Idea&checkout.repo=' + gitUrl;
-    }
     this.onBuildsUpdated();
 
     let name = this.name;

--- a/src/a-runtime-console/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
+++ b/src/a-runtime-console/kubernetes/ui/buildconfig/list/list.buildconfig.component.html
@@ -27,17 +27,14 @@
             <li>
               <a [routerLink]="[buildconfig.id, 'edit']">Edit</a>
             </li>
-            <li class="divider" *ngIf="buildconfig.gitUrl"></li>
-            <li *ngIf="buildconfig.openInDEAUrl">
-              <a [href]="buildconfig.openInDEAUrl | safeUrl"  title="open this project in IDEA IntelliJ">
-                Open in IDEA
-              </a>
-            </li>
-            <li *ngIf="buildconfig.jenkinsJobUrl">
-              <a href="{{buildconfig.jenkinsJobUrl}}"  title="open the Jenksin Job for this build" target="jenkins">
-                Open Jenkins Job
-              </a>
-            </li>
+            <div *ngIf="pipeline.jenkinsJobUrl">
+              <li class="divider"></li>
+              <li>
+                <a href="{{buildconfig.jenkinsJobUrl}}"  title="open the Jenkins Job for this build" target="jenkins">
+                  Open Jenkins Job
+                </a>
+              </li>
+            </div>
             <li class="divider"></li>
             <li>
               <a (click)="openDeleteDialog(deleteBuildConfigModal, buildconfig)" title="Delete this BuildConfig">Delete</a>

--- a/src/a-runtime-console/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/full-history/full-history.pipeline.component.html
@@ -36,17 +36,14 @@
                   </a>
                 </li>
                 <li class="divider" *ngIf="pipeline.serviceUrls.length"></li>
-                <li class="divider" *ngIf="pipeline.gitUrl"></li>
-                <li *ngIf="pipeline.openInDEAUrl">
-                  <a [href]="pipeline.openInDEAUrl | safeUrl" title="open this project in IDEA IntelliJ">
-                    Open in IDEA
-                  </a>
-                </li>
-                <li *ngIf="pipeline.jenkinsJobUrl">
-                  <a href="{{pipeline.jenkinsJobUrl}}" title="open the Jenksin Job for this build" target="jenkins">
-                    Open Jenkins Job
-                  </a>
-                </li>
+                <div *ngIf="pipeline.jenkinsJobUrl">
+                  <li class="divider"></li>
+                  <li>
+                    <a href="{{pipeline.jenkinsJobUrl}}" title="open the Jenkins Job for this build" target="jenkins">
+                        Open Jenkins Job
+                    </a>
+                  </li>
+                </div>
                 <li class="divider"></li>
                 <li>
                   <a [routerLink]="[pipeline.id, 'edit']">Edit</a>

--- a/src/a-runtime-console/kubernetes/ui/pipeline/history/history.pipeline.component.html
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/history/history.pipeline.component.html
@@ -37,17 +37,15 @@
                   </a>
                 </li>
                 <li class="divider" *ngIf="pipeline.serviceUrls.length"></li>
-                <li class="divider" *ngIf="pipeline.gitUrl"></li>
-                <li *ngIf="pipeline.openInDEAUrl">
-                  <a [href]="pipeline.openInDEAUrl | safeUrl" title="open this project in IDEA IntelliJ">
-                    Open in IDEA
-                  </a>
-                </li>
-                <li *ngIf="pipeline.jenkinsJobUrl">
-                  <a href="{{pipeline.jenkinsJobUrl}}" title="open the Jenksin Job for this build" target="jenkins">
-                    Open Jenkins Job
-                  </a>
-                </li>
+              
+                <div *ngIf="pipeline.jenkinsJobUrl">
+                  <li class="divider"></li>
+                  <li>
+                    <a href="{{pipeline.jenkinsJobUrl}}" title="open the Jenkins Job for this build" target="jenkins">
+                      Open Jenkins Job
+                    </a>
+                  </li>
+                </div>
                 <li class="divider"></li>
                 <li>
                   <a [routerLink]="[pipeline.id, 'edit']">Edit</a>

--- a/src/a-runtime-console/kubernetes/ui/pipeline/list/list.pipeline.component.html
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/list/list.pipeline.component.html
@@ -26,17 +26,14 @@
                   <a (click)="startBuild(pipeline)" title="Start this Pipeline">Start Pipeline</a>
                 </li>
 
-                <li class="divider" *ngIf="pipeline.gitUrl"></li>
-                <li *ngIf="pipeline.openInDEAUrl">
-                  <a [href]="pipeline.openInDEAUrl | safeUrl" title="open this project in IDEA IntelliJ\n(Requires Jetbrains Toolbox to be installed)">
-                    Open in IDEA
-                  </a>
-                </li>
-                <li *ngIf="pipeline.jenkinsJobUrl">
-                  <a href="{{pipeline.jenkinsJobUrl}}" title="open the Jenksin Job for this build" target="jenkins">
-                    Open Jenkins Job
-                  </a>
-                </li>
+                <div *ngIf="pipeline.jenkinsJobUrl">
+                  <li class="divider"></li>
+                  <li>
+                    <a href="{{pipeline.jenkinsJobUrl}}" title="open the Jenkins Job for this build" target="jenkins">
+                      Open Jenkins Job
+                    </a>
+                  </li>
+                </div>
                 <li class="divider"></li>
                 <li>
                   <a (click)="openDeleteDialog(deleteBuildConfigModal, pipeline)" title="Delete this Pipeline">Delete</a>


### PR DESCRIPTION
This patch removes the user's ability to select "launch IDEA" - a feature which is not supported - from various dropdown menus throughout the pipelines section of the codebase.

issue : https://github.com/openshiftio/openshift.io/issues/510 



