### PR TITLE
Relock create area's create button and move event handler code

### DIFF
--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -38,7 +38,7 @@
   </div>
 </div>
 
-<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()" (onHide)="onHideHandler()">
+<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="createAreaDialog.onOpen()" (onHide)="createAreaDialog.onClose()">
   <div class="modal-dialog">
     <div class="modal-content">
       <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -61,15 +61,6 @@ export class AreasComponent implements OnInit, OnDestroy {
     this.modal.show();
   }
 
-  onShowHandler() {
-    this.createAreaDialog.focus();
-  }
-
-  onHideHandler() {
-    this.createAreaDialog.clearField();
-    this.createAreaDialog.resetError();
-  }
-
   addChildArea(id: string) {
     if (id) {
       this.selectedAreaId = id;

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -24,6 +24,7 @@ export class AreasComponent implements OnInit, OnDestroy {
   private listConfig: ListConfig;
   private areaSubscription: Subscription;
   private selectedAreaId: string;
+  private defaultArea: string;
 
   constructor(
     private contexts: ContextService,
@@ -47,6 +48,7 @@ export class AreasComponent implements OnInit, OnDestroy {
       areas.forEach((area) => {
         if (area.attributes.parent_path == '/') {
           this.selectedAreaId = area.id;
+          this.defaultArea = area.id;
         }
       });
       this.areas = areas;
@@ -62,6 +64,7 @@ export class AreasComponent implements OnInit, OnDestroy {
   }
 
   addChildArea(id: string) {
+    this.selectedAreaId = this.defaultArea;
     if (id) {
       this.selectedAreaId = id;
     }

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -1,4 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { NgForm, NgModel } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
@@ -22,6 +23,7 @@ export class CreateAreaDialogComponent {
   @Input() areas: Area[];
   @Output() onAdded = new EventEmitter<Area>();
   @ViewChild('nameInput') nameInput: ElementRef;
+  @ViewChild('areaForm') areaForm: NgForm;
 
   private context: Context;
   private name: string;
@@ -38,7 +40,7 @@ export class CreateAreaDialogComponent {
   }
 
   public clearField() {
-    this.nameInput.nativeElement.value = '';
+    this.areaForm.form.controls['name'].reset();
   }
 
   public resetError() {

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -35,15 +35,24 @@ export class CreateAreaDialogComponent {
     this.contexts.current.subscribe(val => this.context = val);
   }
 
-  public focus() {
+  public onOpen() {
+    this.focus();
+  }
+
+  public onClose() {
+    this.clearField();
+    this.resetErrors();
+  }
+
+  focus() {
     this.nameInput.nativeElement.focus();
   }
 
-  public clearField() {
+  clearField() {
     this.areaForm.form.controls['name'].reset();
   }
 
-  public resetError() {
+  resetErrors() {
     this.errors = null;
   }
 


### PR DESCRIPTION
This PR accomplishes two goals : It ensures that when the Create Area modal is re-opened (i.e., when creating a second area) that the create button is disabled by default until user input is provided [0]. It also moves all event handler code to the create-area-dialog component, rather than having some there and the rest in the areas component. 

Solves: 
[0] https://github.com/openshiftio/openshift.io/issues/2252

There is discussion in [0] about the desired behaviour regarding which area should be selected on the modal open event. This implementation follows what @catrobson describes in that issue.