### PR TITLE
Convert uses of ngx-modal to ngx-bootstrap/modal

### DIFF
--- a/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.component.html
+++ b/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.component.html
@@ -1,6 +1,14 @@
-<span>You are about to remove codebase <b>{{codebase.name}}</b> from your space.
-    Please, verify this action by clicking Remove below.</span>
-<div class="remove-footer pull-right">
-  <button class="btn btn-default" (click)="cancel()">Cancel</button>
-  <button class="btn btn-danger" (click)="confirmDelete()">Remove</button>
+<div class="modal-header">
+  <h4 class="modal-title pull-left">Remove Codebase</h4>
+  <button type="button" class="close pull-right" aria-label="Close" (click)="host.hide()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+    <span>You are about to remove codebase <b>{{codebase.name}}</b> from your space.
+      Please, verify this action by clicking Remove below.</span>
+</div>
+<div class="modal-footer">
+    <button class="btn btn-default" (click)="cancel()">Cancel</button>
+    <button class="btn btn-danger" (click)="confirmDelete()">Remove</button>
 </div>

--- a/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.component.ts
+++ b/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.component.ts
@@ -1,7 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
-
-import { Modal } from 'ngx-modal';
-
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Codebase } from '../services/codebase';
 
 @Component({
@@ -12,7 +10,7 @@ import { Codebase } from '../services/codebase';
 })
 export class CodebaseDeleteDialogComponent implements OnInit, OnDestroy {
   @Input() codebase: Codebase;
-  @Input() host: Modal;
+  @Input() host: ModalDirective;
   @Output() onDelete = new EventEmitter<Codebase>();
 
   constructor() {
@@ -35,6 +33,6 @@ export class CodebaseDeleteDialogComponent implements OnInit, OnDestroy {
    * Cancel and close the dialog.
    */
   cancel() {
-    this.host.close();
+    this.host.hide();
   }
 }

--- a/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.module.ts
+++ b/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.module.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ModalModule } from 'ngx-modal';
+import { ModalModule } from 'ngx-bootstrap/modal';
 
 import { CodebaseDeleteDialogComponent } from './codebase-delete-dialog.component';
 
 @NgModule({
-  imports:      [ CommonModule, ModalModule ],
+  imports:      [ CommonModule, ModalModule.forRoot() ],
   declarations: [ CodebaseDeleteDialogComponent ],
   exports: [ CodebaseDeleteDialogComponent, ModalModule ]
 })

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -16,8 +16,11 @@
     </li>
   </ul>
 </span>
-<modal #deleteCodebaseDialog title="Remove codebase">
-  <modal-content>
-    <codebase-delete-dialog [host]="deleteCodebaseDialog" [codebase]="codebase" (onDelete)="onDeleteCodebase($event)"></codebase-delete-dialog>
-  </modal-content>
-</modal>
+
+<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-md">
+    <div class="modal-content" tabindex="0">
+      <codebase-delete-dialog [host]="modal" [codebase]="codebase" (onDelete)="onDeleteCodebase($event)"></codebase-delete-dialog>
+    </div>
+  </div>
+</div>

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { Broadcaster, Notifications } from 'ngx-base';
+import { ModalDirective, ModalModule } from 'ngx-bootstrap/modal';
 import { Observable } from 'rxjs';
 
 import { CodebasesService } from '../services/codebases.service';
@@ -24,7 +25,7 @@ describe('Codebases Item Actions Component', () => {
 
   beforeEach(() => {
     gitHubServiceMock = jasmine.createSpy('GitHubService');
-    dialogMock = jasmine.createSpyObj('IModalHost', ['open', 'close']);
+    dialogMock = jasmine.createSpyObj('bs-modal', ['show', 'hide']);
     notificationMock = jasmine.createSpyObj('Notifications', ['message']);
     broadcasterMock = jasmine.createSpyObj('Broadcaster', ['broadcast', 'on']);
     windowServiceMock = jasmine.createSpyObj('WindowService', ['open']);
@@ -32,7 +33,7 @@ describe('Codebases Item Actions Component', () => {
     codebasesServiceMock = jasmine.createSpyObj('CodebasesService', ['deleteCodebase']);
 
     TestBed.configureTestingModule({
-      imports: [FormsModule, HttpModule],
+      imports: [FormsModule, HttpModule, ModalModule.forRoot()],
       declarations: [CodebasesItemActionsComponent],
       providers: [
         {

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 
 import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Dialog } from 'ngx-widgets';
 import { Subscription } from 'rxjs';
 
-import { IModalHost } from '../../../wizard/models/modal-host';
+import { CodebaseDeleteDialogComponent } from '../codebases-delete/codebase-delete-dialog.component';
 import { Codebase } from '../services/codebase';
 import { CodebasesService } from '../services/codebases.service';
 import { WindowService } from '../services/window.service';
@@ -20,7 +21,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   @Input() cheRunning: boolean;
   @Input() codebase: Codebase;
   @Input() index: number = -1;
-  @ViewChild('deleteCodebaseDialog') deleteCodebaseDialog: IModalHost;
+  @ViewChild(ModalDirective) modal: ModalDirective;
 
   subscriptions: Subscription[] = [];
   workspaceBusy: boolean = false;
@@ -80,7 +81,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
    * @param {MouseEvent} event mouse event
    */
   confirmDeleteCodebase(event: MouseEvent): void {
-    this.deleteCodebaseDialog.open();
+    this.modal.show();
   }
 
   /**
@@ -95,12 +96,12 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
    */
   deleteCodebase(): void {
     this.subscriptions.push(this.codebasesService.deleteCodebase(this.codebase).subscribe((codebase: Codebase) => {
-      this.deleteCodebaseDialog.close();
+      this.modal.hide();
       this.broadcaster.broadcast('codebaseDeleted', {
         codebase: codebase
       });
     }, (error: any) => {
-      this.deleteCodebaseDialog.close();
+      this.modal.hide();
       this.handleError('Failed to deleteCodebase codebase ' + this.codebase.name, NotificationType.DANGER);
     }));
   }

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.module.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { ModalModule } from 'ngx-bootstrap/modal';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { DialogModule } from 'ngx-widgets';
 
@@ -20,6 +21,7 @@ import { CodebasesItemActionsComponent } from './codebases-item-actions.componen
     CommonModule,
     DialogModule,
     FormsModule,
+    ModalModule.forRoot(),
     TooltipModule.forRoot()
   ],
   declarations: [ CodebasesItemActionsComponent ],

--- a/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.html
+++ b/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.html
@@ -1,10 +1,9 @@
-<form role="form" #collaboratorsForm="ngForm" (ngSubmit)="addCollaborators()" novalidate>
-  <header>
-    <h3 class="add-dialog-header">
-      <b>Add collaborators</b>
-    </h3>
-  </header>
-  <section>
+<div class="modal-header">
+  <b>Add collaborators</b>
+</div>
+
+<div class="modal-body">
+  <form role="form" #collaboratorsForm="ngForm" (ngSubmit)="addCollaborators()" novalidate>
     <div class="form">
       <fieldset class="add-fieldset">
         <div class="form-group">
@@ -22,13 +21,14 @@
         </div>
       </fieldset>
     </div>
-  </section>
-  <footer>
-    <div class="add-footer">
-      <div>
-        <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
-        <button class="btn btn-primary" [disabled]="!collaboratorsForm.form.valid" type="submit">Add</button>
+    <div class="modal-footer">
+      <div class="add-footer">
+        <div>
+          <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
+          <button class="btn btn-primary" [disabled]="!collaboratorsForm.form.valid" type="submit">Add</button>
+        </div>
       </div>
     </div>
-  </footer>
-</form>
+  </form>
+</div>
+

--- a/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.less
+++ b/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 
-.add-dialog { padding: 20px; }
 .add-dialog-header {
   position: absolute;
   top: -48px;

--- a/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.ts
+++ b/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.component.ts
@@ -1,9 +1,9 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 
 import { IMultiSelectOption, IMultiSelectSettings } from 'angular-2-dropdown-multiselect';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { CollaboratorService, Context } from 'ngx-fabric8-wit';
 import { User, UserService } from 'ngx-login-client';
-import { Modal } from 'ngx-modal';
 import { Subscription } from 'rxjs';
 
 import { ContextService } from '../../../../shared/context.service';
@@ -17,9 +17,9 @@ import { ContextService } from '../../../../shared/context.service';
   templateUrl: './add-collaborators-dialog.component.html',
   styleUrls: ['./add-collaborators-dialog.component.less']
 })
-export class AddCollaboratorsDialogComponent implements OnInit, OnDestroy {
+export class AddCollaboratorsDialogComponent implements OnInit {
 
-  @Input() host: Modal;
+  @Input() host: ModalDirective;
   @Input() spaceId: string;
   @Input() collaborators: User[];
   @Output() onAdded = new EventEmitter<User[]>();
@@ -53,20 +53,16 @@ export class AddCollaboratorsDialogComponent implements OnInit, OnDestroy {
       maxHeight: '300px'
     };
 
-    this.openSubscription = this.host.onOpen.subscribe(() => {
-      this.dropdownModel = [];
-    });
   }
 
-  ngOnDestroy() {
-    this.openSubscription.unsubscribe();
+  public onOpen() {
+    this.dropdownModel = [];
   }
 
   addCollaborators() {
-    this.host.close();
     this.collaboratorService.addCollaborators(this.spaceId, this.dropdownModel).subscribe(() => {
       this.onAdded.emit(this.dropdownModel as User[]);
-      this.host.close();
+      this.host.hide();
     });
   }
 
@@ -84,6 +80,6 @@ export class AddCollaboratorsDialogComponent implements OnInit, OnDestroy {
   }
 
   cancel() {
-    this.host.close();
+    this.host.hide();
   }
 }

--- a/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.module.ts
+++ b/src/app/space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.module.ts
@@ -3,12 +3,12 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { MultiselectDropdownModule } from 'angular-2-dropdown-multiselect';
-import { ModalModule } from 'ngx-modal';
+import { ModalModule } from 'ngx-bootstrap/modal';
 
 import { AddCollaboratorsDialogComponent } from './add-collaborators-dialog.component';
 
 @NgModule({
-  imports:      [ CommonModule, ModalModule, FormsModule, MultiselectDropdownModule ],
+  imports:      [ CommonModule, ModalModule.forRoot(), FormsModule, MultiselectDropdownModule ],
   declarations: [ AddCollaboratorsDialogComponent ],
   exports: [ AddCollaboratorsDialogComponent, ModalModule ]
 })

--- a/src/app/space/settings/collaborators/collaborators.component.html
+++ b/src/app/space/settings/collaborators/collaborators.component.html
@@ -47,21 +47,30 @@
   </div>
 </div>
 
-<modal #addCollaborators modalClass="chromeless-modal">
-  <modal-content class="chromeless-modal-content">
-    <add-collaborators-dialog [host]="addCollaborators" [spaceId]="context?.space.id" (onAdded)="addCollaboratorsToParent($event)"></add-collaborators-dialog>
-  </modal-content>
-</modal>
-
-
-<!-- Delete modal -->
-<modal #removeCollaborator title="Remove collaborator from space">
-  <modal-content *ngIf="userToRemove">
-    <div>You are about to remove collaborator {{userToRemove.attributes.fullName}} from this collaboration space.</div>
-    <div>The selected user will not be able to edit or be assigned work in the {{context.space.attributes.name}}.</div>
-    <div class="remove-footer pull-right">
-      <button class="btn btn-default" (click)="removeCollaborator.close()">Cancel</button>
-      <button class="btn btn-danger" (click)="removeUser()">Remove</button>
+<div class="modal fade" bsModal #modalAdd="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <add-collaborators-dialog #addCollabDialog [host]="modalAdd" [spaceId]="context?.space.id" (onAdded)="addCollaboratorsToParent($event)"></add-collaborators-dialog>
     </div>
-  </modal-content>
-</modal>
+  </div>
+</div>
+
+<div class="modal fade" bsModal #modalDelete="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" *ngIf="userToRemove">
+    <div class="modal-content">
+      <div class="modal-header">
+        <b>Remove collaborator</b>
+      </div>
+      <div class="modal-body">
+        <div>You are about to remove collaborator {{userToRemove.attributes.fullName}} from this collaboration space.</div>
+        <div>The selected user will not be able to edit or be assigned work in the {{context.space.attributes.name}}.</div>
+      </div>
+      <div class="modal-footer">
+        <div class="pull-right">
+          <button class="btn btn-default" (click)="modalDelete.hide()">Cancel</button>
+          <button class="btn btn-danger" (click)="removeUser()">Remove</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/space/settings/collaborators/collaborators.component.ts
+++ b/src/app/space/settings/collaborators/collaborators.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 
 import { find } from 'lodash';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { CollaboratorService, Context } from 'ngx-fabric8-wit';
 import { User } from 'ngx-login-client';
 import { EmptyStateConfig, ListConfig } from 'patternfly-ng';
 import { Subscription } from 'rxjs';
 
 import { ContextService } from '../../../shared/context.service';
-import { IModalHost } from '../../wizard/models/modal-host';
+import { AddCollaboratorsDialogComponent } from './add-collaborators-dialog/add-collaborators-dialog.component';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -23,8 +24,9 @@ export class CollaboratorsComponent implements OnInit, OnDestroy {
   private contextSubscription: Subscription;
   private collaboratorSubscription: Subscription;
   private userToRemove: User;
-  @ViewChild('addCollaborators') addCollaboratorsModal: IModalHost;
-  @ViewChild('removeCollaborator') removeCollaborator: IModalHost;
+  @ViewChild('addCollabDialog') addCollabDialog: AddCollaboratorsDialogComponent;
+  @ViewChild('modalAdd') modalAdd: ModalDirective;
+  @ViewChild('modalDelete') modalDelete: ModalDirective;
 
   constructor(
     private contexts: ContextService,
@@ -73,19 +75,19 @@ export class CollaboratorsComponent implements OnInit, OnDestroy {
   }
 
   launchAddCollaborators() {
-    this.addCollaboratorsModal.open();
+    this.modalAdd.show();
   }
 
   confirmUserRemove(user: User): void {
     this.userToRemove = user;
-    this.removeCollaborator.open();
+    this.modalDelete.show();
   }
 
   removeUser() {
     this.collaboratorService.removeCollaborator(this.context.space.id, this.userToRemove.id).subscribe(() => {
       this.collaborators.splice(this.collaborators.indexOf(this.userToRemove), 1);
       this.userToRemove = null;
-      this.removeCollaborator.close();
+      this.modalDelete.hide();
     });
   }
 
@@ -98,5 +100,9 @@ export class CollaboratorsComponent implements OnInit, OnDestroy {
         this.collaborators.push(user);
       }
     });
+  }
+
+  onShowHandler() {
+    this.addCollabDialog.onOpen();
   }
 }

--- a/src/app/space/settings/collaborators/collaborators.module.ts
+++ b/src/app/space/settings/collaborators/collaborators.module.ts
@@ -4,7 +4,7 @@ import { Http } from '@angular/http';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { ModalModule } from 'ngx-modal';
+import { ModalModule } from 'ngx-bootstrap/modal';
 import { InfiniteScrollModule } from 'ngx-widgets';
 import { ListModule } from 'patternfly-ng';
 
@@ -20,7 +20,7 @@ import { CollaboratorsComponent } from './collaborators.component';
     ListModule,
     InfiniteScrollModule,
     AddCollaboratorsDialogModule,
-    ModalModule,
+    ModalModule.forRoot(),
     Fabric8WitModule
   ],
   declarations: [


### PR DESCRIPTION
These commits convert two components, `codebase-delete-dialog` and `add-collaborators-dialog and codebase-delete-dialog` to use ngx-bootstrap/modal as their modal provider, instead of ngx-modal.

This is part of a larger issue tracked [here](https://github.com/openshiftio/openshift.io/issues/2170) to ultimately drop ngx-modal, which is no longer maintained, from the project. Since there are many references to ngx-modal in the runtime-console, which itself is being dropped, these commits are meant to be put it for now until that is done, at which point the dependency can be dropped altogether. 