### PR TITLE
fix(spelling): fix spelling of 'tenent' to 'tenant'

### DIFF
--- a/src/app/profile/cleanup/cleanup.component.ts
+++ b/src/app/profile/cleanup/cleanup.component.ts
@@ -7,14 +7,14 @@ import { Observable, Subscription } from 'rxjs';
 
 import { EventService } from '../../shared/event.service';
 import { IModalHost } from '../../space/wizard/models/modal-host';
-import { TenentService } from '../services/tenent.service';
+import { TenantService } from '../services/tenant.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'fabric8-cleanup',
   templateUrl: 'cleanup.component.html',
   styleUrls: ['./cleanup.component.less'],
-  providers: [ TenentService ]
+  providers: [ TenantService ]
 })
 export class CleanupComponent implements OnInit, OnDestroy {
   spaces: Space[] = [];
@@ -38,7 +38,7 @@ export class CleanupComponent implements OnInit, OnDestroy {
 
   constructor(private contexts: Contexts,
                private spaceService: SpaceService,
-               private tenantService: TenentService,
+               private tenantService: TenantService,
                private eventService: EventService,
                private router: Router) {
   }
@@ -123,7 +123,7 @@ export class CleanupComponent implements OnInit, OnDestroy {
     //join all space delete observables and wait for completion before running tenant cleanup
     Observable.forkJoin(...observableArray).subscribe((result) => {
       if (!tenantCleanError) {
-        this.tenantService.updateTenent().subscribe(() => {
+        this.tenantService.updateTenant().subscribe(() => {
           if (!spaceDeleteError) {
             this.showSuccessNotification();
           }

--- a/src/app/profile/services/tenant.service.ts
+++ b/src/app/profile/services/tenant.service.ts
@@ -10,7 +10,7 @@ import { Codebase } from './codebase';
 import { Workspace, WorkspaceLinks } from './workspace';
 
 @Injectable()
-export class TenentService {
+export class TenantService {
   private headers = new Headers({ 'Content-Type': 'application/json' });
   private userUrl: string;
 
@@ -27,11 +27,11 @@ export class TenentService {
   }
 
   /**
-   * Update tenent
+   * Update tenant
    *
    * @returns {Observable<any>}
    */
-  updateTenent(): Observable<any> {
+  updateTenant(): Observable<any> {
     let url = `${this.userUrl}/services`;
     return this.http
       .patch(url, null, { headers: this.headers })

--- a/src/app/profile/tenant/tenant.component.ts
+++ b/src/app/profile/tenant/tenant.component.ts
@@ -11,14 +11,14 @@ import { ExtProfile, GettingStartedService } from '../../getting-started/service
 import { ProviderService } from '../../shared/account/provider.service';
 import { GitHubService } from '../../space/create/codebases/services/github.service';
 import { CopyService } from '../services/copy.service';
-import { TenentService } from '../services/tenent.service';
+import { TenantService } from '../services/tenant.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'alm-update',
   templateUrl: 'tenant.component.html',
   styleUrls: ['./tenant.component.less'],
-  providers: [CopyService, GettingStartedService, GitHubService, ProviderService, TenentService]
+  providers: [CopyService, GettingStartedService, GitHubService, ProviderService, TenantService]
 })
 export class TenantComponent implements AfterViewInit, OnInit {
   @ViewChild('_jenkinsVersion') jenkinsVersionElement: HTMLElement;
@@ -69,7 +69,7 @@ export class TenantComponent implements AfterViewInit, OnInit {
       private contexts: Contexts,
       private notifications: Notifications,
       private router: Router,
-      private tenentService: TenentService,
+      private tenantService: TenantService,
       private userService: UserService) {
     this.subscriptions.push(contexts.current.subscribe(val => this.context = val));
 
@@ -177,7 +177,7 @@ export class TenantComponent implements AfterViewInit, OnInit {
     this.subscriptions.push(this.gettingStartedService.update(profile).subscribe(user => {
       this.setUserProperties(user);
 
-      this.subscriptions.push(this.tenentService.updateTenent()
+      this.subscriptions.push(this.tenantService.updateTenant()
         .subscribe(res => {
           this.notifications.message({
             message: `Tenant Updated!`,
@@ -185,7 +185,7 @@ export class TenantComponent implements AfterViewInit, OnInit {
           } as Notification);
           this.routeToProfile();
         }, error => {
-          this.handleError('Failed to update tenent', NotificationType.DANGER);
+          this.handleError('Failed to update tenant', NotificationType.DANGER);
         }));
 
     }, error => {

--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -179,7 +179,7 @@
         <div class="container-fluid pull-right">
           <div class="row">
             <div class="col">
-              <button class="btn btn-lg btn-default" (click)="updateTenent()" [disabled]="updateTenantStatus === TenantUpdateStatus.Updating">Update Tenant</button>
+              <button class="btn btn-lg btn-default" (click)="updateTenant()" [disabled]="updateTenantStatus === TenantUpdateStatus.Updating">Update Tenant</button>
               <button class="btn btn-lg btn-default" (click)="cleanupTenant()">Reset Environment</button>
             </div>
             <div class="update-tenant-status" *ngIf="updateTenantStatus !== TenantUpdateStatus.NoAction">

--- a/src/app/profile/update/update.component.spec.ts
+++ b/src/app/profile/update/update.component.spec.ts
@@ -15,7 +15,7 @@ import { GettingStartedService } from '../../getting-started/services/getting-st
 import { ProviderService } from '../../shared/account/provider.service';
 import { GitHubService } from '../../space/create/codebases/services/github.service';
 import { CopyService } from '../services/copy.service';
-import { TenentService } from '../services/tenent.service';
+import { TenantService } from '../services/tenant.service';
 import { UpdateComponent } from './update.component';
 
 describe('UpdateComponent', () => {
@@ -30,7 +30,7 @@ describe('UpdateComponent', () => {
   let mockProviderService: any = jasmine.createSpyObj('ProviderService', ['getGitHubStatus']);
   let mockRenderer: any = jasmine.createSpy('Renderer2');
   let mockRouter: any = jasmine.createSpy('Router');
-  let mockTenentService: any = jasmine.createSpy('TenentService');
+  let mockTenantService: any = jasmine.createSpy('TenantService');
   let mockUserService: any = jasmine.createSpy('UserService');
   let mockLogger: any = jasmine.createSpy('Logger');
 
@@ -52,7 +52,7 @@ describe('UpdateComponent', () => {
         { provide: ProviderService, useValue: mockProviderService },
         { provide: Renderer2, useValue: mockRenderer },
         { provide: Router, useValue: mockRouter },
-        { provide: TenentService, useValue: mockTenentService },
+        { provide: TenantService, useValue: mockTenantService },
         { provide: UserService, useValue: mockUserService },
         { provide: Logger, useValue: mockLogger },
         { provide: WIT_API_URL, useValue: 'http://example.com'}

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -11,7 +11,7 @@ import { ExtProfile, GettingStartedService } from '../../getting-started/service
 import { ProviderService } from '../../shared/account/provider.service';
 import { GitHubService } from '../../space/create/codebases/services/github.service';
 import { CopyService } from '../services/copy.service';
-import { TenentService } from '../services/tenent.service';
+import { TenantService } from '../services/tenant.service';
 
 export enum TenantUpdateStatus {
   NoAction,
@@ -25,7 +25,7 @@ export enum TenantUpdateStatus {
   selector: 'alm-update',
   templateUrl: 'update.component.html',
   styleUrls: ['./update.component.less'],
-  providers: [CopyService, GettingStartedService, GitHubService, TenentService]
+  providers: [CopyService, GettingStartedService, GitHubService, TenantService]
 })
 export class UpdateComponent implements AfterViewInit, OnInit {
   // Required for usage of enums in the template.
@@ -77,7 +77,7 @@ export class UpdateComponent implements AfterViewInit, OnInit {
       private providerService: ProviderService,
       private renderer: Renderer2,
       private router: Router,
-      private tenentService: TenentService,
+      private tenantService: TenantService,
       private userService: UserService) {
     this.subscriptions.push(contexts.current.subscribe(val => this.context = val));
 
@@ -247,11 +247,11 @@ export class UpdateComponent implements AfterViewInit, OnInit {
   }
 
   /**
-   * Update tenent
+   * Update tenant
    */
-  updateTenent(): void {
+  updateTenant(): void {
     this.updateTenantStatus = TenantUpdateStatus.Updating;
-    this.subscriptions.push(this.tenentService.updateTenent()
+    this.subscriptions.push(this.tenantService.updateTenant()
       .subscribe(res => {
         if (res.status === 200) {
           this.updateTenantStatus = TenantUpdateStatus.Success;


### PR DESCRIPTION
This PR addresses instances where the word 'tenant' is spelled as 'tenent'.

Looking back through past issues and PRs [0][1], it would appear that the use of 'tenent' is a typo (if it is indeed intentional, then disregard this PR). 

This could be particularly confusing in instances such as https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/profile/update/update.component.html#L182 where the two spellings are used in the same line of html.

[0] https://github.com/fabric8-ui/fabric8-ui/issues/1256
[1] https://github.com/fabric8-ui/fabric8-ui/pull/1420