### PR TITLE
Correct "Recent Active Pipelines" links

### DIFF
--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
@@ -17,7 +17,7 @@
         <div class="f8-card__pipeline-column">
           <span class="{{buildconfig.iconStyle}} fa-spin" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle === 'pficon-running'"></span>
           <span class="{{buildconfig.iconStyle}}" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle !== 'pficon-running'"></span>
-          <a id="spacehome-pipelines-title" [routerLink]="['/', buildconfig.namespace, buildconfig.labels['space'], 'create', 'pipelines']" class="f8-card__pipeline-column-name">
+          <a id="spacehome-pipelines-title" [routerLink]="[contextPath | async, buildconfig.labels['space'], 'create', 'pipelines']" class="f8-card__pipeline-column-name">
             {{buildconfig.name}}
           </a>
           <span>|</span>

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { Contexts } from 'ngx-fabric8-wit';
 import { Observable } from 'rxjs/Rx';
@@ -12,7 +12,7 @@ import { PipelinesService } from '../../shared/runtime-console/pipelines.service
   templateUrl: './recent-pipelines-widget.component.html',
   styleUrls: ['./recent-pipelines-widget.component.less']
 })
-export class RecentPipelinesWidgetComponent implements OnInit, OnDestroy {
+export class RecentPipelinesWidgetComponent implements OnInit {
 
   buildConfigs: Observable<BuildConfigs>;
   buildConfigsCount: Observable<number>;
@@ -29,14 +29,8 @@ export class RecentPipelinesWidgetComponent implements OnInit, OnDestroy {
     this.bcs = this.pipelinesService.recentPipelines
       .publish();
     this.buildConfigs = this.bcs;
-    this.buildConfigsCount = this.bcs.do((object) => {
-      return object;
-    }).map(buildConfigs => buildConfigs.length);
+    this.buildConfigsCount = this.bcs.map(buildConfigs => buildConfigs.length);
     this.bcs.connect();
-  }
-
-  ngOnDestroy() {
-
   }
 
 }

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
@@ -25,7 +25,7 @@ export class RecentPipelinesWidgetComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    this.contextPath = this.context.current.map(context => context.path);
+    this.contextPath = this.context.default.map(context => context.path);
     this.bcs = this.pipelinesService.recentPipelines
       .publish();
     this.buildConfigs = this.bcs;

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { Contexts } from 'ngx-fabric8-wit';
-import { Observable } from 'rxjs/Rx';
+import { ConnectableObservable, Observable } from 'rxjs/Rx';
 
 import { BuildConfigs } from '../../../a-runtime-console/index';
 import { PipelinesService } from '../../shared/runtime-console/pipelines.service';
@@ -14,10 +14,9 @@ import { PipelinesService } from '../../shared/runtime-console/pipelines.service
 })
 export class RecentPipelinesWidgetComponent implements OnInit {
 
-  buildConfigs: Observable<BuildConfigs>;
-  buildConfigsCount: Observable<number>;
   contextPath: Observable<string>;
-  bcs: any;
+  buildConfigs: ConnectableObservable<BuildConfigs>;
+  buildConfigsCount: Observable<number>;
 
   constructor(
     private context: Contexts,
@@ -26,11 +25,10 @@ export class RecentPipelinesWidgetComponent implements OnInit {
 
   ngOnInit() {
     this.contextPath = this.context.default.map(context => context.path);
-    this.bcs = this.pipelinesService.recentPipelines
+    this.buildConfigs = this.pipelinesService.recentPipelines
       .publish();
-    this.buildConfigs = this.bcs;
-    this.buildConfigsCount = this.bcs.map(buildConfigs => buildConfigs.length);
-    this.bcs.connect();
+    this.buildConfigsCount = this.buildConfigs.map(buildConfigs => buildConfigs.length);
+    this.buildConfigs.connect();
   }
 
 }


### PR DESCRIPTION
https://github.com/openshiftio/openshift.io/issues/1048

The "Recent Active Pipelines" links are currently constructed from the buildconfig namespace, space label, and path to pipelines page ("/create/pipelines"). This does not work for users whose buildconfig namespace is different from their OSIO username - namely, users who log in with an email address. For example, in my case, my OSIO username is "aazores@redhat.com" and my namespace is "aazores". A correct Pipelines page URL for me is "openshift.io/aazores@redhat.com/test-space/create/pipelines", not "openshift.io/aazores/test-space/create/pipelines". The first commit corrects the router link to use the OSIO username rather than buildconfig namespace. The second commit performs some code cleanup that makes no behaviour change.