### PR TITLE
fix(deployments): use null check instead for desired replicas

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -132,7 +132,7 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
   private updateCountText(): void {
     if (!this.mini && this.pods) {
       let smallText: string;
-      if (!this.desiredReplicas || this.desiredReplicas === this.pods.total) {
+      if (this.desiredReplicas == null || this.desiredReplicas === this.pods.total) {
         smallText = (this.pods.total === 1) ? 'pod' : 'pods';
       } else {
         smallText = `scaling to ${this.desiredReplicas}...`;


### PR DESCRIPTION
This is a tiny fix. The intention was to not allow null. This now allows 0, which is a valid value for desired replicas. `==` is used to also check for undefined without having to write another or statement.

Sorry for the mistake;