### PR TITLE
fix(space-wizard): make request to create space once

### DIFF
--- a/src/app/space/wizard/space-wizard.component.ts
+++ b/src/app/space/wizard/space-wizard.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { Notification, Notifications, NotificationType } from 'ngx-base';
+import { Logger, Notification, Notifications, NotificationType } from 'ngx-base';
 import { Context, SpaceNamePipe, SpaceService } from 'ngx-fabric8-wit';
 import { ProcessTemplate } from 'ngx-fabric8-wit';
 import { Space, SpaceAttributes } from 'ngx-fabric8-wit';
@@ -37,7 +37,8 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
     private spaceNamespaceService: SpaceNamespaceService,
     private spaceNamePipe: SpaceNamePipe,
     private spacesService: SpacesService,
-    private context: ContextService
+    private context: ContextService,
+    private logger: Logger
   ) {
     this.spaceTemplates = dummy.processTemplates;
     this.space = this.createTransientSpace();
@@ -54,7 +55,7 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
    */
   createSpace() {
     if (!this.userService.currentLoggedInUser && !this.userService.currentLoggedInUser.id) {
-      console.log('Error creating space, invalid user.', this.userService.currentLoggedInUser);
+      this.logger.error('Error creating space, invalid user.' + this.userService.currentLoggedInUser);
       this.notifications.message(<Notification> {
         message: `Failed to create "${this.space.name}". Invalid user: "${this.userService.currentLoggedInUser}"`,
         type: NotificationType.DANGER
@@ -86,7 +87,7 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
         this.finish();
       },
       err => {
-        console.log('Error creating space', err);
+        this.logger.error(err);
         this.notifications.message(<Notification> {
           message: `Failed to create "${this.space.name}"`,
           type: NotificationType.DANGER

--- a/src/app/space/wizard/space-wizard.component.ts
+++ b/src/app/space/wizard/space-wizard.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  ErrorHandler,
+  EventEmitter,
+  OnDestroy,
+  OnInit,
+  Output
+} from '@angular/core';
 import { Router } from '@angular/router';
 
 import { Logger, Notification, Notifications, NotificationType } from 'ngx-base';
@@ -38,7 +45,8 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
     private spaceNamePipe: SpaceNamePipe,
     private spacesService: SpacesService,
     private context: ContextService,
-    private logger: Logger
+    private logger: Logger,
+    private errorHandler: ErrorHandler
   ) {
     this.spaceTemplates = dummy.processTemplates;
     this.space = this.createTransientSpace();
@@ -55,7 +63,9 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
    */
   createSpace() {
     if (!this.userService.currentLoggedInUser && !this.userService.currentLoggedInUser.id) {
-      this.logger.error('Error creating space, invalid user.' + this.userService.currentLoggedInUser);
+      const err: Error = Error('Error creating space, invalid user.' + this.userService.currentLoggedInUser);
+      this.errorHandler.handleError(err);
+      this.logger.error(err);
       this.notifications.message(<Notification> {
         message: `Failed to create "${this.space.name}". Invalid user: "${this.userService.currentLoggedInUser}"`,
         type: NotificationType.DANGER
@@ -87,6 +97,7 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
         this.finish();
       },
       err => {
+        this.errorHandler.handleError(err);
         this.logger.error(err);
         this.notifications.message(<Notification> {
           message: `Failed to create "${this.space.name}"`,

--- a/src/app/space/wizard/space-wizard.component.ts
+++ b/src/app/space/wizard/space-wizard.component.ts
@@ -70,7 +70,6 @@ export class SpaceWizardComponent implements OnInit, OnDestroy {
 
     this.space.relationships['owned-by'].data.id = this.userService.currentLoggedInUser.id;
     this.spaceService.create(this.space)
-    .first()
     .do(createdSpace => {
       this.spacesService.addRecent.next(createdSpace);
     })


### PR DESCRIPTION
This fixes the observable used to create a space in the space-wizard. It now is used once and cleaned up via `first()`. As well, the code is updated to use the latest API from `SpaceServices` as the previous API was deprecated.

This also addresses [1], where logging out would trigger another attempt to create the space because of the long-living observable receiving an event emission when logging out (user changes).

[1] https://github.com/openshiftio/openshift.io/issues/2206