### PR TITLE
fix(deployments): fix resource usage collapsed icon

### DIFF
--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.html
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.html
@@ -6,7 +6,7 @@
           <h3>
             <b>
               <a class="resource-title" (click)="resourcesCollapsed = !resourcesCollapsed">
-                <span class="fa fa-angle-down"></span>&nbsp;&nbsp;Resource Usage
+                <span [ngClass]="resourcesCollapsed ? 'fa fa-angle-right' : 'fa fa-angle-down'"></span>&nbsp;&nbsp;Resource Usage
               </a>
             </b>
           </h3>


### PR DESCRIPTION
This short PR adjusts the fa-angle icon to change dynamically based on the "resource usage" section of the page being expanded or collapsed.

Currently, the icon is always set to fa-angle-down, regardless of the resources section being collapsed or expanded. Here, an `ngClass` can be introduced to change the icon based on the status of the `resourcesCollapsed` variable that gets toggled when the user expands/collapses the section.

What it looks like currently:
![old-collapsed](https://user-images.githubusercontent.com/10425301/36312507-be6d2e70-12fc-11e8-9930-76fd5df64ce2.png)

What it looks like after this patch:
![now-collapsed](https://user-images.githubusercontent.com/10425301/36312517-c376f658-12fc-11e8-9f38-0a2e29d08ee2.png)
