### PR TITLE
fix(deployments): propagate deployment chart data timestamps from ser…

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -109,13 +109,13 @@ describe('DeploymentDetailsComponent', () => {
   const mb = Math.pow(1024, 2);
   const initialStats: TimeConstrainedStats = {
     cpu: [
-      { data: { used: 2, quota: 2 }, timestamp: 1234567891011 }
+      { used: 2, quota: 2, timestamp: 1234567891011 }
     ],
     memory: [
-      { data: { used: 2, quota: 4, units: 'GB' }, timestamp: 1234567891011 }
+      { used: 2, quota: 4, units: 'GB', timestamp: 1234567891011 }
     ],
     network: [
-      { data: { sent: new ScaledNetworkStat(2 * mb), received: new ScaledNetworkStat(1 * mb) }, timestamp: 1234567891011 }
+      { sent: new ScaledNetworkStat(2 * mb, 1234567891011), received: new ScaledNetworkStat(1 * mb, 1234567891011) }
     ]
   };
 

--- a/src/app/space/create/deployments/models/scaled-memory-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-memory-stat.ts
@@ -13,7 +13,8 @@ export class ScaledMemoryStat implements MemoryStat {
 
   constructor(
     public readonly used: number,
-    public readonly quota: number
+    public readonly quota: number,
+    public readonly timestamp?: number
   ) {
     let scale = 0;
     if (this.used !== 0) {

--- a/src/app/space/create/deployments/models/scaled-network-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-network-stat.ts
@@ -10,7 +10,8 @@ export class ScaledNetworkStat {
   public readonly units: MemoryUnit;
 
   constructor(
-    public readonly used: number
+    public readonly used: number,
+    public readonly timestamp?: number
   ) {
     this.raw = used;
     let scale = 0;

--- a/src/app/space/create/deployments/models/stat.ts
+++ b/src/app/space/create/deployments/models/stat.ts
@@ -1,4 +1,5 @@
 export declare interface Stat {
   readonly used: number;
   readonly quota: number;
+  readonly timestamp?: number;
 }

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -933,7 +933,8 @@ describe('DeploymentsService', () => {
             quota: {
               cpucores: {
                 quota: 3,
-                used: 4
+                used: 4,
+                timestamp: 1
               }
             }
           }
@@ -962,7 +963,7 @@ describe('DeploymentsService', () => {
 
       svc.getDeploymentCpuStat('foo-space', 'foo-app', 'foo-env')
         .subscribe((stat: CpuStat) => {
-          expect(stat).toEqual({ used: 2, quota: 3 });
+          expect(stat).toEqual({ used: 2, quota: 3, timestamp: 1 });
           subscription.unsubscribe();
           done();
         });
@@ -1008,7 +1009,8 @@ describe('DeploymentsService', () => {
             quota: {
               memory: {
                 quota: 3,
-                used: 4
+                used: 4,
+                timestamp: 1
               }
             }
           }
@@ -1037,7 +1039,7 @@ describe('DeploymentsService', () => {
 
       svc.getDeploymentMemoryStat('foo-space', 'foo-app', 'foo-env')
         .subscribe((stat: MemoryStat) => {
-          expect(stat).toEqual(new ScaledMemoryStat(2, 3));
+          expect(stat).toEqual(new ScaledMemoryStat(2, 3, 1));
           subscription.unsubscribe();
           done();
         });
@@ -1050,11 +1052,11 @@ describe('DeploymentsService', () => {
         data: {
           attributes: {
             net_tx: {
-              time: 0,
+              time: 1,
               value: 1.7
             },
             net_rx: {
-              time: 2,
+              time: 1,
               value: 3.1
             }
           }
@@ -1102,7 +1104,7 @@ describe('DeploymentsService', () => {
 
       svc.getDeploymentNetworkStat('foo-space', 'foo-app', 'foo-env')
         .subscribe((stat: NetworkStat) => {
-          expect(stat).toEqual({ sent: new ScaledNetworkStat(1.7), received: new ScaledNetworkStat(3.1) });
+          expect(stat).toEqual({ sent: new ScaledNetworkStat(1.7, 1), received: new ScaledNetworkStat(3.1, 1) });
           subscription.unsubscribe();
           done();
         });
@@ -1161,16 +1163,16 @@ describe('DeploymentsService', () => {
       };
       const expectedResponse: TimeConstrainedStats = {
         cpu: [
-          { data: { used: 1, quota: 2 }, timestamp: 1 },
-          { data: { used: 2, quota: 2 }, timestamp: 2 }
+          { used: 1, quota: 2, timestamp: 1 },
+          { used: 2, quota: 2, timestamp: 2 }
         ],
         memory: [
-          { data: new ScaledMemoryStat(2, 4), timestamp: 1 },
-          { data: new ScaledMemoryStat(3, 4), timestamp: 2 }
+          new ScaledMemoryStat(2, 4, 1),
+          new ScaledMemoryStat(3, 4, 2)
         ],
         network: [
-          { data: { sent: new ScaledNetworkStat(3), received: new ScaledNetworkStat(4) }, timestamp: 1 },
-          { data: { sent: new ScaledNetworkStat(4), received: new ScaledNetworkStat(5) }, timestamp: 2 }
+          { sent: new ScaledNetworkStat(3, 1), received: new ScaledNetworkStat(4, 1) },
+          { sent: new ScaledNetworkStat(4, 2), received: new ScaledNetworkStat(5, 2) }
         ]
       };
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {


### PR DESCRIPTION
…vice to caller

This patch adds an optional timestamp attribute to the stat interface, which can be used to return the timestamp of a data point to it's caller. The deployment charts have been updated to use these timestamps for the chart xData instead of incrementing the cpuTime/memTime variables as previously used. This fixes a problem where retrieving new data could cause the charts to update in an unintended manner. 

Additionally, this PR manages to fix https://github.com/openshiftio/openshift.io/issues/2199.

Example:
![screenshot from 2018-02-14 16-56-48](https://user-images.githubusercontent.com/10425301/36230329-13908b46-11a8-11e8-8bad-5929e6727c31.png)
