### PR TITLE
fix(areas): Hide warning message after modal closed

### DIFF
--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -67,6 +67,7 @@ export class AreasComponent implements OnInit, OnDestroy {
 
   onHideHandler() {
     this.createAreaDialog.clearField();
+    this.createAreaDialog.resetError();
   }
 
   addChildArea(id: string) {

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -41,6 +41,10 @@ export class CreateAreaDialogComponent {
     this.nameInput.nativeElement.value = '';
   }
 
+  public resetError() {
+    this.errors = null;
+  }
+
   createArea() {
     let area = {} as Area;
     area.attributes = new AreaAttributes();


### PR DESCRIPTION
This patch fixes a bug in which the warning message for attempting to create a space with a duplicate name persists after the modal is closed.

Solves: https://github.com/openshiftio/openshift.io/issues/2231 