### PR TITLE
WIP: fix(settings): Add public/private email options

### DIFF
--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -17,13 +17,23 @@
           </div>
         </div>
         <div class="form-group">
-          <label for="email" class="control-label required-pf">Email</label>
-          <div [ngClass]="{'has-error': emailInvalid}">
+          <label for="email" class="control-label required-pf email-alignment-label">Email</label>
+          <div [ngClass]="{'has-error': emailInvalid}" class="email-alignment">
             <input type="email" class="form-control" id="email" name="email" #_email
                     placeholder="name@gmail.com"
                     [maxLength]="255"
                     [(ngModel)]="email"
                     (change)="validateEmail()">
+            <div class="radio email-alignment_settings">
+              <label>
+                <input type="radio" name="emailVisibility" id="emailPublic">
+                Private
+              </label>
+              <label class="padding-left-30">
+                <input type="radio" name="emailVisibility" id="emailPrivate" checked>
+                Public
+              </label>
+            </div>
           </div>
         </div>
         <div class="form-group">

--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -29,7 +29,7 @@
                 <input type="radio" name="emailVisibility" id="emailPublic">
                 Private
               </label>
-              <label class="padding-left-30">
+              <label class="margin-left-30">
                 <input type="radio" name="emailVisibility" id="emailPrivate" checked>
                 Public
               </label>

--- a/src/app/profile/update/update.component.less
+++ b/src/app/profile/update/update.component.less
@@ -28,11 +28,11 @@
 }
 .email-alignment {
   display: inline-flex;
-  width: 70%;
+  width: 90%;
   align-items: center;
   &_settings {
-    position: absolute;
-    right: 25px;
+    display: inline-flex;
+    left: 25px;
   }
 }
 .preview-field {

--- a/src/app/profile/update/update.component.less
+++ b/src/app/profile/update/update.component.less
@@ -23,6 +23,18 @@
     padding-left: 5px;
   }
 }
+.email-alignment-label {
+  display: block;
+}
+.email-alignment {
+  display: inline-flex;
+  width: 70%;
+  align-items: center;
+  &_settings {
+    position: absolute;
+    right: 25px;
+  }
+}
 .preview-field {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
Add option to set your email to either public or private.

related to https://github.com/fabric8-ui/fabric8-ux/issues/841

**Note:** This is just the HTML/CSS and does not include the specific functionality for setting a user's email to public or private.