### PR TITLE
fix(areas): Automatically focus input field when create are modal opened

### DIFF
--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -38,8 +38,12 @@
   </div>
 </div>
 
-<modal #createArea modalClass="chromeless-modal">
-  <modal-content class="chromeless-modal-content">
-    <create-area-dialog [host]="createArea" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
-  </modal-content>
-</modal>
+<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-body">
+        <create-area-dialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -42,7 +42,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-body">
-        <create-area-dialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
+        <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
       </div>
     </div>
   </div>

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
-
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
 import { EmptyStateConfig, ListConfig } from 'patternfly-ng';
 import { Subscription } from 'rxjs';
 
 import { ContextService } from '../../../shared/context.service';
-import { IModalHost } from '../../wizard/models/modal-host';
+import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dialog.component';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -14,13 +14,15 @@ import { IModalHost } from '../../wizard/models/modal-host';
   styleUrls: ['./areas.component.less']
 })
 export class AreasComponent implements OnInit, OnDestroy {
+
+  @ViewChild(ModalDirective) modal: ModalDirective;
+
   private context: Context;
   private areas: Area[];
   private emptyStateConfig: EmptyStateConfig;
   private listConfig: ListConfig;
   private areaSubscription: Subscription;
   private selectedAreaId: string;
-  @ViewChild('createArea') createArea: IModalHost;
 
   constructor(
     private contexts: ContextService,
@@ -54,11 +56,15 @@ export class AreasComponent implements OnInit, OnDestroy {
     this.areaSubscription.unsubscribe();
   }
 
+  openModal() {
+    this.modal.show();
+  }
+
   addChildArea(id: string) {
     if (id) {
       this.selectedAreaId = id;
     }
-    this.createArea.open();
+    this.openModal();
   }
 
   itemPath(item: AreaAttributes) {

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -15,6 +15,7 @@ import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dial
 })
 export class AreasComponent implements OnInit, OnDestroy {
 
+  @ViewChild(CreateAreaDialogComponent) createAreaDialog: CreateAreaDialogComponent;
   @ViewChild(ModalDirective) modal: ModalDirective;
 
   private context: Context;
@@ -58,6 +59,10 @@ export class AreasComponent implements OnInit, OnDestroy {
 
   openModal() {
     this.modal.show();
+  }
+
+  onShowHandler() {
+    this.createAreaDialog.focus();
   }
 
   addChildArea(id: string) {

--- a/src/app/space/settings/areas/areas.module.ts
+++ b/src/app/space/settings/areas/areas.module.ts
@@ -3,12 +3,13 @@ import { NgModule } from '@angular/core';
 import { Http } from '@angular/http';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
-import { ModalModule } from 'ngx-modal';
 import { ListModule } from 'patternfly-ng';
 
 import { AreasRoutingModule } from './areas-routing.module';
 import { AreasComponent } from './areas.component';
+import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dialog.component';
 import { CreateAreaDialogModule } from './create-area-dialog/create-area-dialog.module';
 
 @NgModule({
@@ -18,7 +19,7 @@ import { CreateAreaDialogModule } from './create-area-dialog/create-area-dialog.
     AreasRoutingModule,
     ListModule,
     CreateAreaDialogModule,
-    ModalModule,
+    ModalModule.forRoot(),
     Fabric8WitModule
   ],
   declarations: [

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
@@ -15,7 +15,7 @@
         </div>
         <div class="form-group">
           <label for="name" class="control-label">Name</label>
-          <input id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
+          <input #nameInput id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
         </div>
         <div class="form-group">
           <label class="control-label">Parent area</label>

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
@@ -21,6 +21,7 @@ export class CreateAreaDialogComponent implements OnInit, OnDestroy {
   @Input() parentId: string;
   @Input() areas: Area[];
   @Output() onAdded = new EventEmitter<Area>();
+  @ViewChild('nameInput') nameInput: ElementRef;
 
   private context: Context;
   private openSubscription: Subscription;
@@ -37,6 +38,10 @@ export class CreateAreaDialogComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.openSubscription.unsubscribe();
+  }
+
+  public focus() {
+    this.nameInput.nativeElement.focus();
   }
 
   createArea() {

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
-
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
-import { Modal } from 'ngx-modal';
 import { Subscription } from 'rxjs';
 
 import { AreaError } from '../../../../models/area-error';
@@ -18,7 +17,7 @@ import { ContextService } from '../../../../shared/context.service';
 })
 export class CreateAreaDialogComponent implements OnInit, OnDestroy {
 
-  @Input() host: Modal;
+  @Input() host: ModalDirective;
   @Input() parentId: string;
   @Input() areas: Area[];
   @Output() onAdded = new EventEmitter<Area>();
@@ -34,12 +33,7 @@ export class CreateAreaDialogComponent implements OnInit, OnDestroy {
     this.contexts.current.subscribe(val => this.context = val);
   }
 
-  ngOnInit() {
-    this.openSubscription = this.host.onOpen.subscribe(() => {
-      this.name = '';
-      this.errors = null;
-    });
-  }
+  ngOnInit() { }
 
   ngOnDestroy() {
     this.openSubscription.unsubscribe();
@@ -52,7 +46,7 @@ export class CreateAreaDialogComponent implements OnInit, OnDestroy {
     area.type = 'areas';
     this.areaService.create(this.parentId, area).subscribe(newArea => {
       this.onAdded.emit(newArea);
-      this.host.close();
+      this.host.hide();
     }, error => {
       this.handleError(error.json());
     });
@@ -68,7 +62,7 @@ export class CreateAreaDialogComponent implements OnInit, OnDestroy {
   }
 
   cancel() {
-    this.host.close();
+    this.host.hide();
   }
 
   handleError(error: any) {

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.module.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.module.ts
@@ -2,13 +2,13 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ModalModule } from 'ngx-modal';
+import { ModalModule } from 'ngx-bootstrap';
 
 import { CreateAreaDialogComponent } from './create-area-dialog.component';
 
 @NgModule({
   imports:      [ CommonModule, ModalModule, FormsModule ],
   declarations: [ CreateAreaDialogComponent ],
-  exports: [ CreateAreaDialogComponent, ModalModule ]
+  exports:      [ CreateAreaDialogComponent, ModalModule ]
 })
 export class CreateAreaDialogModule { }


### PR DESCRIPTION
This patch sets the focus on the "name" input field of the Create Area Dialogue immediately after the modal displaying the component appears.

Solves issue: https://github.com/openshiftio/openshift.io/issues/1999 