### PR TITLE
fix(update): fix user profile requiring a browser refresh to show cha…

### DIFF
--- a/src/app/profile/overview/overview.component.ts
+++ b/src/app/profile/overview/overview.component.ts
@@ -40,6 +40,9 @@ export class OverviewComponent implements OnDestroy, OnInit {
 
   ngOnInit() {
     this.viewingOwnAccount = this.contextService.viewingOwnContext();
+    if (this.userService.currentLoggedInUser.attributes) {
+      this.context.user = this.userService.currentLoggedInUser;
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -227,11 +227,8 @@ export class UpdateComponent implements AfterViewInit, OnInit {
     profile.featureLevel = this.featureLevel;
 
     this.subscriptions.push(this.gettingStartedService.update(profile).subscribe(user => {
+      this.userService.currentLoggedInUser = user;
       this.setUserProperties(user);
-      this.userService.loggedInUser.map(loggedInUser => {
-        // make sure the update of profile (deep clone of user) also get the logged-in user updated
-        (loggedInUser.attributes as any).featureLevel = (user.attributes as any).featureLevel;
-      }).publish().connect();
       this.notifications.message({
         message: `Profile updated!`,
         type: NotificationType.SUCCESS


### PR DESCRIPTION
…nges

This PR addresses https://github.com/openshiftio/openshift.io/issues/862 [0].

The overview page now assigns the `context.user` to be the `userService.currentLoggedInUser` value in the `ngOnInit`, which allows the page to show the latest incoming changes. 

The update component has switched the `userService.loggedInUser` for `userService.currentLoggedInUser`, as is recommended by the comments in the `user.service.d.ts` file [1]. It looks like instances of `loggedInUser` should be updated to use `currentLoggedInUser` [1], and can be done in a follow up PR.

Now, introducing an update should automatically show the changes when being redirected to the profile page, and the changes should persist when going back to the update page.

[0] https://github.com/openshiftio/openshift.io/issues/862
[1] https://github.com/fabric8-ui/ngx-login-client/blob/master/src/app/user/user.service.ts#L27

