### PR TITLE
fix(deployments): tweak deployment card detail styling

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -3,29 +3,31 @@
     <hr>
     <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="false"></deployments-donut>
 
+    <p class="resource-usage-header">Resource Usage</p>
+
     <div class="deployment-chart">
-      <div class="chart-column">
+      <div class="chart-column-left">
         <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
       </div>
-      <div class="chart-column">
+      <div class="chart-column-right">
         <deployment-graph-label type="CPU" dataMeasure="Cores" [value]="cpuVal" [valueUpperBound]="cpuMax"></deployment-graph-label>
       </div>
     </div>
 
     <div class="deployment-chart">
-      <div class="chart-column">
+      <div class="chart-column-left">
         <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
       </div>
-      <div class="chart-column">
+      <div class="chart-column-right">
         <deployment-graph-label type="Memory" [dataMeasure]="memUnits" [value]="memVal" [valueUpperBound]="memMax"></deployment-graph-label>
       </div>
     </div>
 
     <div class="deployment-chart">
-      <div class="chart-column">
+      <div class="chart-column-left">
         <f8-deployments-linechart [config]="netConfig" [chartData]="netData"></f8-deployments-linechart>
       </div>
-      <div class="chart-column">
+      <div class="chart-column-right">
         <deployment-graph-label type="Network" [dataMeasure]="netUnits + '/s'" [value]="netVal"></deployment-graph-label>
       </div>
     </div>

--- a/src/app/space/create/deployments/apps/deployment-details.component.less
+++ b/src/app/space/create/deployments/apps/deployment-details.component.less
@@ -4,6 +4,12 @@
   display: flex;
 }
 
+.resource-usage-header {
+  padding-top: 20px;
+  font-weight: 600;
+  font-size: .9em;
+}
+
 .chart-info-header {
   margin-bottom: 10px;
 }
@@ -11,5 +17,10 @@
 .chart-column {
   flex: 1;
   height: 100%;
-  width: 50%;
+  &-left {
+    width: 65%;
+  }
+  &-right {
+    width: 35%;
+  }
 }

--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.less
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.less
@@ -2,6 +2,7 @@
 
 .chart-text {
   padding-left: 10px;
+  font-size: .9em;
 }
 
 .chart-info-header {


### PR DESCRIPTION
related to https://github.com/openshiftio/openshift.io/issues/2176

This adresses the text size and column width for the details graphs/labels as well as adds the "Resource Usage" heading. It does not fix the donut chart scaling label.

![screenshot-20180202151238](https://user-images.githubusercontent.com/3787464/35753143-7ed3f62a-082c-11e8-9f88-a50f447c1c92.png)
