### PR TITLE
fix(areas): fix config in html

### DIFF
--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-md-12">
       <pfng-list
-        [config]="listViewConfig"
+        [config]="listConfig"
         [itemTemplate]="itemTemplate"
         [actionTemplate]="actionTemplate"
         [items]="areas" >


### PR DESCRIPTION
`areas.component.ts` does not have a property `listViewConfig` but it does have the property `listConfig`. This fixes the html to refer to the correct property, which is what I think was intended.