### PR TITLE
fix(feature-flag): fix typo in warning text

### DIFF
--- a/src/app/feature-flag/warning-page/feature-warning-page.component.html
+++ b/src/app/feature-flag/warning-page/feature-warning-page.component.html
@@ -6,7 +6,7 @@
           <i class="fa fa-lock fa-5x"></i>
           <h2>Internal Features Opt-in</h2>
           <p>These features are only available to Red Hat users and have no guarantee of performance or stability.
-            Use theses at your own risk.</p>
+            Use these at your own risk.</p>
           <button class="btn btn-lg btn-feature-level" [routerLink]="profileLink">Opt-in to Internal Features</button>
          </div>
       </div>
@@ -19,7 +19,7 @@
           <i class="fa fa-flask fa-5x"></i>
           <h2>Experimental Features Opt-in</h2>
           <p>These features are currently in beta testing and have no guarantee of performance or stability.
-            Use theses at your own risk.</p>
+            Use these at your own risk.</p>
             <button class="btn btn-lg btn-feature-level" [routerLink]="profileLink">Opt-in to Experimental Features</button>
         </div>
       </div>
@@ -32,7 +32,7 @@
           <i class="fa fa-5x">&Beta;</i>
           <h2>Beta Features Opt-in</h2>
           <p>These features are currently in beta testing and have no guarantee of performance or stability.
-            Use theses at your own risk.</p>
+            Use these at your own risk.</p>
           <button class="btn btn-lg btn-feature-level" [routerLink]="profileLink">Opt-in to Beta Features</button>
         </div>
       </div>


### PR DESCRIPTION
This fixes a typo. Closes https://github.com/openshiftio/openshift.io/issues/1930