### PR TITLE
fix(version): bump Lesscss to 3.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "karma-safari-launcher": "1.0.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
-    "less": "3.0.0-alpha.3",
+    "less": "3.0.0",
     "less-loader": "4.0.5",
     "less-plugin-autoprefix": "1.5.1",
     "lesshint": "4.3.0",


### PR DESCRIPTION
Bump Lesscss to 3.0.0, removing alpha tag

