### PR TITLE
fix(pipelines): correct application pipelines link URL

### DIFF
--- a/src/app/dashboard-widgets/pipelines-widget/pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/pipelines-widget/pipelines-widget.component.html
@@ -25,7 +25,7 @@
         <div class="f8-card__pipeline-column">
           <span class="{{buildconfig.iconStyle}} fa-spin" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle === 'pficon-running'"></span>
           <span class="{{buildconfig.iconStyle}}" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle !== 'pficon-running'"></span>
-          <a [routerLink]="['/', buildconfig.namespace, buildconfig.labels['space'], 'create', 'pipelines']" class="f8-card__pipeline-column-name">
+          <a [routerLink]="[contextPath | async, 'create', 'pipelines']" class="f8-card__pipeline-column-name">
             {{buildconfig.name}}
           </a>
           <span>|</span>

--- a/src/app/dashboard-widgets/pipelines-widget/pipelines-widget.component.ts
+++ b/src/app/dashboard-widgets/pipelines-widget/pipelines-widget.component.ts
@@ -6,7 +6,10 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { Observable } from 'rxjs/Rx';
+import {
+  ConnectableObservable,
+  Observable
+} from 'rxjs/Rx';
 
 import { Broadcaster } from 'ngx-base';
 import { Contexts } from 'ngx-fabric8-wit';
@@ -25,9 +28,9 @@ export class PipelinesWidgetComponent implements OnInit {
 
   @Output() addToSpace = new EventEmitter();
 
-  buildConfigs: Observable<BuildConfigs>;
-  buildConfigsCount: Observable<number>;
   contextPath: Observable<string>;
+  buildConfigs: ConnectableObservable<BuildConfigs>;
+  buildConfigsCount: Observable<number>;
 
   constructor(
     private context: Contexts,
@@ -37,11 +40,10 @@ export class PipelinesWidgetComponent implements OnInit {
 
   ngOnInit() {
     this.contextPath = this.context.current.map(context => context.path);
-    let bcs = this.pipelinesService.current
+    this.buildConfigs = this.pipelinesService.current
       .publish();
-    this.buildConfigs = bcs;
-    this.buildConfigsCount = bcs.map(buildConfigs => buildConfigs.length);
-    bcs.connect();
+    this.buildConfigsCount = this.buildConfigs.map(buildConfigs => buildConfigs.length);
+    this.buildConfigs.connect();
   }
 
 }


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/2334

See also https://github.com/fabric8-ui/fabric8-ui/pull/2589 , which is very similar. In this component the `contextPath` already contains the current space, whereas on the homepage for the component in #2589, the buildconfig space label must also be used to construct the path (since there is no active space on the homepage).