### PR TITLE
feat(deployments): add time and color indicators to deployments chart…

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -53,13 +53,13 @@ export class DeploymentDetailsComponent {
   cpuData: SparklineData = {
     dataAvailable: true,
     xData: ['time'],
-    yData: ['used']
+    yData: ['CPU']
   };
 
   memData: SparklineData = {
     dataAvailable: true,
     xData: ['time'],
-    yData: ['used']
+    yData: ['Memory']
   };
 
   netData: DeploymentsLinechartData = {
@@ -75,7 +75,9 @@ export class DeploymentDetailsComponent {
     chartId: uniqueId('cpu-chart'),
     axis: {
       type: 'timeseries'
-    }
+    },
+    tooltip: this.getTooltipContents(),
+    units: 'Cores'
   };
 
   memConfig: SparklineConfig = {
@@ -83,7 +85,8 @@ export class DeploymentDetailsComponent {
     chartId: uniqueId('mem-chart'),
     axis: {
       type: 'timeseries'
-    }
+    },
+    tooltip: this.getTooltipContents()
   };
 
   netConfig: DeploymentsLinechartConfig = {
@@ -241,4 +244,43 @@ export class DeploymentDetailsComponent {
     );
     return latch;
   }
+
+  private getTooltipContents(): any {
+    return {
+      contents: (d: any) => {
+        // d is an object containing the data displayed for a given data point in the tooltip
+        // example: [{ x: Date, value: number, id: string, index: number, name: string }]
+        // http://c3js.org/reference.html#tooltip-contents
+        let tipRows: string = '';
+        let color = '#0088ce'; // pf-blue-400
+        let units: string = '';
+        if (d[0].name === 'CPU') {
+          units = this.cpuConfig.units;
+        } else if (d[0].name === 'Memory') {
+          units = this.memUnits;
+        }
+        tipRows += `
+          <tr><th colspan="2">${d[0].x.toLocaleString()}</th></tr>
+          <tr>
+            <td class="name"><span style="background-color: ${color}"></span>${d[0].name}</td>
+            <td class="value text-nowrap">${d[0].value} ${units}</td>
+          </tr>
+        `;
+        return this.getTooltipTableHTML(tipRows);
+      }
+    };
+  }
+
+  private getTooltipTableHTML(tipRows: string): string {
+    return `
+      <div class="module-triangle-bottom">
+        <table class="c3-tooltip">
+          <tbody>
+            ${tipRows}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
 }

--- a/src/app/space/create/deployments/deployments-linechart/deployments-linechart.component.ts
+++ b/src/app/space/create/deployments/deployments-linechart/deployments-linechart.component.ts
@@ -132,11 +132,21 @@ export class DeploymentsLinechartComponent extends ChartBase implements DoCheck,
       contents: (d: any) => {
         let tipRows: string = '';
         for (let i = 0; i < d.length; i++) {
-          tipRows +=
-          '<tr>' +
-          '  <td class="value">' + d[i].name + '</td>' +
-          '  <td class="value text-nowrap">' + d[i].value + '</td>' +
-          '</tr>';
+          let color;
+          if (d[i].name === 'sent') {
+            color = this.defaultConfig.data.colors.sent;
+          } else if (d[i].name === 'received') {
+            color = this.defaultConfig.data.colors.received;
+          }
+          if (i === 0) {
+            tipRows += `<tr><th colspan="2">${d[i].x.toLocaleString()}</th></tr>`;
+          }
+          tipRows += `
+            <tr>
+              <td class="name"><span style="background-color: ${color}"></span>${d[i].name}</td>
+              <td class="value text-nowrap">${d[i].value} ${this.config.units}/s</td>
+            </tr>
+          `;
         }
         return this.getTooltipTableHTML(tipRows);
       },
@@ -166,13 +176,15 @@ export class DeploymentsLinechartComponent extends ChartBase implements DoCheck,
   }
 
   private getTooltipTableHTML(tipRows: string): string {
-    return '<div class="module-triangle-bottom">' +
-      '  <table class="c3-tooltip">' +
-      '    <tbody>' +
-      tipRows +
-      '    </tbody>' +
-      '  </table>' +
-      '</div>';
+    return `
+      <div class="module-triangle-bottom">
+        <table class="c3-tooltip">
+          <tbody>
+            ${tipRows}
+          </tbody>
+        </table>
+      </div>
+    `;
   }
 
 }


### PR DESCRIPTION
… tooltips

This PR adds the newly propagated timestamp values from the DeploymentsService to the chart tooltips. This is an attempt to make the charts look more closely related to the OSO counter-parts. The CSS values were taken from inspecting the OSO console. The tooltips for the CPU and Memory charts have also been updated in a similar fashion.

Here's an example of what the openshift console network chart tooltips look like:
![osio-network](https://user-images.githubusercontent.com/10425301/36331340-6bb26bac-133b-11e8-83d3-7ad5b1f30fdb.png)

Here's what the deployments network chart tooltips look like currently:
![old-network](https://user-images.githubusercontent.com/10425301/36331362-76fe3590-133b-11e8-8e71-4f26a8795c2a.png)

Here's what the deployments network chart tooltips look like with this PR:
![new-network](https://user-images.githubusercontent.com/10425301/36331348-6ff0e176-133b-11e8-9ac8-3db5240e1eb1.png)


