### PR TITLE
fix(deployments): make collapsed cards linger

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="active">
-  <div class="card-pf" (click)="collapsed = !collapsed">
+  <div class="card-pf" (click)="toggleCollapsed()">
     <div class="card-pf-body">
       <div class="row mini-card-content">
         <div class="col-sm-2">
@@ -38,7 +38,7 @@
           </div>
         </div>
       </div>
-      <deployment-details (click)="$event.stopPropagation()" [collapsed]="collapsed"
+      <deployment-details (click)="$event.stopPropagation()" [collapsed]="collapsed" [active]="detailsActive"
         [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId"></deployment-details>
     </div>
   </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -82,6 +82,7 @@ class FakeDeploymentDetailsComponent {
   @Input() applicationId: string;
   @Input() environment: Environment;
   @Input() spaceId: string;
+  @Input() active: boolean;
 }
 
 function initMockSvc(): jasmine.SpyObj<DeploymentsService> {

--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -1,5 +1,5 @@
 <div [collapse]="collapsed">
-  <ng-container *ngIf="!collapsed">
+  <ng-container *ngIf="active">
     <hr>
     <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="false"></deployments-donut>
 

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -31,7 +31,8 @@ import 'patternfly/dist/js/patternfly-settings.js';
   [collapsed]="collapsed"
   [applicationId]="applicationId"
   [environment]="environment"
-  [spaceId]="spaceId">
+  [spaceId]="spaceId"
+  [active]="detailsActive">
   </deployment-details>`
 })
 class HostComponent {
@@ -39,6 +40,7 @@ class HostComponent {
   public applicationId: string = 'mockAppId';
   public environment: Environment = { name: 'mockEnvironment' };
   public spaceId: string = 'mockSpaceId';
+  public detailsActive: boolean = true;
 }
 
 @Component({

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -25,6 +25,7 @@ export class DeploymentDetailsComponent {
 
   public static readonly DEFAULT_SPARKLINE_DATA_DURATION: number = 15 * 60 * 1000;
 
+  @Input() active: boolean;
   @Input() collapsed: boolean;
   @Input() applicationId: string;
   @Input() environment: Environment;


### PR DESCRIPTION
This addresses https://github.com/openshiftio/openshift.io/issues/2095

The collapsed components linger for 5 seconds before being unloaded if the card is collapsed while remaining loaded if the card is expanded.