### PR TITLE
fix(overview): add word-wrap functionality to bio text

### DIFF
--- a/src/app/profile/overview/overview.component.html
+++ b/src/app/profile/overview/overview.component.html
@@ -52,7 +52,7 @@
         </ng-template>
         <div *ngIf="(context.user.attributes.bio !== undefined && context.user.attributes.bio.length !== 0); then showBio else addBio"></div>
         <ng-template #showBio>
-          <p class="col-sm-12 profile-wrapper-bio">{{context.user.attributes.bio}}</p>
+          <p class="col-sm-12 profile-wrapper-bio" lang="en">{{context.user.attributes.bio}}</p>
         </ng-template>
         <ng-template #addBio>
           <p class="col-sm-12 profile-wrapper-bio">

--- a/src/app/profile/overview/overview.component.less
+++ b/src/app/profile/overview/overview.component.less
@@ -23,7 +23,17 @@
 .profile-wrapper {
   &-email,
   &-url,
-  &-bio,
+  &-bio {
+    word-wrap: break-word;
+    /*
+     * Hyphens CSS property not currently supported by all browsers
+     * For more information & support, see: 
+     * https://caniuse.com/#search=hyphens
+     */
+    -webkit-hyphens: auto; // Safari & Chrome
+    -ms-hyphens: auto; // IE and Edge
+    hyphens: auto; // Firefox
+  }
   &-username {
     padding-left: 5px;
   }


### PR DESCRIPTION
This PR addresses https://github.com/openshiftio/openshift.io/issues/2100 [0].

This PR adds some CSS properties to the bio section of the profile page. The word-wrap is used to make text word-wrap, and the hyphens property introduces hyphens when word-wrapping occurs. However, the hyphens property is not currently supported by all browsers [1], and only the 'none' option is supported by Chrome [2]. This results in word-wrapping and hyphenating in many browsers (IE, Firefox, Edge, Safari, etc.), but Chrome will only have word-wrapping. Additionally, for hyphenation to work properly, the html component it applies to has to have the lang option set. I've included some screenshots below to demo the functionality.

Here is what the bio looks like currently:
![old](https://user-images.githubusercontent.com/10425301/36276670-a0a73624-125c-11e8-8827-df2ebd04d701.png)

Here is what the bio looks like with these fixes in Firefox:
![new-firefox](https://user-images.githubusercontent.com/10425301/36276674-a3f22a5a-125c-11e8-9286-f1047e5cc873.png)

Here is what the bio looks like with these fixes in Chrome:
![new-chrome](https://user-images.githubusercontent.com/10425301/36276675-a58924ae-125c-11e8-91fb-790ac32fdac7.png)

[0] https://github.com/openshiftio/openshift.io/issues/2100
[1] https://caniuse.com/#search=hyphens
[2] https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens
