### PR TITLE
Deployments service refactor

### DIFF
--- a/src/app/dashboard-widgets/environment-widget/environment-widget.module.ts
+++ b/src/app/dashboard-widgets/environment-widget/environment-widget.module.ts
@@ -5,11 +5,11 @@ import { RouterModule } from '@angular/router';
 
 import { MomentModule } from 'angular2-moment';
 
+import { DeploymentsModule } from '../../space/create/deployments/deployments.module';
 import { EnvironmentWidgetComponent } from './environment-widget.component';
 
-
 @NgModule({
-  imports: [CommonModule, FormsModule, RouterModule, MomentModule ],
+  imports: [CommonModule, DeploymentsModule, FormsModule, RouterModule, MomentModule],
   declarations: [EnvironmentWidgetComponent],
   exports: [EnvironmentWidgetComponent]
 })

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -25,8 +25,7 @@ import { Pods } from '../models/pods';
 import { ScaledNetworkStat } from '../models/scaled-network-stat';
 import {
   DeploymentsService,
-  NetworkStat,
-  TimeConstrainedStats
+  NetworkStat
 } from '../services/deployments.service';
 import { DeploymentDetailsComponent } from './deployment-details.component';
 
@@ -104,25 +103,12 @@ describe('DeploymentDetailsComponent', () => {
   let memStatObservable: BehaviorSubject<MemoryStat>;
   let netStatObservable: BehaviorSubject<NetworkStat>;
   let podsObservable: BehaviorSubject<Pods>;
-  let initialStatsObservable: Subject<TimeConstrainedStats>;
-
-  const mb = Math.pow(1024, 2);
-  const initialStats: TimeConstrainedStats = {
-    cpu: [
-      { used: 2, quota: 2, timestamp: 1234567891011 }
-    ],
-    memory: [
-      { used: 2, quota: 4, units: 'GB', timestamp: 1234567891011 }
-    ],
-    network: [
-      { sent: new ScaledNetworkStat(2 * mb, 1234567891011), received: new ScaledNetworkStat(1 * mb, 1234567891011) }
-    ]
-  };
 
   beforeEach(() => {
     cpuStatObservable = new BehaviorSubject({ used: 1, quota: 2 } as CpuStat);
     memStatObservable = new BehaviorSubject({ used: 3, quota: 4, units: 'GB' } as MemoryStat);
 
+    const mb = Math.pow(1024, 2);
     netStatObservable = new BehaviorSubject({
       sent: new ScaledNetworkStat(1 * mb),
       received: new ScaledNetworkStat(2 * mb)
@@ -131,8 +117,6 @@ describe('DeploymentDetailsComponent', () => {
     podsObservable = new BehaviorSubject(
       { total: 1, pods: [['Running', 1], ['Starting', 0], ['Stopping', 0]] } as Pods
     );
-
-    initialStatsObservable = new Subject<TimeConstrainedStats>();
 
     mockSvc = createMock(DeploymentsService);
     mockSvc.getVersion.and.returnValue(Observable.of('1.2.3'));
@@ -144,7 +128,6 @@ describe('DeploymentDetailsComponent', () => {
     mockSvc.deleteApplication.and.returnValue(Observable.of('mockDeletedMessage'));
     mockSvc.getDeploymentNetworkStat.and.returnValue(netStatObservable);
     mockSvc.getPods.and.returnValue(podsObservable);
-    mockSvc.getDeploymentTimeConstrainedStats.and.returnValue(initialStatsObservable);
   });
 
   initContext(DeploymentDetailsComponent, HostComponent, {
@@ -175,16 +158,7 @@ describe('DeploymentDetailsComponent', () => {
   });
 
   describe('hasPods', () => {
-    it('should be true for initial state', function(this: Context, done: DoneFn) {
-      initialStatsObservable.next(initialStats);
-      this.testedDirective.hasPods.subscribe((b: boolean) => {
-        expect(b).toBeTruthy();
-        done();
-      });
-    });
-
     it('should be false for state without pods', function(this: Context, done: DoneFn) {
-      initialStatsObservable.complete();
       podsObservable.next({ total: 0, pods: [] });
       this.testedDirective.hasPods.subscribe((b: boolean) => {
         expect(b).toBeFalsy();
@@ -193,47 +167,10 @@ describe('DeploymentDetailsComponent', () => {
     });
   });
 
-  describe('initial data', () => {
-    beforeEach(function(this: Context) {
-      initialStatsObservable.next(initialStats);
-    });
-
-    it('should request the last 15 minutes worth of deployments data on chart initialization', () => {
-      expect(mockSvc.getDeploymentTimeConstrainedStats).toHaveBeenCalledWith('mockSpaceId', 'mockAppId', 'mockEnvironment', DeploymentDetailsComponent.DEFAULT_SPARKLINE_DATA_DURATION);
-    });
-
-    it('should have cpu information be added first to the cpuData data structure', function(this: Context) {
-      let detailsComponent = this.testedDirective;
-      expect(detailsComponent.cpuData.xData.length).toEqual(3);
-      expect(detailsComponent.cpuData.yData[1]).toEqual(2); // value of 2 from initialStatsObservable
-      expect(detailsComponent.cpuData.yData[2]).toEqual(1); // value of 1 from cpuStatObservable
-    });
-
-    it('should have memory information be added first to the memData data structure', function(this: Context) {
-      let detailsComponent = this.testedDirective;
-      expect(detailsComponent.memData.xData.length).toEqual(3);
-      expect(detailsComponent.memData.yData[1]).toEqual(2); // value of 2 from initialStatsObservable
-      expect(detailsComponent.memData.yData[2]).toEqual(3); // value of 3 from memStatObservable
-    });
-
-    it('should have network information be added first to the netData data structure', function(this: Context) {
-      let detailsComponent = this.testedDirective;
-      let mb = Math.pow(1024, 2);
-      expect(detailsComponent.netData.xData.length).toEqual(3);
-      expect(detailsComponent.netData.yData[0][1]).toEqual(2 * mb); // value of 2 * mb from initialStatsObservable
-      expect(detailsComponent.netData.yData[0][2]).toEqual(1 * mb); // value of 1 * mb from netStatObservable
-    });
-  });
-
   describe('cpu label', () => {
     let de: DebugElement;
 
     beforeEach(function(this: Context) {
-      initialStatsObservable.next(initialStats);
-      initialStatsObservable.complete();
-
-      this.detectChanges();
-
       const charts: DebugElement[] = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
       const cpuChart: DebugElement = charts[0];
       de = cpuChart.query(By.directive(FakeDeploymentGraphLabelComponent));
@@ -260,11 +197,6 @@ describe('DeploymentDetailsComponent', () => {
     let de: DebugElement;
 
     beforeEach(function(this: Context) {
-      initialStatsObservable.next(initialStats);
-      initialStatsObservable.complete();
-
-      this.detectChanges();
-
       const charts: DebugElement[] = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
       const memoryChart: DebugElement = charts[1];
       de = memoryChart.query(By.directive(FakeDeploymentGraphLabelComponent));
@@ -288,11 +220,6 @@ describe('DeploymentDetailsComponent', () => {
     let de: DebugElement;
 
     beforeEach(function(this: Context) {
-      initialStatsObservable.next(initialStats);
-      initialStatsObservable.complete();
-
-      this.detectChanges();
-
       const charts: DebugElement[] = this.fixture.debugElement.queryAll(By.css('.deployment-chart'));
       const networkChart: DebugElement = charts[2];
       de = networkChart.query(By.directive(FakeDeploymentGraphLabelComponent));
@@ -316,13 +243,6 @@ describe('DeploymentDetailsComponent', () => {
   });
 
   describe('charts', () => {
-    beforeEach(function(this: Context) {
-      initialStatsObservable.next(initialStats);
-      initialStatsObservable.complete();
-
-      this.detectChanges();
-    });
-
     it('by default should be the default data duration divided by the polling rate', function(this: Context) {
       const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
       const expectedDefaultElements: number =
@@ -377,10 +297,10 @@ describe('DeploymentDetailsComponent', () => {
         this.detectChanges();
         const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
         expect(detailsComponent.netVal).toEqual(301);
-        expect(detailsComponent.netData.xData.length).toEqual(4);
+        expect(detailsComponent.netData.xData.length).toEqual(3);
         expect(detailsComponent.netData.yData.length).toEqual(2);
-        expect(detailsComponent.netData.yData[0][3]).toEqual(101);
-        expect(detailsComponent.netData.yData[1][3]).toEqual(200);
+        expect(detailsComponent.netData.yData[0][2]).toEqual(101);
+        expect(detailsComponent.netData.yData[1][2]).toEqual(200);
       });
 
       it('should be rounded to tenths when units are larger than bytes', function(this: Context) {
@@ -391,10 +311,10 @@ describe('DeploymentDetailsComponent', () => {
         this.detectChanges();
         const detailsComponent: DeploymentDetailsComponent = this.testedDirective;
         expect(detailsComponent.netVal).toEqual(58);
-        expect(detailsComponent.netData.xData.length).toEqual(4);
+        expect(detailsComponent.netData.xData.length).toEqual(3);
         expect(detailsComponent.netData.yData.length).toEqual(2);
-        expect(detailsComponent.netData.yData[0][3]).toEqual(12636.2);
-        expect(detailsComponent.netData.yData[1][3]).toEqual(46766.1);
+        expect(detailsComponent.netData.yData[0][2]).toEqual(12636.2);
+        expect(detailsComponent.netData.yData[1][2]).toEqual(46766.1);
       });
     });
   });

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -2,17 +2,19 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { Http } from '@angular/http';
 
+import { Observable } from 'rxjs';
+
 import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ChartModule, ToolbarModule } from 'patternfly-ng';
 
-import { DeploymentStatusIconComponent } from '../deployments/apps/deployment-status-icon.component';
 import { DeploymentCardContainerComponent } from './apps/deployment-card-container.component';
 import { DeploymentCardComponent } from './apps/deployment-card.component';
 import { DeploymentDetailsComponent } from './apps/deployment-details.component';
 import { DeploymentGraphLabelComponent } from './apps/deployment-graph-label.component';
+import { DeploymentStatusIconComponent } from './apps/deployment-status-icon.component';
 import { DeploymentsAppsComponent } from './apps/deployments-apps.component';
 import { DeploymentsDonutChartComponent } from './deployments-donut/deployments-donut-chart/deployments-donut-chart.component';
 import { DeploymentsDonutComponent } from './deployments-donut/deployments-donut.component';
@@ -23,6 +25,14 @@ import { DeploymentsComponent } from './deployments.component';
 import { DeploymentsResourceUsageComponent } from './resource-usage/deployments-resource-usage.component';
 import { ResourceCardComponent } from './resource-usage/resource-card.component';
 import { UtilizationBarComponent } from './resource-usage/utilization-bar.component';
+import {
+  DeploymentsService,
+  TIMER_TOKEN
+} from './services/deployments.service';
+
+const DEPLOYMENTS_SERVICE_POLL_TIMER = Observable
+  .timer(DeploymentsService.INITIAL_UPDATE_DELAY, DeploymentsService.POLL_RATE_MS)
+  .share();
 
 @NgModule({
   imports: [
@@ -52,7 +62,8 @@ import { UtilizationBarComponent } from './resource-usage/utilization-bar.compon
     UtilizationBarComponent
   ],
   providers: [
-    BsDropdownConfig
+    BsDropdownConfig,
+    { provide: TIMER_TOKEN, useValue: DEPLOYMENTS_SERVICE_POLL_TIMER }
   ]
 })
 export class DeploymentsModule {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -1,10 +1,5 @@
 import { ErrorHandler } from '@angular/core';
-import {
-  discardPeriodicTasks,
-  fakeAsync,
-  TestBed,
-  tick
-} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import {
   HttpModule,
@@ -23,6 +18,7 @@ import { createMock } from 'testing/mock';
 
 import {
   Observable,
+  Subject,
   Subscription
 } from 'rxjs';
 
@@ -30,20 +26,15 @@ import { Logger } from 'ngx-base';
 
 import { NotificationsService } from 'app/shared/notifications.service';
 
-import {
-  AuthenticationService,
-  UserService
-} from 'ngx-login-client';
+import { AuthenticationService } from 'ngx-login-client';
 
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 
 import { CpuStat } from '../models/cpu-stat';
-import { Environment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 import { ScaledNetworkStat } from '../models/scaled-network-stat';
 import {
-  Application,
   DeploymentsService,
   NetworkStat,
   TIMER_TOKEN
@@ -60,6 +51,7 @@ interface MockHttpParams<U> {
 
 describe('DeploymentsService', () => {
 
+  const serviceUpdater: Subject<void> = new Subject<void>();
   let mockBackend: MockBackend;
   let mockLogger: jasmine.SpyObj<Logger>;
   let mockErrorHandler: jasmine.SpyObj<ErrorHandler>;
@@ -97,9 +89,7 @@ describe('DeploymentsService', () => {
         },
         {
           provide: TIMER_TOKEN,
-          useValue: Observable
-            .timer(DeploymentsService.INITIAL_UPDATE_DELAY, DeploymentsService.POLL_RATE_MS)
-            .share()
+          useValue: serviceUpdater
         },
         DeploymentsService
       ]
@@ -149,6 +139,7 @@ describe('DeploymentsService', () => {
         );
       }
     });
+    serviceUpdater.next();
   }
 
   describe('#getApplications', () => {
@@ -989,6 +980,7 @@ describe('DeploymentsService', () => {
           expect(stat).toEqual({ used: 2, quota: 3, timestamp: 2 });
           done();
         });
+      serviceUpdater.next();
     });
   });
 
@@ -1077,6 +1069,7 @@ describe('DeploymentsService', () => {
           subscription.unsubscribe();
           done();
         });
+      serviceUpdater.next();
     });
   });
 
@@ -1151,6 +1144,7 @@ describe('DeploymentsService', () => {
           subscription.unsubscribe();
           done();
         });
+      serviceUpdater.next();
     });
   });
 

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -45,9 +45,7 @@ import { ScaledNetworkStat } from '../models/scaled-network-stat';
 import {
   Application,
   DeploymentsService,
-  MultiTimeseriesData,
-  NetworkStat,
-  TimeConstrainedStats
+  NetworkStat
 } from './deployments.service';
 
 interface MockHttpParams<U> {
@@ -902,14 +900,26 @@ describe('DeploymentsService', () => {
 
   describe('#getDeploymentCpuStat', () => {
     it('should combine timeseries and quota data', (done: DoneFn) => {
-      const timeseriesResponse = {
+      const initialTimeseriesResponse = {
         data: {
-          attributes: {
-            cores: {
-              time: 1,
-              value: 2
-            }
-          }
+          cores: [
+            { value: 1, time: 1 },
+            { value: 2, time: 2 }
+          ],
+          memory: [
+            { value: 3, time: 3 },
+            { value: 4, time: 4}
+          ],
+          net_rx: [
+            { value: 5, time: 5 },
+            { value: 6, time: 6 }
+          ],
+          net_tx: [
+            { value: 7, time: 7 },
+            { value: 8, time: 8}
+          ],
+          start: 1,
+          end: 8
         }
       };
       const deploymentResponse = {
@@ -939,8 +949,8 @@ describe('DeploymentsService', () => {
             quota: {
               cpucores: {
                 quota: 3,
-                used: 4,
-                timestamp: 1
+                used: 2,
+                timestamp: 2
               }
             }
           }
@@ -948,12 +958,12 @@ describe('DeploymentsService', () => {
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const initialTimeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/statseries\?start=\d+&end=\d+$/;
         const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
-        if (timeseriesRegex.test(requestUrl)) {
-          responseBody = timeseriesResponse;
+        if (initialTimeseriesRegex.test(requestUrl)) {
+          responseBody = initialTimeseriesResponse;
         } else if (deploymentRegex.test(requestUrl)) {
           responseBody = deploymentResponse;
         } else {
@@ -969,8 +979,7 @@ describe('DeploymentsService', () => {
 
       svc.getDeploymentCpuStat('foo-space', 'foo-app', 'foo-env')
         .subscribe((stat: CpuStat) => {
-          expect(stat).toEqual({ used: 2, quota: 3, timestamp: 1 });
-          subscription.unsubscribe();
+          expect(stat).toEqual({ used: 2, quota: 3, timestamp: 2 });
           done();
         });
     });
@@ -978,14 +987,26 @@ describe('DeploymentsService', () => {
 
   describe('#getDeploymentMemoryStat', () => {
     it('should combine timeseries and quota data', (done: DoneFn) => {
-      const timeseriesResponse = {
+      const initialTimeseriesResponse = {
         data: {
-          attributes: {
-            memory: {
-              time: 1,
-              value: 2
-            }
-          }
+          cores: [
+            { value: 1, time: 1 },
+            { value: 2, time: 2 }
+          ],
+          memory: [
+            { value: 3, time: 3 },
+            { value: 4, time: 4}
+          ],
+          net_rx: [
+            { value: 5, time: 5 },
+            { value: 6, time: 6 }
+          ],
+          net_tx: [
+            { value: 7, time: 7 },
+            { value: 8, time: 8}
+          ],
+          start: 1,
+          end: 8
         }
       };
       const deploymentResponse = {
@@ -1014,9 +1035,9 @@ describe('DeploymentsService', () => {
             name: 'foo-env',
             quota: {
               memory: {
-                quota: 3,
+                quota: 5,
                 used: 4,
-                timestamp: 1
+                timestamp: 4
               }
             }
           }
@@ -1024,12 +1045,12 @@ describe('DeploymentsService', () => {
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const initialTimeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/statseries\?start=\d+&end=\d+$/;
         const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
-        if (timeseriesRegex.test(requestUrl)) {
-          responseBody = timeseriesResponse;
+        if (initialTimeseriesRegex.test(requestUrl)) {
+          responseBody = initialTimeseriesResponse;
         } else if (deploymentRegex.test(requestUrl)) {
           responseBody = deploymentResponse;
         } else {
@@ -1045,7 +1066,7 @@ describe('DeploymentsService', () => {
 
       svc.getDeploymentMemoryStat('foo-space', 'foo-app', 'foo-env')
         .subscribe((stat: MemoryStat) => {
-          expect(stat).toEqual(new ScaledMemoryStat(2, 3, 1));
+          expect(stat).toEqual(new ScaledMemoryStat(4, 5, 4));
           subscription.unsubscribe();
           done();
         });
@@ -1054,21 +1075,28 @@ describe('DeploymentsService', () => {
 
   describe('#getDeploymentNetworkStat', () => {
     it('should return scaled timeseries data', (done: DoneFn) => {
-      const timeseriesResponse = {
+      const initialTimeseriesResponse = {
         data: {
-          attributes: {
-            net_tx: {
-              time: 1,
-              value: 1.7
-            },
-            net_rx: {
-              time: 1,
-              value: 3.1
-            }
-          }
+          cores: [
+            { value: 1, time: 1 },
+            { value: 2, time: 2 }
+          ],
+          memory: [
+            { value: 3, time: 3 },
+            { value: 4, time: 4}
+          ],
+          net_rx: [
+            { value: 5, time: 5 },
+            { value: 6, time: 6 }
+          ],
+          net_tx: [
+            { value: 7, time: 7 },
+            { value: 8, time: 8}
+          ],
+          start: 1,
+          end: 8
         }
       };
-
       const deploymentResponse = {
         data: {
           attributes: {
@@ -1091,12 +1119,12 @@ describe('DeploymentsService', () => {
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/stats$/;
+        const initialTimeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/statseries\?start=\d+&end=\d+$/;
         const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
         const requestUrl: string = connection.request.url;
         let responseBody: any;
-        if (timeseriesRegex.test(requestUrl)) {
-          responseBody = timeseriesResponse;
+        if (initialTimeseriesRegex.test(requestUrl)) {
+          responseBody = initialTimeseriesResponse;
         } else if (deploymentRegex.test(requestUrl)) {
           responseBody = deploymentResponse;
         }
@@ -1108,184 +1136,14 @@ describe('DeploymentsService', () => {
         ));
       });
 
+      // use "first" operator because there is no network quota request which acts as a bottleneck for other metric cases
       svc.getDeploymentNetworkStat('foo-space', 'foo-app', 'foo-env')
+        .first()
         .subscribe((stat: NetworkStat) => {
-          expect(stat).toEqual({ sent: new ScaledNetworkStat(1.7, 1), received: new ScaledNetworkStat(3.1, 1) });
+          expect(stat).toEqual({ sent: new ScaledNetworkStat(7, 7), received: new ScaledNetworkStat(5, 5) });
           subscription.unsubscribe();
           done();
         });
-    });
-  });
-
-  describe('#getDeploymentTimeConstrainedStats', () => {
-    it('should combine MultiTimeseries and quota data', (done: DoneFn) => {
-      const timeseriesResponse = {
-        data: {
-          cores: [{ time: 1, value: 1 }, { time: 2, value: 2 }],
-          memory: [{ time: 1, value: 2 }, { time: 2, value: 3 }],
-          net_tx: [{ time: 1, value: 3 }, { time: 2, value: 4 }],
-          net_rx: [{ time: 1, value: 4 }, { time: 2, value: 5 }],
-          start: 0,
-          end: 0
-        }
-      };
-      const deploymentResponse = {
-        data: {
-          attributes: {
-            applications: [
-              {
-                attributes: {
-                  name: 'foo-app',
-                  deployments: [
-                    {
-                      attributes: {
-                        name: 'foo-env'
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      };
-      const quotaResponse = {
-        data: [{
-          attributes: {
-            name: 'foo-env',
-            quota: {
-              cpucores: {
-                quota: 2,
-                used: 1
-              },
-              memory: {
-                quota: 4,
-                used: 2,
-                units: 'MB'
-              }
-            }
-          }
-        }]
-      };
-      const expectedResponse: TimeConstrainedStats = {
-        cpu: [
-          { used: 1, quota: 2, timestamp: 1 },
-          { used: 2, quota: 2, timestamp: 2 }
-        ],
-        memory: [
-          new ScaledMemoryStat(2, 4, 1),
-          new ScaledMemoryStat(3, 4, 2)
-        ],
-        network: [
-          { sent: new ScaledNetworkStat(3, 1), received: new ScaledNetworkStat(4, 1) },
-          { sent: new ScaledNetworkStat(4, 2), received: new ScaledNetworkStat(5, 2) }
-        ]
-      };
-      const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/statseries\?start=\d+&end=\d+$/;
-        const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
-        const requestUrl: string = connection.request.url;
-        let responseBody: any;
-        if (timeseriesRegex.test(requestUrl)) {
-          responseBody = timeseriesResponse;
-        } else if (deploymentRegex.test(requestUrl)) {
-          responseBody = deploymentResponse;
-        } else {
-          responseBody = quotaResponse;
-        }
-        connection.mockRespond(new Response(
-          new ResponseOptions({
-            body: JSON.stringify(responseBody),
-            status: 200
-          })
-        ));
-      });
-
-      svc.getDeploymentTimeConstrainedStats('foo-space', 'foo-app', 'foo-env', (2 * 60 * 1000))
-        .subscribe((stats: TimeConstrainedStats) => {
-          expect(stats).toEqual(expectedResponse);
-          subscription.unsubscribe();
-          done();
-        });
-    });
-
-    it('should return an empty TimeConstrainedStats object if there is no data', (done: DoneFn) => {
-      const timeseriesResponse = {
-        data: {
-          cores: [],
-          memory: [],
-          net_tx: [],
-          net_rx: []
-        }
-      };
-      const deploymentResponse = {
-        data: {
-          attributes: {
-            applications: [
-              {
-                attributes: {
-                  name: 'foo-app',
-                  deployments: [
-                    {
-                      attributes: {
-                        name: 'foo-env'
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      };
-      const quotaResponse = {
-        data: [{
-          attributes: {
-            name: 'foo-env',
-            quota: {
-              cpucores: {
-                quota: 2,
-                used: 0
-              },
-              memory: {
-                quota: 4,
-                used: 0
-              }
-            }
-          }
-        }]
-      };
-      const expectedResponse: TimeConstrainedStats = {
-        cpu: [],
-        memory: [],
-        network: []
-      };
-      const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
-        const timeseriesRegex: RegExp = /\/deployments\/spaces\/foo-space\/applications\/foo-app\/deployments\/foo-env\/statseries\?start=\d+&end=\d+$/;
-        const deploymentRegex: RegExp = /\/deployments\/spaces\/foo-space$/;
-        const requestUrl: string = connection.request.url;
-        let responseBody: any;
-        if (timeseriesRegex.test(requestUrl)) {
-          responseBody = timeseriesResponse;
-        } else if (deploymentRegex.test(requestUrl)) {
-          responseBody = deploymentResponse;
-        } else {
-          responseBody = quotaResponse;
-        }
-        connection.mockRespond(new Response(
-          new ResponseOptions({
-            body: JSON.stringify(responseBody),
-            status: 200
-          })
-        ));
-      });
-
-      svc.getDeploymentTimeConstrainedStats('foo-space', 'foo-app', 'foo-env', (2 * 60 * 1000))
-      .subscribe((stats: TimeConstrainedStats) => {
-        expect(stats).toEqual(expectedResponse);
-        subscription.unsubscribe();
-        done();
-      });
     });
   });
 

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -45,7 +45,8 @@ import { ScaledNetworkStat } from '../models/scaled-network-stat';
 import {
   Application,
   DeploymentsService,
-  NetworkStat
+  NetworkStat,
+  TIMER_TOKEN
 } from './deployments.service';
 
 interface MockHttpParams<U> {
@@ -93,6 +94,12 @@ describe('DeploymentsService', () => {
         },
         {
           provide: NotificationsService, useValue: mockNotificationsService
+        },
+        {
+          provide: TIMER_TOKEN,
+          useValue: Observable
+            .timer(DeploymentsService.INITIAL_UPDATE_DELAY, DeploymentsService.POLL_RATE_MS)
+            .share()
         },
         DeploymentsService
       ]

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -2,6 +2,7 @@ import {
   ErrorHandler,
   Inject,
   Injectable,
+  InjectionToken,
   OnDestroy
 } from '@angular/core';
 
@@ -183,6 +184,8 @@ export interface SeriesData {
   value: number;
 }
 
+export const TIMER_TOKEN: InjectionToken<string> = new InjectionToken<string>('DeploymentsServiceTimer');
+
 @Injectable()
 export class DeploymentsService implements OnDestroy {
 
@@ -199,10 +202,6 @@ export class DeploymentsService implements OnDestroy {
   private readonly envsObservables: Map<string, Observable<EnvironmentStat[]>> = new Map<string, Observable<EnvironmentStat[]>>();
   private readonly timeseriesSubjects: Map<string, Subject<TimeseriesData>> = new Map<string, Subject<TimeseriesData>>();
 
-  private readonly pollTimer = Observable
-    .timer(DeploymentsService.INITIAL_UPDATE_DELAY, DeploymentsService.POLL_RATE_MS)
-    .share();
-
   private readonly serviceSubscriptions: Subscription[] = [];
 
   constructor(
@@ -211,7 +210,8 @@ export class DeploymentsService implements OnDestroy {
     public logger: Logger,
     public errorHandler: ErrorHandler,
     public notifications: NotificationsService,
-    @Inject(WIT_API_URL) witUrl: string
+    @Inject(WIT_API_URL) witUrl: string,
+    @Inject(TIMER_TOKEN) private readonly pollTimer: Observable<void>
   ) {
     if (this.auth.getToken() != null) {
       this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -195,8 +195,8 @@ export class DeploymentsService implements OnDestroy {
   static readonly FRONT_LOAD_SAMPLES: number = 15;
   static readonly FRONT_LOAD_WINDOW_WIDTH: number = DeploymentsService.FRONT_LOAD_SAMPLES * DeploymentsService.POLL_RATE_MS;
 
-  readonly headers: Headers = new Headers({ 'Content-Type': 'application/json' });
-  readonly apiUrl: string;
+  private readonly headers: Headers = new Headers({ 'Content-Type': 'application/json' });
+  private readonly apiUrl: string;
 
   private readonly appsObservables: Map<string, Observable<Application[]>> = new Map<string, Observable<Application[]>>();
   private readonly envsObservables: Map<string, Observable<EnvironmentStat[]>> = new Map<string, Observable<EnvironmentStat[]>>();
@@ -205,12 +205,12 @@ export class DeploymentsService implements OnDestroy {
   private readonly serviceSubscriptions: Subscription[] = [];
 
   constructor(
-    public http: Http,
-    public auth: AuthenticationService,
-    public logger: Logger,
-    public errorHandler: ErrorHandler,
-    public notifications: NotificationsService,
-    @Inject(WIT_API_URL) witUrl: string,
+    private readonly http: Http,
+    private readonly auth: AuthenticationService,
+    private readonly logger: Logger,
+    private readonly errorHandler: ErrorHandler,
+    private readonly notifications: NotificationsService,
+    @Inject(WIT_API_URL) private readonly witUrl: string,
     @Inject(TIMER_TOKEN) private readonly pollTimer: Observable<void>
   ) {
     if (this.auth.getToken() != null) {

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -189,6 +189,9 @@ export class DeploymentsService implements OnDestroy {
   static readonly INITIAL_UPDATE_DELAY: number = 0;
   static readonly POLL_RATE_MS: number = 60000;
 
+  static readonly FRONT_LOAD_SAMPLES: number = 15;
+  static readonly FRONT_LOAD_WINDOW_WIDTH: number = DeploymentsService.FRONT_LOAD_SAMPLES * DeploymentsService.POLL_RATE_MS;
+
   readonly headers: Headers = new Headers({ 'Content-Type': 'application/json' });
   readonly apiUrl: string;
 
@@ -437,11 +440,10 @@ export class DeploymentsService implements OnDestroy {
         }
         const key = `${spaceId}:${applicationId}:${environmentName}`;
         if (!this.timeseriesSubjects.has(key)) {
-          const subject = new ReplaySubject<TimeseriesData>(15);
+          const subject = new ReplaySubject<TimeseriesData>(DeploymentsService.FRONT_LOAD_SAMPLES);
 
-          const frontLoadWindowWidth = 15 * 60 * 1000;
           const now = +Date.now();
-          const frontLoadedUpdates = this.getInitialTimeseriesData(spaceId, applicationId, environmentName, now - frontLoadWindowWidth, now);
+          const frontLoadedUpdates = this.getInitialTimeseriesData(spaceId, applicationId, environmentName, now - DeploymentsService.FRONT_LOAD_WINDOW_WIDTH, now);
 
           const polledUpdates = this.getStreamingTimeseriesData(spaceId, applicationId, environmentName);
 


### PR DESCRIPTION
This patch set relates to https://github.com/openshiftio/openshift.io/issues/2253 . The goal of these patches is to simplify the DeploymentsService interface by removing the distinction between historical and streaming series data - consumers should be able to simply ask for series data, and it's the service's responsibility to decide what that data is. In this case, the service will decide to include 15 minutes' worth of stats immediately on the stream, and then continue publishing data on the same stream according to the service's own polling cycle to update the consumer with live results. This "front loading" of 15 minutes' worth of data is done on-demand per <space, app, env> tuple so that multiple consumers do not trigger multiple front-loading requests, and the last 15 data points are also cached by the service so that late subscribers are unable to distinguish between results that were front loaded vs results that were streamed.

The next step after this to close issue 2253 is to move the data trimming logic out of the components and into the service, which effectively means that the service should simply be re-emitting all 15 of its cached data points on every poll cycle, rather than only the latest new data point. Consumers would then be able to simply replace their own local state with that provided by the service, rather than needing to maintain their own buffer of historical data and trim it to size.