### PR TITLE
Deployments code cleanup

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
@@ -1,11 +1,19 @@
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Input
+} from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { Observable } from 'rxjs';
-import { initContext, TestContext } from 'testing/test-context';
 
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
 
 import { Environment } from '../models/environment';
+
 import { DeploymentCardContainerComponent } from './deployment-card-container.component';
 
 @Component({
@@ -26,31 +34,35 @@ class FakeDeploymentCardComponent {
 describe('DeploymentCardContainer', () => {
   type Context = TestContext<DeploymentCardContainerComponent, HostComponent>;
 
-  const environments = [
+  const environments: Environment[] = [
     { name: 'envId1' },
     { name: 'envId2' }
   ];
 
-  initContext(DeploymentCardContainerComponent, HostComponent, { declarations: [FakeDeploymentCardComponent] },
-    component => {
+  initContext(DeploymentCardContainerComponent, HostComponent,
+    {
+      declarations: [FakeDeploymentCardComponent]
+    },
+    (component: DeploymentCardContainerComponent) => {
       component.spaceId = 'space';
       component.environments = Observable.of(environments);
       component.application = 'app';
     });
 
-  it('should created children components with proper objects', function(this: Context) {
-    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardComponent));
+  it('should create child components with proper inputs', function(this: Context) {
+    const arrayOfComponents: DebugElement[] =
+      this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardComponent));
     expect(arrayOfComponents.length).toEqual(environments.length);
 
-    environments.forEach((envData, index) => {
-      let cardComponent = arrayOfComponents[index].componentInstance;
+    environments.forEach((envData: Environment, index: number) => {
+      const cardComponent = arrayOfComponents[index].componentInstance;
       expect(cardComponent.applicationId).toEqual('app');
       expect(cardComponent.environment).toEqual(environments[index]);
     });
   });
 
   it('should set the application title properly', function(this: Context) {
-    let el = this.fixture.debugElement.query(By.css('#deploymentCardApplicationTitle')).nativeElement;
+    const el: any = this.fixture.debugElement.query(By.css('#deploymentCardApplicationTitle')).nativeElement;
     expect(el.textContent.trim()).toEqual('app');
   });
 

--- a/src/app/space/create/deployments/apps/deployment-card-container.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.ts
@@ -12,11 +12,7 @@ import { Environment } from '../models/environment';
   templateUrl: 'deployment-card-container.component.html'
 })
 export class DeploymentCardContainerComponent {
-
   @Input() spaceId: string;
   @Input() environments: Observable<Environment[]>;
   @Input() application: string;
-
-  constructor() { }
-
 }

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -86,7 +86,7 @@ class FakeDeploymentDetailsComponent {
 }
 
 function initMockSvc(): jasmine.SpyObj<DeploymentsService> {
-  let mockSvc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
+  const mockSvc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
 
   mockSvc.getVersion.and.returnValue(Observable.of('1.2.3'));
   mockSvc.getDeploymentCpuStat.and.returnValue(Observable.of({ used: 1, quota: 2 }));
@@ -124,7 +124,8 @@ describe('DeploymentCardComponent async tests', () => {
         imports: [
           BsDropdownModule.forRoot(),
           CollapseModule.forRoot(),
-          ChartModule ],
+          ChartModule
+        ],
         providers: [
           BsDropdownConfig,
           { provide: NotificationsService, useValue: notifications },
@@ -149,16 +150,16 @@ describe('DeploymentCardComponent async tests', () => {
 
       function getItemByLabel(label: string): DebugElement {
         return menuItems
-          .filter(item => item.nativeElement.textContent.includes(label))[0];
+          .filter((item: DebugElement) => item.nativeElement.textContent.includes(label))[0];
       }
 
       beforeEach(fakeAsync(() => {
-        let de = fixture.debugElement.query(By.directive(BsDropdownToggleDirective));
+        const de: DebugElement = fixture.debugElement.query(By.directive(BsDropdownToggleDirective));
         de.triggerEventHandler('click', null);
 
         fixture.detectChanges();
 
-        let menu = fixture.debugElement.query(By.css('.dropdown-menu'));
+        const menu: DebugElement = fixture.debugElement.query(By.css('.dropdown-menu'));
         menuItems = menu.queryAll(By.css('li'));
       }));
 
@@ -167,14 +168,14 @@ describe('DeploymentCardComponent async tests', () => {
 
         fixture.detectChanges();
 
-        let menu = fixture.debugElement.query(By.css('.dropdown-menu'));
+        const menu: DebugElement = fixture.debugElement.query(By.css('.dropdown-menu'));
         menuItems = menu.queryAll(By.css('li'));
-        let item = getItemByLabel('Open Application');
+        const item: DebugElement = getItemByLabel('Open Application');
         expect(item).toBeFalsy();
       }));
 
       it('should invoke service \'delete\' function on Delete item click', fakeAsync(() => {
-        let item = getItemByLabel('Delete');
+        const item: DebugElement = getItemByLabel('Delete');
         expect(item).toBeTruthy();
         expect(mockSvc.deleteApplication).not.toHaveBeenCalled();
         item.query(By.css('a')).triggerEventHandler('click', null);
@@ -225,17 +226,19 @@ describe('DeploymentCardComponent', () => {
     imports: [
       BsDropdownModule.forRoot(),
       CollapseModule.forRoot(),
-      ChartModule ],
+      ChartModule
+    ],
     providers: [
       BsDropdownConfig,
       { provide: NotificationsService, useFactory: () => notifications },
       { provide: DeploymentsService, useFactory: () => mockSvc }
     ]
-  }, component => {
-    component.spaceId = 'mockSpaceId';
-    component.applicationId = 'mockAppId';
-    component.environment = { name: 'mockEnvironment' } as Environment;
-  });
+  },
+    (component: DeploymentCardComponent) => {
+      component.spaceId = 'mockSpaceId';
+      component.applicationId = 'mockAppId';
+      component.environment = { name: 'mockEnvironment' } as Environment;
+    });
 
   it('should be active', function(this: Context) {
     let detailsComponent = this.testedDirective;
@@ -262,7 +265,6 @@ describe('DeploymentCardComponent', () => {
       expect(this.testedDirective.toolTip).toBe('CPU usage has exceeded capacity.');
     });
   });
-
 
   describe('versionLabel', () => {
     let de: DebugElement;

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -1,9 +1,16 @@
-import { Component, DebugElement, Input } from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Input
+} from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import 'patternfly/dist/js/patternfly-settings.js';
-import { BehaviorSubject, Observable } from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable
+} from 'rxjs';
 import { createMock } from 'testing/mock';
 import {
   initContext,
@@ -25,7 +32,11 @@ import { DeploymentDetailsComponent } from './deployment-details.component';
 import { times } from 'lodash';
 
 // Makes patternfly charts available
-import { ChartModule } from 'patternfly-ng';
+import {
+  ChartModule,
+  SparklineConfig,
+  SparklineData
+} from 'patternfly-ng';
 import 'patternfly/dist/js/patternfly-settings.js';
 
 @Component({
@@ -38,11 +49,11 @@ import 'patternfly/dist/js/patternfly-settings.js';
   </deployment-details>`
 })
 class HostComponent {
-  public collapsed: boolean = false;
-  public applicationId: string = 'mockAppId';
-  public environment: Environment = { name: 'mockEnvironment' };
-  public spaceId: string = 'mockSpaceId';
-  public detailsActive: boolean = true;
+  collapsed: boolean = false;
+  applicationId: string = 'mockAppId';
+  environment: Environment = { name: 'mockEnvironment' };
+  spaceId: string = 'mockSpaceId';
+  detailsActive: boolean = true;
 }
 
 @Component({
@@ -81,8 +92,8 @@ class FakePfngChartSparkline {
   template: ''
 })
 class FakeDeploymentsLinechart {
-  @Input() config: any;
-  @Input() chartData: any;
+  @Input() config: SparklineConfig;
+  @Input() chartData: SparklineData;
 }
 
 describe('DeploymentDetailsComponent', () => {
@@ -147,15 +158,16 @@ describe('DeploymentDetailsComponent', () => {
   });
 
   it('should generate unique chartIds for each DeploymentDetailsComponent instance', function(this: Context) {
-    let detailsComponent = this.testedDirective;
+    const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
     expect(detailsComponent.cpuConfig.chartId).not.toBe(detailsComponent.memConfig.chartId);
   });
 
   it('should create a child donut component with proper values', function(this: Context) {
-    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeDeploymentsDonutComponent));
+    const arrayOfComponents: DebugElement[] =
+      this.fixture.debugElement.queryAll(By.directive(FakeDeploymentsDonutComponent));
     expect(arrayOfComponents.length).toEqual(1);
 
-    let container = arrayOfComponents[0].componentInstance;
+    const container: DeploymentDetailsComponent = arrayOfComponents[0].componentInstance;
     expect(container.applicationId).toEqual('mockAppId');
   });
 
@@ -208,8 +220,8 @@ describe('DeploymentDetailsComponent', () => {
     let de: DebugElement;
 
     beforeEach(function(this: Context) {
-      let charts = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
-      let cpuChart = charts[0];
+      const charts: DebugElement[] = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
+      const cpuChart: DebugElement = charts[0];
       de = cpuChart.query(By.directive(FakeDeploymentGraphLabelComponent));
     });
 
@@ -234,8 +246,8 @@ describe('DeploymentDetailsComponent', () => {
     let de: DebugElement;
 
     beforeEach(function(this: Context) {
-      let charts = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
-      let memoryChart = charts[1];
+      const charts: DebugElement[] = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
+      const memoryChart: DebugElement = charts[1];
       de = memoryChart.query(By.directive(FakeDeploymentGraphLabelComponent));
     });
 
@@ -257,8 +269,8 @@ describe('DeploymentDetailsComponent', () => {
     let de: DebugElement;
 
     beforeEach(function(this: Context) {
-      let charts = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
-      let networkChart = charts[2];
+      const charts: DebugElement[] = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
+      const networkChart: DebugElement = charts[2];
       de = networkChart.query(By.directive(FakeDeploymentGraphLabelComponent));
     });
 
@@ -281,15 +293,15 @@ describe('DeploymentDetailsComponent', () => {
 
   describe('charts', () => {
     it('by default should be the default data duration divided by the polling rate', function(this: Context) {
-      let detailsComponent = this.testedDirective;
-      let expectedDefaultElements =
+      const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
+      const expectedDefaultElements: number =
         DeploymentDetailsComponent.DEFAULT_SPARKLINE_DATA_DURATION / DeploymentsService.POLL_RATE_MS;
       expect(detailsComponent.getChartMaxElements()).toBe(expectedDefaultElements);
     });
 
     it('should not be able to be set to anything less than 1', function(this: Context) {
-      let detailsComponent = this.testedDirective;
-      [0, -5, -1873].forEach(n => {
+      const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
+      [0, -5, -1873].forEach((n: number) => {
         detailsComponent.setChartMaxElements(n);
         expect(detailsComponent.getChartMaxElements()).toBe(1);
       });
@@ -298,7 +310,7 @@ describe('DeploymentDetailsComponent', () => {
     describe('sparkline data', () => {
       it('should have its cpu data bounded when enough data has been emitted', function(this: Context) {
         const MAX_CPU_SPARKLINE_ELEMENTS = 4;
-        let detailsComponent = this.testedDirective;
+        const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
         detailsComponent.setChartMaxElements(MAX_CPU_SPARKLINE_ELEMENTS);
         times(MAX_CPU_SPARKLINE_ELEMENTS + 10, () => cpuStatObservable.next({ used: 1, quota: 2 }));
         expect(detailsComponent.cpuData.xData.length).toBe(MAX_CPU_SPARKLINE_ELEMENTS);
@@ -307,7 +319,7 @@ describe('DeploymentDetailsComponent', () => {
 
       it('should have its memory data bounded when enough data has been emitted', function(this: Context) {
         const MAX_MEM_SPARKLINE_ELEMENTS = 6;
-        let detailsComponent = this.testedDirective;
+        const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
         detailsComponent.setChartMaxElements(MAX_MEM_SPARKLINE_ELEMENTS);
         times(MAX_MEM_SPARKLINE_ELEMENTS + 10, () => memStatObservable.next({ used: 3, quota: 4, units: 'GB' }));
         expect(detailsComponent.memData.xData.length).toBe(MAX_MEM_SPARKLINE_ELEMENTS);
@@ -318,7 +330,7 @@ describe('DeploymentDetailsComponent', () => {
     describe('linechart data', () => {
       it('should have its net data bounded when enough data has been emitted', function(this: Context) {
         const MAX_NET_LINE_ELEMENTS = 4;
-        let detailsComponent = this.testedDirective;
+        const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
         detailsComponent.setChartMaxElements(MAX_NET_LINE_ELEMENTS);
         times(MAX_NET_LINE_ELEMENTS + 10,
           () => netStatObservable.next({ sent: new ScaledNetworkStat(3), received: new ScaledNetworkStat(4) }));

--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.ts
@@ -1,25 +1,16 @@
 import {
   Component,
-  Input,
-  OnDestroy,
-  OnInit
+  Input
 } from '@angular/core';
 
 @Component({
   selector: 'deployment-graph-label',
   templateUrl: 'deployment-graph-label.component.html',
   styleUrls: ['./deployment-graph-label.component.less']
-
 })
-export class DeploymentGraphLabelComponent implements OnDestroy, OnInit {
-  @Input() type: any;
-  @Input() dataMeasure: any;
-  @Input() value: any;
-  @Input() valueUpperBound: any;
-
-  constructor() { }
-
-  ngOnDestroy(): void { }
-
-  ngOnInit(): void { }
+export class DeploymentGraphLabelComponent {
+  @Input() type: string;
+  @Input() dataMeasure: string;
+  @Input() value: number;
+  @Input() valueUpperBound: number;
 }

--- a/src/app/space/create/deployments/apps/deployment-status-icon.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-status-icon.component.ts
@@ -19,15 +19,14 @@ enum CLASSES {
 }
 
 const STAT_THRESHOLD = .6;
+
 @Component({
   selector: 'deployment-status-icon',
   templateUrl: 'deployment-status-icon.component.html'
 })
 export class DeploymentStatusIconComponent {
+  static readonly CLASSES = CLASSES;
 
   @Input() iconClass: String;
   @Input() toolTip: String;
-
-  public static readonly CLASSES = CLASSES;
-
 }

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -1,14 +1,21 @@
 import {
   Component,
+  DebugElement,
   EventEmitter,
   Input,
   Output
 } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
-import { FilterEvent, SortEvent } from 'patternfly-ng';
+import {
+  FilterEvent,
+  SortEvent
+} from 'patternfly-ng';
 import { Observable } from 'rxjs';
-import { initContext, TestContext } from 'testing/test-context';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
 
 import { Environment } from '../models/environment';
 import { DeploymentsAppsComponent } from './deployments-apps.component';
@@ -33,34 +40,37 @@ class FakeDeploymentCardContainerComponent {
   template: ''
 })
 class FakeDeploymentsToolbarComponent {
-  @Output('onFilterChange') public onFilterChange: EventEmitter<FilterEvent> = new EventEmitter<FilterEvent>();
-  @Output('onSortChange') public onSortChange: EventEmitter<SortEvent> = new EventEmitter<SortEvent>();
-  @Input() public resultsCount: number;
+  @Output('onFilterChange') onFilterChange: EventEmitter<FilterEvent> = new EventEmitter<FilterEvent>();
+  @Output('onSortChange') onSortChange: EventEmitter<SortEvent> = new EventEmitter<SortEvent>();
+  @Input() resultsCount: number;
 }
 
 describe('DeploymentsAppsComponent', () => {
   type Context = TestContext<DeploymentsAppsComponent, HostComponent>;
 
-  let environments = [ { name: 'envId1' }, { name: 'envId2' } ];
-  let applications = ['first', 'second'];
-  let spaceId = Observable.of('spaceId');
-  let mockEnvironments = Observable.of(environments);
-  let mockApplications = Observable.of(applications);
+  const environments: Environment[] = [{ name: 'envId1' }, { name: 'envId2' }];
+  const applications: string[] = ['first', 'second'];
+  const spaceId: Observable<string> = Observable.of('spaceId');
+  const mockEnvironments: Observable<Environment[]> = Observable.of(environments);
+  const mockApplications: Observable<string[]> = Observable.of(applications);
 
   initContext(DeploymentsAppsComponent, HostComponent,
-    { declarations: [FakeDeploymentCardContainerComponent, FakeDeploymentsToolbarComponent] },
-    component => {
+    {
+      declarations: [FakeDeploymentCardContainerComponent, FakeDeploymentsToolbarComponent]
+    },
+    (component: DeploymentsAppsComponent) => {
       component.spaceId = spaceId;
       component.environments = mockEnvironments;
       component.applications = mockApplications;
     });
 
   it('should created children components with proper objects', function(this: Context) {
-    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardContainerComponent));
+    const arrayOfComponents: DebugElement[] =
+      this.fixture.debugElement.queryAll(By.directive(FakeDeploymentCardContainerComponent));
     expect(arrayOfComponents.length).toEqual(applications.length);
 
-    applications.forEach((appName, index) => {
-      let container = arrayOfComponents[index].componentInstance;
+    applications.forEach((appName: string, index: number) => {
+      const container = arrayOfComponents[index].componentInstance;
       expect(container.application).toEqual(appName);
       expect(container.environments).toEqual(mockEnvironments);
     });

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -12,7 +12,10 @@ import {
   SortEvent,
   SortField
 } from 'patternfly-ng';
-import { Observable, Subscription } from 'rxjs';
+import {
+  Observable,
+  Subscription
+} from 'rxjs';
 
 import { DeploymentsToolbarComponent } from '../deployments-toolbar/deployments-toolbar.component';
 import { Environment } from '../models/environment';
@@ -23,12 +26,12 @@ import { Environment } from '../models/environment';
 })
 export class DeploymentsAppsComponent implements OnInit, OnDestroy {
 
-  @Input() public applications: Observable<string[]>;
-  @Input() public environments: Observable<Environment[]>;
-  @Input() public spaceId: Observable<string>;
+  @Input() applications: Observable<string[]>;
+  @Input() environments: Observable<Environment[]>;
+  @Input() spaceId: Observable<string>;
 
-  public filteredApplicationsList: string[];
-  public resultsCount: number = 0;
+  filteredApplicationsList: string[];
+  resultsCount: number = 0;
 
   private applicationsList: string[];
   private currentFilters: Filter[];
@@ -36,29 +39,29 @@ export class DeploymentsAppsComponent implements OnInit, OnDestroy {
   private isAscendingSort: boolean = true;
   private subscriptions: Subscription[] = [];
 
-  public constructor() { }
-
   ngOnInit(): void {
-    this.subscriptions.push(this.applications.subscribe(applications => {
-      this.applicationsList = applications;
-      this.applyFilters();
-    }));
+    this.subscriptions.push(
+      this.applications.subscribe((applications: string[]) => {
+        this.applicationsList = applications;
+        this.applyFilters();
+      })
+    );
   }
 
   ngOnDestroy(): void {
     this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
   }
 
-  filterChange($event: FilterEvent): void {
-    this.currentFilters = $event.appliedFilters;
+  filterChange(event: FilterEvent): void {
+    this.currentFilters = event.appliedFilters;
     this.applyFilters();
 
     this.sortApplications();
   }
 
-  sortChange($event: SortEvent): void {
-    this.currentSortField = $event.field;
-    this.isAscendingSort = $event.isAscending;
+  sortChange(event: SortEvent): void {
+    this.currentSortField = event.field;
+    this.isAscendingSort = event.isAscending;
 
     this.sortApplications();
   }

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
@@ -2,7 +2,13 @@ import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { Observable } from 'rxjs';
-import { initContext, TestContext } from 'testing/test-context';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { PodPhase } from '../../models/pod-phase';
+import { Pods } from '../../models/pods';
 
 import { DeploymentsDonutChartComponent } from './deployments-donut-chart.component';
 
@@ -11,7 +17,7 @@ import { DeploymentsDonutChartComponent } from './deployments-donut-chart.compon
     <deployments-donut-chart
     [colors]="colors"
     [mini]="mini"
-    [pods]="pods | async"
+    [pods]="pods"
     [desiredReplicas]="desiredReplicas"
     [idled]="isIdled">
     </deployments-donut-chart>
@@ -19,10 +25,10 @@ import { DeploymentsDonutChartComponent } from './deployments-donut-chart.compon
 })
 class TestHostComponent {
   mini = false;
-  pods = Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 });
-  desiredReplicas = 1;
-  isIdled = false;
-  colors = {
+  pods: Pods = { pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]], total: 2 };
+  desiredReplicas: number = 1;
+  isIdled: boolean = false;
+  colors: { [s in PodPhase]: string } = {
     'Empty': '#030303', // pf-black
     'Running': '#00b9e4', // pf-light-blue-400
     'Not Ready': '#beedf9', // pf-light-blue-100

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.ts
@@ -11,8 +11,13 @@ import {
 
 import * as c3 from 'c3';
 import * as d3 from 'd3';
-import { debounce, isEqual, uniqueId } from 'lodash';
+import {
+  debounce,
+  isEqual,
+  uniqueId
+} from 'lodash';
 
+import { PodPhase } from '../../models/pod-phase';
 import { Pods } from '../../models/pods';
 
 @Component({
@@ -32,22 +37,8 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
   chartId = uniqueId('deployments-donut-chart');
   debounceUpdateChart = debounce(this.updateChart, 350, { maxWait: 500 });
 
-  private phases = [
-    'Running',
-    'Not Ready',
-    'Warning',
-    'Error',
-    'Pulling',
-    'Pending',
-    'Succeeded',
-    'Terminating',
-    'Unknown'
-  ];
-
   private config: any;
   private chart: any;
-
-  constructor() { }
 
   ngOnInit(): void {
     this.config = {
@@ -86,7 +77,7 @@ export class DeploymentsDonutChartComponent implements AfterViewInit, OnChanges,
       },
       data: {
         type: 'donut',
-        groups: [this.phases],
+        groups: [Object.keys(PodPhase).map(p => PodPhase[p]).filter(p => p !== PodPhase.EMPTY)],
         order: null,
         colors: this.colors,
         selection: {

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -1,16 +1,21 @@
-import { Component, Input } from '@angular/core';
 import {
-  fakeAsync
-} from '@angular/core/testing';
+  Component,
+  DebugElement,
+  Input
+} from '@angular/core';
+import { fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { Observable } from 'rxjs';
 import { createMock } from 'testing/mock';
-import { initContext, TestContext } from 'testing/test-context';
-
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
 
 import { NotificationsService } from 'app/shared/notifications.service';
 import { Environment } from '../models/environment';
+import { PodPhase } from '../models/pod-phase';
 import { Pods } from '../models/pods';
 import { DeploymentsService } from '../services/deployments.service';
 import { DeploymentsDonutComponent } from './deployments-donut.component';
@@ -44,7 +49,7 @@ describe('DeploymentsDonutComponent', () => {
       Observable.of('scalePods')
     );
     mockSvc.getPods.and.returnValue(
-      Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 } as Pods)
+      Observable.of({ pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]], total: 2 })
     );
   }));
 
@@ -56,7 +61,7 @@ describe('DeploymentsDonutComponent', () => {
         { provide: NotificationsService, useValue: notifications }
       ]
     },
-    component => {
+    (component: DeploymentsDonutComponent) => {
       component.mini = false;
       component.spaceId = 'space';
       component.applicationId = 'application';
@@ -68,7 +73,7 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should increment desired replicas on scale up by one', function(this: Context) {
-    let desired = 2;
+    let desired: number = 2;
     expect(this.testedDirective.desiredReplicas).toBe(desired);
 
     this.testedDirective.scaleUp();
@@ -77,7 +82,7 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should decrement desired replicas on scale down by one', function(this: Context) {
-    let desired = 2;
+    let desired: number = 2;
     expect(this.testedDirective.desiredReplicas).toBe(desired);
 
     this.testedDirective.scaleDown();
@@ -86,7 +91,7 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should not decrement desired replicas below zero when scaling down', function(this: Context) {
-    let desired = 2;
+    let desired: number = 2;
     expect(this.testedDirective.desiredReplicas).toBe(desired);
 
     this.testedDirective.scaleDown();
@@ -103,9 +108,9 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should acquire pods data', function(this: Context, done: DoneFn) {
-    this.testedDirective.pods.subscribe(pods => {
+    this.testedDirective.pods.subscribe((pods: Pods) => {
       expect(pods).toEqual({
-        pods: [['Running', 1], ['Terminating', 1]],
+        pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]],
         total: 2
       });
       done();
@@ -113,8 +118,8 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should call scalePods when scaling up', function(this: Context) {
-    let de = this.fixture.debugElement.query(By.css('#scaleUp'));
-    let el = de.nativeElement;
+    let de: DebugElement = this.fixture.debugElement.query(By.css('#scaleUp'));
+    let el: any = de.nativeElement;
 
     el.click();
     this.testedDirective.debounceScale.flush();
@@ -122,8 +127,8 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should call scalePods when scaling down', function(this: Context) {
-    let de = this.fixture.debugElement.query(By.css('#scaleDown'));
-    let el = de.nativeElement;
+    let de: DebugElement = this.fixture.debugElement.query(By.css('#scaleDown'));
+    let el: any = de.nativeElement;
 
     el.click();
     this.testedDirective.debounceScale.flush();
@@ -131,8 +136,8 @@ describe('DeploymentsDonutComponent', () => {
   });
 
   it('should not call scalePods when scaling below 0', function(this: Context) {
-    let de = this.fixture.debugElement.query(By.css('#scaleDown'));
-    let el = de.nativeElement;
+    let de: DebugElement = this.fixture.debugElement.query(By.css('#scaleDown'));
+    let el: any = de.nativeElement;
 
     el.click();
     this.testedDirective.debounceScale.flush();
@@ -141,7 +146,6 @@ describe('DeploymentsDonutComponent', () => {
     el.click();
     this.testedDirective.debounceScale.flush();
     expect(mockSvc.scalePods).toHaveBeenCalledWith('space', 'environmentName', 'application', 0);
-
 
     el.click();
     this.testedDirective.debounceScale.flush();
@@ -170,7 +174,7 @@ describe('DeploymentsDonutComponent error handling', () => {
       Observable.throw('scalePods error')
     );
     mockSvc.getPods.and.returnValue(
-      Observable.of({ pods: [['Running', 1], ['Terminating', 1]], total: 2 } as Pods)
+      Observable.of({ pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]], total: 2 })
     );
   }));
 
@@ -182,7 +186,7 @@ describe('DeploymentsDonutComponent error handling', () => {
         { provide: NotificationsService, useValue: notifications }
       ]
     },
-    component => {
+    (component: DeploymentsDonutComponent) => {
       component.mini = false;
       component.spaceId = 'space';
       component.applicationId = 'application';

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -1,10 +1,19 @@
-import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
 
-import { debounce, isNumber } from 'lodash';
+import {
+  debounce,
+  isNumber
+} from 'lodash';
 import { NotificationType } from 'ngx-base';
 import { Observable } from 'rxjs';
 
 import { Environment } from '../models/environment';
+import { PodPhase } from '../models/pod-phase';
 
 import { NotificationsService } from 'app/shared/notifications.service';
 import { Pods } from '../models/pods';
@@ -29,7 +38,7 @@ export class DeploymentsDonutComponent implements OnInit {
   desiredReplicas: number = 1;
   debounceScale = debounce(this.scale, 650);
 
-  colors = {
+  colors: { [s in PodPhase]: string} = {
     'Empty': '#fafafa', // pf-black-100
     'Running': '#00b9e4', // pf-light-blue-400
     'Not Ready': '#beedf9', // pf-light-blue-100

--- a/src/app/space/create/deployments/deployments-linechart/deployments-linechart.component.ts
+++ b/src/app/space/create/deployments/deployments-linechart/deployments-linechart.component.ts
@@ -31,7 +31,6 @@ import { DeploymentsLinechartData } from './deployments-linechart-data';
 export class DeploymentsLinechartComponent extends ChartBase implements DoCheck, OnInit {
 
   @Input() chartData: DeploymentsLinechartData;
-
   @Input() config: DeploymentsLinechartConfig;
 
   private defaultConfig: DeploymentsLinechartConfig;
@@ -142,11 +141,11 @@ export class DeploymentsLinechartComponent extends ChartBase implements DoCheck,
         return this.getTooltipTableHTML(tipRows);
       },
       position: (data: any, width: number, height: number, element: any) => {
-        let center;
-        let top;
-        let chartBox;
-        let graphOffsetX;
-        let x;
+        let center: number;
+        let top: number;
+        let chartBox: ClientRect;
+        let graphOffsetX: number;
+        let x: number;
 
         try {
           center = parseInt(element.getAttribute('x'), 10);
@@ -166,7 +165,7 @@ export class DeploymentsLinechartComponent extends ChartBase implements DoCheck,
     };
   }
 
-  private getTooltipTableHTML(tipRows: any): string {
+  private getTooltipTableHTML(tipRows: string): string {
     return '<div class="module-triangle-bottom">' +
       '  <table class="c3-tooltip">' +
       '    <tbody>' +

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.spec.ts
@@ -21,9 +21,8 @@ import { DeploymentsToolbarComponent } from './deployments-toolbar.component';
 })
 class TestHostComponent {
   public resultsCount: number = 0;
-
-  public filterChange($event: FilterEvent): void { }
-  public sortChange($event: SortEvent): void { }
+  public filterChange(event: FilterEvent): void { }
+  public sortChange(event: SortEvent): void { }
 }
 
 @Component({
@@ -61,7 +60,17 @@ describe('DeploymentsToolbarComponent', () => {
 
   it('should emit sortChange event', function(this: Context) {
     spyOn(this.hostComponent, 'sortChange');
-    this.testedDirective.sortChange({field: {sortType: 'alphanumeric'}, isAscending: false});
-    expect(this.hostComponent.sortChange).toHaveBeenCalledWith({field: {sortType: 'alphanumeric'}, isAscending: false});
+    this.testedDirective.sortChange({
+      field: {
+        sortType: 'alphanumeric'
+      },
+      isAscending: false
+    });
+    expect(this.hostComponent.sortChange).toHaveBeenCalledWith({
+      field: {
+        sortType: 'alphanumeric'
+      },
+      isAscending: false
+    });
   });
 });

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
@@ -28,30 +28,18 @@ export class DeploymentsToolbarComponent implements OnChanges, OnInit {
 
   public static readonly APPLICATION_ID: string = 'applicationId';
 
-  public filterConfig: FilterConfig;
-  public isAscendingSort: boolean = true;
+  @Input() public resultsCount: number;
 
   @Output('onFilterChange') public onFilterChange: EventEmitter<FilterEvent> = new EventEmitter<FilterEvent>();
   @Output('onSortChange') public onSortChange: EventEmitter<SortEvent> = new EventEmitter<SortEvent>();
 
-  @Input() public resultsCount: number;
+  filterConfig: FilterConfig;
+  isAscendingSort: boolean = true;
 
   private sortConfig: SortConfig;
   private toolbarConfig: ToolbarConfig;
 
-  public constructor() { }
-
-  public filterChange($event: FilterEvent): void {
-    this.onFilterChange.emit($event);
-  }
-
-  public ngOnChanges(changes: SimpleChanges): void {
-    if (changes.resultsCount && this.filterConfig) {
-      this.filterConfig.resultsCount = changes.resultsCount.currentValue;
-    }
-  }
-
-  public ngOnInit(): void {
+  ngOnInit(): void {
     this.filterConfig = {
       appliedFilters: [],
       fields: [{
@@ -79,8 +67,18 @@ export class DeploymentsToolbarComponent implements OnChanges, OnInit {
     };
   }
 
-  public sortChange($event: SortEvent): void {
-    this.onSortChange.emit($event);
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.resultsCount && this.filterConfig) {
+      this.filterConfig.resultsCount = changes.resultsCount.currentValue;
+    }
+  }
+
+  filterChange(event: FilterEvent): void {
+    this.onFilterChange.emit(event);
+  }
+
+  sortChange(event: SortEvent): void {
+    this.onSortChange.emit(event);
   }
 
 }

--- a/src/app/space/create/deployments/models/pod-phase.ts
+++ b/src/app/space/create/deployments/models/pod-phase.ts
@@ -1,0 +1,12 @@
+export enum PodPhase {
+  EMPTY = 'Empty',
+  RUNNING = 'Running',
+  NOT_READY = 'Not Ready',
+  WARNING = 'Warning',
+  ERROR = 'Error',
+  PULLING = 'Pulling',
+  PENDING = 'Pending',
+  SUCCEEDED = 'Succeeded',
+  TERMINATING = 'Terminating',
+  UNKNOWN = 'Unknown'
+}

--- a/src/app/space/create/deployments/models/pods.ts
+++ b/src/app/space/create/deployments/models/pods.ts
@@ -1,6 +1,6 @@
+import { PodPhase } from './pod-phase';
 
-
-type PodsData = [string, number];
+export type PodsData = [PodPhase, number];
 
 export declare interface Pods {
   readonly pods: PodsData[];

--- a/src/app/space/create/deployments/models/scaled-memory-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-memory-stat.ts
@@ -9,11 +9,11 @@ export class ScaledMemoryStat implements MemoryStat {
 
   private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
 
-  public units: MemoryUnit;
+  public readonly units: MemoryUnit;
 
   constructor(
-    public used: number,
-    public quota: number
+    public readonly used: number,
+    public readonly quota: number
   ) {
     let scale = 0;
     if (this.used !== 0) {

--- a/src/app/space/create/deployments/models/scaled-network-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-network-stat.ts
@@ -6,11 +6,11 @@ export class ScaledNetworkStat {
 
   private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
 
-  public raw: number;
-  public units: MemoryUnit;
+  public readonly raw: number;
+  public readonly units: MemoryUnit;
 
   constructor(
-    public used: number
+    public readonly used: number
   ) {
     this.raw = used;
     let scale = 0;

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
@@ -1,4 +1,8 @@
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Input
+} from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { CollapseModule } from 'ngx-bootstrap/collapse';
@@ -25,29 +29,31 @@ class FakeResourceCardComponent {
 describe('DeploymentsResourceUsageComponent', () => {
   type Context = TestContext<DeploymentsResourceUsageComponent, HostComponent>;
 
-  let spaceIdObservable = Observable.of('spaceId');
-  let mockEnvironmentData = [
-    { name: 'envId1'} as Environment,
-    { name: 'envId2'} as Environment
+  let spaceIdObservable: Observable<string> = Observable.of('spaceId');
+  let mockEnvironmentData: Environment[] = [
+    { name: 'envId1'},
+    { name: 'envId2'}
   ];
-  let mockEnvironments = Observable.of(mockEnvironmentData);
+  let mockEnvironments: Observable<Environment[]> = Observable.of(mockEnvironmentData);
 
   initContext(DeploymentsResourceUsageComponent, HostComponent,
     {
       imports: [CollapseModule.forRoot()],
       declarations: [FakeResourceCardComponent]
     },
-    component => {
+    (component: DeploymentsResourceUsageComponent) => {
       component.environments = mockEnvironments;
       component.spaceId = spaceIdObservable;
-    });
+    }
+  );
 
   it('should create children components with proper environment objects', function(this: Context) {
-    let arrayOfComponents = this.fixture.debugElement.queryAll(By.directive(FakeResourceCardComponent));
+    let arrayOfComponents: DebugElement[] =
+      this.fixture.debugElement.queryAll(By.directive(FakeResourceCardComponent));
     expect(arrayOfComponents.length).toEqual(mockEnvironmentData.length);
 
-    mockEnvironmentData.forEach((envData, index) => {
-      let cardComponent = arrayOfComponents[index].componentInstance;
+    mockEnvironmentData.forEach((envData: Environment, index: number) => {
+      let cardComponent: FakeResourceCardComponent = arrayOfComponents[index].componentInstance;
       expect(cardComponent.environment).toEqual(mockEnvironmentData[index]);
       expect(cardComponent.spaceId).toEqual('spaceId');
     });

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.ts
@@ -10,10 +10,8 @@ import { Environment } from '../models/environment';
   templateUrl: 'deployments-resource-usage.component.html'
 })
 export class DeploymentsResourceUsageComponent {
-
   @Input() environments: Observable<Environment[]>;
   @Input() spaceId: Observable<string>;
 
-  constructor() { }
-
+  resourcesCollapsed: boolean = false;
 }

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -16,7 +16,10 @@ import {
 
 import { CpuStat } from '../models/cpu-stat';
 import { Environment } from '../models/environment';
-import { MemoryStat } from '../models/memory-stat';
+import {
+  MemoryStat,
+  MemoryUnit
+} from '../models/memory-stat';
 import { Stat } from '../models/stat';
 import { DeploymentsService } from '../services/deployments.service';
 import { ResourceCardComponent } from './resource-card.component';
@@ -39,10 +42,10 @@ class FakeUtilizationBarComponent {
 describe('ResourceCardComponent', () => {
   type Context = TestContext<ResourceCardComponent, HostComponent>;
 
-  let mockResourceTitle = 'resource title';
+  let mockResourceTitle: string = 'resource title';
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
-  let cpuStatMock = Observable.of({ used: 1, quota: 2 } as CpuStat);
-  let memoryStatMock = Observable.of({ used: 3, quota: 4, units: 'GB' } as MemoryStat);
+  let cpuStatMock: Observable<CpuStat> = Observable.of({ used: 1, quota: 2 });
+  let memoryStatMock: Observable<MemoryStat> = Observable.of({ used: 3, quota: 4, units: 'GB' as MemoryUnit  });
   let active: Subject<boolean> = new BehaviorSubject<boolean>(true);
 
   beforeEach(() => {
@@ -57,14 +60,16 @@ describe('ResourceCardComponent', () => {
     mockSvc.isDeployedInEnvironment.and.returnValue(active);
   });
 
-  initContext(ResourceCardComponent, HostComponent, {
-    declarations: [FakeUtilizationBarComponent],
-    providers: [{ provide: DeploymentsService, useFactory: () => mockSvc }]
-  },
-    component => {
+  initContext(ResourceCardComponent, HostComponent,
+    {
+      declarations: [FakeUtilizationBarComponent],
+      providers: [{ provide: DeploymentsService, useFactory: () => mockSvc }]
+    },
+    (component: ResourceCardComponent) => {
       component.spaceId = 'spaceId';
       component.environment = { name: 'stage' } as Environment;
-    });
+    }
+  );
 
   it('should be active', function(this: Context) {
     expect(this.testedDirective.active).toBeTruthy();
@@ -87,9 +92,9 @@ describe('ResourceCardComponent', () => {
 
   describe('inactive environment', () => {
     it('should not display', function(this: Context) {
-        active.next(false);
-        this.detectChanges();
-        expect(this.testedDirective.active).toBeFalsy();
+      active.next(false);
+      this.detectChanges();
+      expect(this.testedDirective.active).toBeFalsy();
     });
   });
 

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -28,17 +28,15 @@ export class ResourceCardComponent implements OnInit {
 
   ngOnInit(): void {
     this.deploymentsService
-    .isDeployedInEnvironment(this.spaceId, this.environment.name)
-    .subscribe((active: boolean) => {
-      this.active = active;
-      if (active) {
-        this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment.name)
-        .first()
-        .map((stat: MemoryStat) => stat.units);
-      }
-    });
-
-
+      .isDeployedInEnvironment(this.spaceId, this.environment.name)
+      .subscribe((active: boolean) => {
+        this.active = active;
+        if (active) {
+          this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment.name)
+            .first()
+            .map((stat: MemoryStat) => stat.units);
+        }
+      });
   }
 
 }

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
@@ -4,7 +4,7 @@
   </div>
   <div class="progress">
     <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"
-      [ngClass]="getUtilizationClasses()"
+      [ngClass]="getUtilizationClass()"
       [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
       <span><b id="resourceCardLabel">{{ used }} of {{ total }}</b></span>
     </div>

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -5,7 +5,10 @@ import { Observable } from 'rxjs';
 import { initContext, TestContext } from 'testing/test-context';
 
 import { Stat } from '../models/stat';
-import { UtilizationBarComponent } from './utilization-bar.component';
+import {
+  State,
+  UtilizationBarComponent
+} from './utilization-bar.component';
 
 @Component({
   template: '<utilization-bar></utilization-bar>'
@@ -16,7 +19,7 @@ describe('UtilizationBarComponent', () => {
   type Context = TestContext<UtilizationBarComponent, HostComponent>;
 
   describe('with valid Stat', () => {
-    initContext(UtilizationBarComponent, HostComponent, {}, component => {
+    initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
       component.stat = Observable.of({ used: 1, quota: 4 } as Stat);
@@ -42,18 +45,18 @@ describe('UtilizationBarComponent', () => {
     });
 
     it('should set state to okay when under 75% used', function(this: Context) {
-      expect(this.testedDirective.currentState).toEqual(['utilization-okay']);
+      expect(this.testedDirective.getUtilizationClass()).toEqual(State.Okay);
 
-      let de = this.fixture.debugElement.query(By.css('.utilization-okay'));
+      let de = this.fixture.debugElement.query(By.css(`.${State.Okay}`));
       expect(de).toBeTruthy();
 
-      let de2 = this.fixture.debugElement.query(By.css('.utilization-warning'));
+      let de2 = this.fixture.debugElement.query(By.css(`.${State.Warning}`));
       expect(de2).toBeFalsy();
     });
   });
 
   describe('with Warning level Stat', () => {
-    initContext(UtilizationBarComponent, HostComponent, {}, component => {
+    initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
       component.stat = Observable.of({ used: 3, quota: 4 } as Stat);
@@ -79,18 +82,18 @@ describe('UtilizationBarComponent', () => {
     });
 
     it('should set state to warning to false when 75% or higher used', function(this: Context) {
-      expect(this.testedDirective.currentState).toEqual(['utilization-warning']);
+      expect(this.testedDirective.getUtilizationClass()).toEqual(State.Warning);
 
-      let de = this.fixture.debugElement.query(By.css('.utilization-okay'));
+      let de = this.fixture.debugElement.query(By.css(`.${State.Okay}`));
       expect(de).toBeFalsy();
 
-      let de2 = this.fixture.debugElement.query(By.css('.utilization-warning'));
+      let de2 = this.fixture.debugElement.query(By.css(`.${State.Warning}`));
       expect(de2).toBeTruthy();
     });
   });
 
   describe('with invalid Stat', () => {
-    initContext(UtilizationBarComponent, HostComponent, {}, component => {
+    initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
       component.stat = Observable.of({ used: 2, quota: 0 } as Stat);

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -9,6 +9,11 @@ import { Observable, Subscription } from 'rxjs';
 
 import { Stat } from '../models/stat';
 
+export enum State {
+  Okay = 'utilization-okay',
+  Warning = 'utilization-warning'
+}
+
 @Component({
   selector: 'utilization-bar',
   templateUrl: 'utilization-bar.component.html',
@@ -20,26 +25,18 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   @Input() resourceUnit: string;
   @Input() stat: Observable<Stat>;
 
+  private static readonly WARNING_THRESHOLD = 75;
+
   used: number;
   total: number;
   usedPercent: number;
   unusedPercent: number;
 
-  currentState: any;
-
+  private currentState: State;
   private statSubscription: Subscription;
-  private readonly warningThreshold = 75;
-
-  private states = {
-    'Okay' : ['utilization-okay'],
-    'Warning' : ['utilization-warning']
-  };
-
-
-  constructor() { }
 
   ngOnInit(): void {
-    this.currentState = this.states.Okay;
+    this.currentState = State.Okay;
 
     this.statSubscription = this.stat.subscribe(val => {
       this.used = val.used;
@@ -47,10 +44,10 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
       this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
       this.unusedPercent = 100 - this.usedPercent;
 
-      if (this.usedPercent < this.warningThreshold) {
-        this.currentState = this.states.Okay;
+      if (this.usedPercent < UtilizationBarComponent.WARNING_THRESHOLD) {
+        this.currentState = State.Okay;
       } else {
-        this.currentState = this.states.Warning;
+        this.currentState = State.Warning;
       }
     });
   }
@@ -59,7 +56,7 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
     this.statSubscription.unsubscribe();
   }
 
-  getUtilizationClasses() {
+  getUtilizationClass(): State {
     return this.currentState;
   }
 


### PR DESCRIPTION
These commits simply clean up the Deployments area. For the most part it's just simple indentation type fixes, but there are also a fair number of type annotations added where previously either no type was declared or the type was declared as "any". There is also one larger commit ("add PodPhase enum type") that adds a new enum type to encapsulate the running states of deployment pods and reduce duplication of strings that were previously used.