### PR TITLE
Add error highlighting functionality

### DIFF
--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
@@ -7,15 +7,16 @@
   <form role="form" #areaForm="ngForm" (ngSubmit)="createArea()" novalidate>
     <div class="form">
       <fieldset class="create-fieldset">
-        <div *ngIf="errors" class="alert alert-danger">
-          <div [hidden]="!errors.uniqueValidationFailure">
+        <div [hidden]="!errors.uniqueValidationFailure" class="alert alert-danger">
+          <div>
             <span class="pficon pficon-error-circle-o"></span>
             <b>Unique Name</b> A unique name is required to add a new area.
           </div>
         </div>
-        <div class="form-group">
+        <div class="form-group" [ngClass]="{'has-error': errors.uniqueValidationFailure}">
           <label for="name" class="control-label">Name</label>
-          <input #nameInput id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
+          <input #rawInputField id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
+          <small [hidden]="!errors.uniqueValidationFailure">Please choose a unique name.</small>
         </div>
         <div class="form-group">
           <label class="control-label">Parent area</label>

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
@@ -8,15 +8,18 @@
     <div class="form">
       <fieldset class="create-fieldset">
         <div [hidden]="!errors.uniqueValidationFailure" class="alert alert-danger">
-          <div>
-            <span class="pficon pficon-error-circle-o"></span>
-            <b>Unique Name</b> A unique name is required to add a new area.
-          </div>
+          <span class="pficon pficon-error-circle-o"></span>
+          <b>Unique Name</b> A unique name is required to add a new area.
         </div>
-        <div class="form-group" [ngClass]="{'has-error': errors.uniqueValidationFailure}">
+        <div [hidden]="!(inputModel.hasError('required')) || inputModel.pristine" class="alert alert-danger">
+          <span class="pficon pficon-error-circle-o"></span>
+          <b>Missing name</b> A name is required to add a new area.
+        </div>
+        <div class="form-group" [ngClass]="{'has-error': errors.uniqueValidationFailure || !inputModel.pristine && !inputModel.valid}">
           <label for="name" class="control-label">Name</label>
-          <input #rawInputField id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
+          <input #rawInputField #inputModel="ngModel" id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
           <small [hidden]="!errors.uniqueValidationFailure">Please choose a unique name.</small>
+          <small [hidden]="!(inputModel.hasError('required')) || inputModel.pristine">Please enter a name.</small>
         </div>
         <div class="form-group">
           <label class="control-label">Parent area</label>
@@ -26,7 +29,6 @@
         </div>
       </fieldset>
     </div>
-
     <div class="modal-footer">
       <div class="create-footer">
         <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
@@ -35,4 +37,3 @@
     </div>
   </form>
 </div>
-

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.less
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.less
@@ -6,3 +6,8 @@
   .glyphicon-remove { .pointer; }
 }
 .create-footer { text-align: right; }
+
+.has-error {
+  color:red;
+  border-color: red;
+}

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -25,6 +25,7 @@ export class CreateAreaDialogComponent implements OnInit {
   @ViewChild('areaForm') areaForm: NgForm;
 
   @ViewChild('rawInputField') rawInputField: ElementRef;
+  @ViewChild('inputModel') inputModel: NgModel;
 
   private context: Context;
   private name: string;
@@ -54,11 +55,11 @@ export class CreateAreaDialogComponent implements OnInit {
   }
 
   clearField() {
-    this.areaForm.form.controls['name'].reset();
+    this.inputModel.reset();
   }
 
   resetErrors() {
-    this.errors = null;
+    this.errors = {uniqueValidationFailure: false};
   }
 
   createArea() {

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { NgForm, NgModel } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
@@ -16,14 +16,15 @@ import { ContextService } from '../../../../shared/context.service';
   templateUrl: './create-area-dialog.component.html',
   styleUrls: ['./create-area-dialog.component.less']
 })
-export class CreateAreaDialogComponent {
+export class CreateAreaDialogComponent implements OnInit {
 
   @Input() host: ModalDirective;
   @Input() parentId: string;
   @Input() areas: Area[];
   @Output() onAdded = new EventEmitter<Area>();
-  @ViewChild('nameInput') nameInput: ElementRef;
   @ViewChild('areaForm') areaForm: NgForm;
+
+  @ViewChild('rawInputField') rawInputField: ElementRef;
 
   private context: Context;
   private name: string;
@@ -45,7 +46,11 @@ export class CreateAreaDialogComponent {
   }
 
   focus() {
-    this.nameInput.nativeElement.focus();
+    this.rawInputField.nativeElement.focus();
+  }
+
+  ngOnInit() {
+    this.errors = {uniqueValidationFailure: false};
   }
 
   clearField() {
@@ -86,9 +91,7 @@ export class CreateAreaDialogComponent {
     if (error.errors.length) {
       error.errors.forEach(error => {
         if (error.status === '409') {
-          this.errors = {
-            uniqueValidationFailure: true
-          };
+          this.errors.uniqueValidationFailure = true;
         }
       });
     }


### PR DESCRIPTION
In order, the accompanying commits to this PR achieve three things in the create area modal:

1) Introduce a custom validator directive to the modal, which checks if a duplicate name has been entered. This saves us from the current wasteful implementation whereby a request must be sent, receiving an 409, before an error can be displayed informing the user that they must enter a unique name. 

2) Adds correct error highlighting (in red) as well as a helpful message underneath any infringing fields, as by the [patternfly specification](http://www.patternfly.org/pattern-library/forms-and-controls/errors-and-validation).

3) Adds additional error messages for the situation where a user types a name into the input, and then removes all inputted text, leaving the field blank. 

Solves : https://github.com/openshiftio/openshift.io/issues/2255

Screenshots: 

![2018-02-20-152428_1903x932_scrot](https://user-images.githubusercontent.com/17230733/36451891-8ce5131a-1660-11e8-9d98-26f7b971f6d0.png)

![2018-02-20-152411_1917x926_scrot](https://user-images.githubusercontent.com/17230733/36451892-8cf3c34c-1660-11e8-97ef-bf8add6800b3.png)
