### PR TITLE
fix(areas): fix various ui issues in create new area modal

### DIFF
--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -38,7 +38,7 @@
   </div>
 </div>
 
-<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()">
+<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()" (onHide)="onHideHandler()">
   <div class="modal-dialog">
     <div class="modal-content">
       <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>

--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -41,9 +41,7 @@
 <div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()">
   <div class="modal-dialog">
     <div class="modal-content">
-      <div class="modal-body">
-        <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
-      </div>
+      <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
     </div>
   </div>
 </div>

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -65,6 +65,10 @@ export class AreasComponent implements OnInit, OnDestroy {
     this.createAreaDialog.focus();
   }
 
+  onHideHandler() {
+    this.createAreaDialog.clearField();
+  }
+
   addChildArea(id: string) {
     if (id) {
       this.selectedAreaId = id;

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
@@ -1,10 +1,10 @@
-<form role="form" #areaForm="ngForm" (ngSubmit)="createArea()" novalidate>
-  <header>
-    <h3 class="create-dialog-header">
-      <b>Add New Area</b>
-    </h3>
-  </header>
-  <section>
+<div class="modal-header">
+  <h3>
+    <b>Add New Area</b>
+  </h3>
+</div>
+<div class="modal-body">
+  <form role="form" #areaForm="ngForm" (ngSubmit)="createArea()" novalidate>
     <div class="form">
       <fieldset class="create-fieldset">
         <div *ngIf="errors" class="alert alert-danger">
@@ -25,11 +25,13 @@
         </div>
       </fieldset>
     </div>
-  </section>
-  <footer>
-    <div class="create-footer">
-      <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
-      <button class="btn btn-primary" [disabled]="!areaForm.form.valid" type="submit">Create</button>
+
+    <div class="modal-footer">
+      <div class="create-footer">
+        <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
+        <button class="btn btn-primary" [disabled]="!areaForm.form.valid" type="submit">Create</button>
+      </div>
     </div>
-  </footer>
-</form>
+  </form>
+</div>
+

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.less
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.less
@@ -1,6 +1,5 @@
 @import (reference) '../../../../../assets/stylesheets/shared/osio.less';
 
-.create-dialog { padding: 20px; }
 .create-dialog-header {
   position: absolute;
   top: -48px;

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -37,6 +37,10 @@ export class CreateAreaDialogComponent {
     this.nameInput.nativeElement.focus();
   }
 
+  public clearField() {
+    this.nameInput.nativeElement.value = '';
+  }
+
   createArea() {
     let area = {} as Area;
     area.attributes = new AreaAttributes();


### PR DESCRIPTION
This patch resolves a bug in the add areas modal, whereby its header appears outside of the modal. It also solves an issue whereby the modal's input field is not reset when it is closed.

Solves issues: 
https://github.com/openshiftio/openshift.io/issues/2212 
https://github.com/openshiftio/openshift.io/issues/2214

