### PR TITLE
refactor(dashboard): Reactivate deployments widget

### DIFF
--- a/src/app/dashboard-widgets/environment-widget/environment-widget.component.html
+++ b/src/app/dashboard-widgets/environment-widget/environment-widget.component.html
@@ -1,31 +1,34 @@
 <div id="spacehome-environments-card" class="environment-widget card-pf f8-card">
-  <div class="card-pf-heading f8-card-heading">
-    <h2 class="card-pf-title">
-      <a id="spacehome-environments-title" [routerLink]="[contextPath | async, 'create', 'deployments']">Deployments</a>
-      <span id="spacehome-environments-badge" class="badge f8-card-badge">{{(apps | async).length}}</span>
-    </h2>
-  </div>
-  <div class="card-pf-body f8-card-body">
-    <div class="f8-blank-slate-card" *ngIf="(apps | async).length === 0">
-      <h3>This space has no applications</h3>
-      <p>
-        Applications are shown once you deploy your code through a pipeline onto the defined environments.
-      </p>
+    <div class="card-pf-heading f8-card-heading">
+      <h2 class="card-pf-title">
+        <a id="spacehome-environments-title" [routerLink]="[contextPath | async, 'create', 'deployments']">Deployments</a>
+        <span id="spacehome-environments-badge" class="badge f8-card-badge">{{(appInfos | async)?.length}}</span>
+      </h2>
     </div>
-    <ul id="spacehome-environments-list" class="list-group" *ngIf="(apps | async).length > 0">
-      <li class="list-group-item" *ngFor="let app of apps | async">
-        <h5>{{app.name}}</h5>
-        <div *ngFor="let envInfo of app.environmentDetails">
-          <span *ngIf="envInfo && envInfo.deployment">
-            <a [href]="envInfo.exposeUrl" title="View the app in this environment" target="app" class="app-version-link" *ngIf="envInfo.exposeUrl">
-              {{envInfo.environmentName}} - {{envInfo.version}}
-            </a>
-            <span *ngIf="!envInfo.exposeUrl">
-              {{envInfo.environmentName}} - {{envInfo.version}}
+    <div class="card-pf-body f8-card-body">
+      <div class="f8-blank-slate-card" *ngIf="!(appInfos | async)">
+        <h3>Loading ...</h3>
+      </div>
+      <div class="f8-blank-slate-card" *ngIf="(appInfos | async)?.length === 0">
+        <h3>This space has no applications</h3>
+        <p>
+          Applications are shown once you deploy your code through a pipeline onto the defined environments.
+        </p>
+      </div>
+      <ul id="spacehome-environments-list" class="list-group" *ngIf="(appInfos | async)?.length > 0">
+        <li class="list-group-item" *ngFor="let app of (appInfos | async)">
+          <h5>{{app.appName}}</h5>
+          <div *ngFor="let envInfo of app.deploymentsInfo">
+            <span *ngIf="envInfo && envInfo.name">
+              <a [href]="envInfo.url" title="View the app in this environment" target="app" class="app-version-link" *ngIf="envInfo.url">
+                {{envInfo.name}} - {{envInfo.version}}
+              </a>
+              <span *ngIf="!envInfo.url">
+                {{envInfo.name}} - {{envInfo.version}}
+              </span>
             </span>
-          </span>
-        </div>
-      </li>
-    </ul>
-  </div>
+          </div>
+        </li>
+      </ul>
+    </div>
 </div>

--- a/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
+++ b/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
@@ -1,232 +1,42 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { BehaviorSubject, ConnectableObservable, Observable, Subject, Subscription } from 'rxjs/Rx';
 
-import { Context, Contexts } from 'ngx-fabric8-wit';
+import { Context, Contexts, Spaces } from 'ngx-fabric8-wit';
+
+import { Environment as ModelEnvironment } from '../../../app/space/create/deployments/models/environment';
 
 import {
-  Environment, Space, SpaceStore
-} from '../../../a-runtime-console/index';
-
-// non-exported classes from runtime that need to be refactored
-import { DeploymentView, DeploymentViews } from '../../../a-runtime-console/index';
-import { AppDeployments, AppEnvironmentDetails, EnvironmentDeployments } from '../../../a-runtime-console/index';
-import { AbstractWatchComponent } from '../../../a-runtime-console/index';
-import { DeploymentService } from '../../../a-runtime-console/index';
-import { ServiceService } from '../../../a-runtime-console/index';
-import { DeploymentConfigService } from '../../../a-runtime-console/index';
-import { RouteService } from '../../../a-runtime-console/index';
+  ApplicationAttributesOverview,
+  DeploymentsService,
+  Space
+} from '../../../app/space/create/deployments/services/deployments.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'fabric8-environment-widget',
   templateUrl: './environment-widget.component.html',
