### PR TITLE
fix(deployments): fix deployment card dropdown tests

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -155,7 +155,7 @@ describe('DeploymentCardComponent async tests', () => {
 
       beforeEach(fakeAsync(() => {
         const de: DebugElement = fixture.debugElement.query(By.directive(BsDropdownToggleDirective));
-        de.triggerEventHandler('click', null);
+        de.triggerEventHandler('click', new CustomEvent('click'));
 
         fixture.detectChanges();
 
@@ -178,7 +178,7 @@ describe('DeploymentCardComponent async tests', () => {
         const item: DebugElement = getItemByLabel('Delete');
         expect(item).toBeTruthy();
         expect(mockSvc.deleteApplication).not.toHaveBeenCalled();
-        item.query(By.css('a')).triggerEventHandler('click', null);
+        item.query(By.css('a')).triggerEventHandler('click', new CustomEvent('click'));
 
         fixture.detectChanges();
 


### PR DESCRIPTION
This fixes the dropdown tests to provide actual Event objects. The event from the handler is now being used by the component and would result in TypeErrors when running the tests. The TypeErrors are no longer seen with this fix. Interestingly, this did not affect the tests ability to run and pass/fail.

This resolves https://github.com/openshiftio/openshift.io/issues/2386