### PR TITLE
fix(home): Update banner items to go to Docs site

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -16,14 +16,14 @@
           <div class="col-sm-4 col-lg-4">
             <div class="card-pf-body text-center">
               <div class="card-pf-top-element">
-                <span class="fa fa-search card-pf-icon-circle home-icon"></span>
+                <span class="fa fa-book card-pf-icon-circle home-icon"></span>
               </div>
               <h2 class="card-pf-title home-title">
-                {{brandInformation.name}} information
+                Get Started
               </h2>
               <p class="card-pf-info">
-                <a [href]="brandInformation.moreInfoLink" class="home-banner-link" target="_blank">Learn more</a>
-                about what {{brandInformation.name}} can do for you.
+                <a href="https://docs.openshift.io/getting-started-guide.html" class="home-banner-link" target="_blank">Follow our guide</a>
+                to build your first application.
               </p>
             </div>
           </div>
@@ -43,13 +43,14 @@
           <div class="col-sm-4 col-lg-4">
             <div class="card-pf-body text-center">
               <div class="card-pf-top-element">
-                <span class="pficon pficon-cluster card-pf-icon-circle home-icon"></span>
+                <span class="fa fa-search card-pf-icon-circle home-icon"></span>
               </div>
               <h2 class="card-pf-title home-title">
-                Learn about OpenShift
+                {{brandInformation.name}} information
               </h2>
-              <p class="card-pf-info">See how
-                <a href="https://www.openshift.com/container-platform" class="home-banner-link" target="_blank">containerized development and deployment</a> can help you.
+              <p class="card-pf-info">
+                <a [href]="brandInformation.moreInfoLink" class="home-banner-link" target="_blank">Learn more</a>
+                about what {{brandInformation.name}} can do for you.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Update the banner on the homepage to include a pointer to the Getting Started guide

related to https://github.com/openshiftio/openshift.io/issues/2215

<img width="1713" alt="screen shot 2018-02-15 at 5 55 00 pm" src="https://user-images.githubusercontent.com/4032718/36285398-60f432c6-1279-11e8-8d34-0ec90604cc31.png">