-  styleUrls: ['./environment-widget.component.less']
+  styleUrls: ['./environment-widget.component.less'],
+  providers: [DeploymentsService]
 })
-export class EnvironmentWidgetComponent extends AbstractWatchComponent  implements OnInit, OnDestroy {
+export class EnvironmentWidgetComponent implements OnInit {
 
-  loading: Subject<boolean> = new BehaviorSubject(true);
+  spaceId: Observable<string>;
+  appInfos: Observable<ApplicationAttributesOverview[]>;
   contextPath: Observable<string>;
-  appsCount: number = 0;
-  contextSubscription: Subscription;
-  currentContext: Context;
-  space: ConnectableObservable<Space>;
-
-  protected environmentCache: Map<string, EnvironmentDeployments> = new Map<string, EnvironmentDeployments>();
-  protected subscriberCache: Map<string, Subscription> = new Map<string, Subscription>();
-  protected appsSubject: Subject<AppDeployments[]> = new BehaviorSubject([]);
-  private listCache: Map<string, Observable<any[]>> = new Map<string, Observable<any[]>>();
-  newSubscription: Subscription;
 
   constructor(private context: Contexts,
-              private spaceStore: SpaceStore,
-              private serviceService: ServiceService,
-              private routeService: RouteService,
-              public route: ActivatedRoute,
-              private deploymentConfigService: DeploymentConfigService,
-              private deploymentService: DeploymentService) {
-    super();
+              private spaces: Spaces,
+              private deploymentsService: DeploymentsService) {
+    this.spaceId = this.spaces.current.first().map(space => space.id);
   }
 
   ngOnInit() {
-    this.contextSubscription = this.context.current.subscribe((context) => {
-      this.currentContext = context;
-      let pathRegex = new RegExp(/^\/(.+?)\//);
-      let pathSections = pathRegex.exec(context.path);
-      if (pathSections && pathSections.length > 0) {
-        let id = pathSections[1];
-        this.spaceStore.load(id);
-
-        this.environmentCache.clear();
-        this.subscriberCache.clear();
-        this.listCache.clear();
-      }
+    this.spaceId.subscribe((spaceId: string) => {
+      this.appInfos = this.deploymentsService.getAppsAndEnvironments(spaceId);
     });
 
     this.contextPath = this.context.current.map(context => context.path);
-
-    this.space = this.spaceStore.resource
-      .distinctUntilChanged()
-      .debounce(space => ((space && space.environments) ? Observable.interval(0) : Observable.interval(1000)))
-      .do(space => {
-        if (space === null) {
-          this.appsSubject.next([]);
-          this.appsCount = 0;
-        }
-      })
-      .publish();
-
-    this.newSubscription = this.space.subscribe(space => {
-      if (space && space.environments) {
-        space.environments.forEach(env => {
-          this.subscribeToDeployments(space, env);
-        });
-        this.appsCount = space.environments.length;
-      }
-    });
-
-    this.space.connect();
-  }
-
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-
-    this.contextSubscription.unsubscribe();
-    this.newSubscription.unsubscribe();
-
-    this.subscriberCache.forEach((subscriber) => {
-      if (subscriber) {
-        subscriber.unsubscribe();
-      }
-    });
-
-    this.subscriberCache.clear();
-    this.listCache.clear();
-  }
-
-
-  get apps(): Observable<AppDeployments[]> {
-    return this.appsSubject.asObservable();
-  }
-
-
-  protected subscribeToDeployments(space: Space, environment: Environment) {
-    let key = environment.namespace.name;
-    if (key) {
-      let oldSubscriber = this.subscriberCache.get(key);
-      if (!oldSubscriber) {
-        let subscriber = this.getDeploymentsObservable(environment)
-          .subscribe(deployments =>  this.onDeployments(space, environment, deployments));
-        this.subscriberCache.set(key, subscriber);
-      }
-    }
-  }
-
-  protected onDeployments(space: Space, environment: Environment, deployments: DeploymentViews) {
-    if (!deployments) {
-      return;
-    }
-    let envNameToIndexMap = new Map<string, number>();
-    let count = 1;
-    for (let env of space.environments) {
-      envNameToIndexMap.set(env.key, count++);
-    }
-
-    let size = count - 1;
-    if (environment) {
-      let name = environment.namespace.name;
-      if (name) {
-        this.environmentCache.set(name, new EnvironmentDeployments(environment, deployments));
-        if (this.environmentCache.size >= size) {
-          this.loading.next(false);
-        }
-      }
-    }
-    let map = new Map<string, AppDeployments>();
-
-    // now lets update the app infos
-    this.environmentCache.forEach((envDeployments) => {
-      let deployments = envDeployments.deployments;
-      for (let deployment of deployments) {
-        let deployName = deployment.name;
-        if (deployName) {
-          let appInfo = map.get(deployName);
-          if (!appInfo) {
-            appInfo = new AppDeployments(this.environmentCache.size);
-            map.set(deployName, appInfo);
-          }
-          this.addDeployment(appInfo, envNameToIndexMap, envDeployments.environment, deployment);
-        }
-      }
-    });
-
-    let array: AppDeployments[] = [];
-    map.forEach((app) => {
-      if (app) {
-        array.push(app);
-      }
-    });
-
-    this.appsSubject.next(array);
-
-    for (let appInfo of array) {
-      for (let env of appInfo.environmentDetails) {
-        if (!env) {
-          env = new AppEnvironmentDetails();
-        }
-      }
-    }
-  }
-
-  /**
-   * Lets cache the observables so that we don't requery the services each time we ask for the observables
-   */
-  private getDeploymentsObservable(environment: Environment): Observable<DeploymentViews> {
-    let namespace = environment.namespace.name;
-    let key = namespace;
-    var answer = this.listCache.get(key);
-    if (!answer) {
-      answer = this.listAndWatchDeployments(namespace, this.deploymentService, this.deploymentConfigService, this.serviceService, this.routeService).
-      map(deploymentViews => this.filterDeploymentViews(deploymentViews));
-      this.listCache.set(key, answer);
-    }
-    return answer;
-  }
-
-  private addDeployment(appInfo: AppDeployments, envNameToIndexMap: Map<string, number>, environment: Environment, deployment: DeploymentView) {
-    if (!appInfo.name) {
-      appInfo.name = deployment.name;
-    }
-    if (!appInfo.icon) {
-      appInfo.icon = deployment.icon;
-    }
-    let key = environment.key;
-    if (key) {
-      let idx = envNameToIndexMap.get(key);
-      if (idx) {
-        idx--;
-        let envInfo = appInfo.environmentDetails[idx];
-        if (!envInfo) {
-          envInfo = new AppEnvironmentDetails();
-          appInfo.environmentDetails[idx] = envInfo;
-        }
-        envInfo.addDeployment(appInfo, environment, deployment);
-      }
-    }
-  }
-
-  private filterDeploymentViews(deploymentViews: DeploymentViews): DeploymentViews {
-    if (!this.currentContext.space || !this.currentContext.space.attributes.name) {
-      return deploymentViews;
-    }
-    let answer = new DeploymentViews();
-    deploymentViews.forEach(dep => {
-      let depSpace = dep.labels['space'];
-      if (!depSpace || depSpace === this.currentContext.space.attributes.name) {
-        answer.push(dep);
-      }
-    });
-    return answer;
   }
 }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -86,6 +86,17 @@ export interface ApplicationAttributes {
   deployments: Deployment[];
 }
 
+export interface ApplicationAttributesOverview {
+  appName: string;
+  deploymentsInfo: DeploymentPreviewInfo[];
+}
+
+export interface DeploymentPreviewInfo {
+  name: string;
+  version: string;
+  url: string;
+}
+
 export interface Deployment {
   attributes: DeploymentAttributes;
   links: Links;
@@ -234,6 +245,23 @@ export class DeploymentsService implements OnDestroy {
       )
       .distinctUntilChanged((p: ModelEnvironment[], q: ModelEnvironment[]) =>
         deepEqual(new Set<string>(p.map(v => v.name)), new Set<string>(q.map(v => v.name))));
+  }
+
+  getAppsAndEnvironments(spaceId: string): Observable<ApplicationAttributesOverview[]> {
+    return this.getApplicationsResponse(spaceId)
+      .map((apps: Application[]) => apps || [])
+      .map((apps: Application[]) => apps.map((app: Application) => {
+        const appName = app.attributes.name;
+        const deploymentNamesAndVersions = app.attributes.deployments.map(
+          (dep: Deployment) => ({ name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
+          })
+        );
+
+        return {
+          appName: appName,
+          deploymentsInfo: deploymentNamesAndVersions as DeploymentPreviewInfo[]
+        } as ApplicationAttributesOverview;
+      }));
   }
 
   isApplicationDeployedInEnvironment(spaceId: string, applicationId: string, environmentName: string):


### PR DESCRIPTION
This patch refactors the component code for the deployments widget on the space dashboard, so that it reflects the actual state of applications that are deployed. It is quite minimal, in that it simply reflects things as they were when we were still using the runtime console.

Solves: https://github.com/openshiftio/openshift.io/issues/2301

Screenshot: 
![2018-02-23-164932_634x596_scrot](https://user-images.githubusercontent.com/17230733/36618539-8c491bf8-18b9-11e8-8333-295549494ea6.png)


