### PR TITLE
fix(header): fix analyze tab not highlighting when selected

### DIFF
--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -177,6 +177,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return (this.router.url.indexOf('_gettingstarted') !== -1);
   }
 
+  private stripQueryFromUrl(url: string) {
+    if (url.indexOf('?q=') !== -1) {
+      url = url.substring(0, url.indexOf('?q='));
+    }
+    return url;
+  }
+
   private updateMenus() {
     if (this.context && this.context.type && this.context.type.hasOwnProperty('menus')) {
       let foundPath = false;
@@ -191,7 +198,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
         // /namespace/space/create instead of /namespace/space/create/pipelines
         // as the 'Create' page matches to the 'Codebases' page
         let subMenus = (n.menus || []).slice().reverse();
-        if (subMenus) {
+        if (subMenus && subMenus.length > 0) {
           for (let o of subMenus) {
             // Clear the menu's active state
             o.active = false;
@@ -231,7 +238,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
               }
             }
           }
-        } else if (!foundPath && n.fullPath === this.router.url) {
+        } else if (!foundPath && n.fullPath === this.stripQueryFromUrl(this.router.url)) {
           n.active = true;
           foundPath = true;
         }


### PR DESCRIPTION
This PR addresses https://github.com/openshiftio/openshift.io/issues/1708

This issue was caused by the analyze tab not being given an active state then selected. The analyze tab has no children, and should be activated (when selected) by [line 235 of the header component](https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/layout/header/header.component.ts#L235)[0]. However, the condition for checking if sub-menu children exist incorrectly passes because subMenus is given the value of [] at [line 193](https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/layout/header/header.component.ts#L193)[1].

[0] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/layout/header/header.component.ts#L235
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/layout/header/header.component.ts#L193
