### PR TITLE
test(about-modal): re-enable tests for about-modal

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -34,6 +34,15 @@ module.exports = function (config) {
     ],
 
     /*
+     * Proxies allow karma to serve specific paths in proxy of another (e.g., a relative path)
+     * Currently used to prevent PhantomJS from crashing when looking for image files
+     * http://karma-runner.github.io/2.0/config/configuration-file.html
+     */
+    proxies: {
+      '/assets/': '/base/src/assets/'
+    },
+
+    /*
      * preprocess matching files before serving them to the browser
      * available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
      */

--- a/src/app/layout/about-modal/about-modal.component.html
+++ b/src/app/layout/about-modal/about-modal.component.html
@@ -8,17 +8,17 @@
         </button>
       </div>
       <div class="modal-body">
-         <div class="product-versions-pf">
-          <img _ngcontent-c8=""
-            class="logo margin-bottom-15 padding-bottom-10"
-            src="../../../assets/images/OpenShift-io_logo.png" />
-          <ul class="list-unstyled margin-top-15">
-            <li><strong>Build</strong> <span *ngIf="about.buildNumber">#{{about.buildNumber}}</span></li>
-            <li><strong>Time stamp</strong><span *ngIf="about.buildNumber"> {{about.buildTimestamp}}</span></li>
-          </ul>
-        </div>
+          <div class="product-versions-pf">
+            <img _ngcontent-c8=""
+              class="logo margin-bottom-15 padding-bottom-10"
+              src="../../../assets/images/OpenShift-io_logo.png" />
+            <ul class="list-unstyled margin-top-15">
+              <li><strong>Build</strong> <span *ngIf="about.buildNumber">#{{about.buildNumber}}</span></li>
+              <li><strong>Time stamp</strong><span *ngIf="about.buildNumber"> {{about.buildTimestamp}}</span></li>
+            </ul>
+          </div>
         <div class="trademark-pf">
-          Copyright &copy;2017 Red Hat,Inc.
+          Copyright &copy;2018 Red Hat,Inc.
         </div>
         <div class="modal-footer">
           <img src="../../../assets/images/Logo_RH_RGB_Reverse.png" alt="Red Hat">

--- a/src/app/layout/about-modal/about-modal.component.spec.ts
+++ b/src/app/layout/about-modal/about-modal.component.spec.ts
@@ -1,87 +1,82 @@
-// import { ComponentFixture, TestBed } from '@angular/core/testing';
-// import { By }              from '@angular/platform-browser';
-// import { DebugElement }    from '@angular/core';
-//
-// import  * as ng2Bootstrap from 'ng2-bootstrap/ng2-bootstrap';
-// import  { ModalModule } from 'ng2-bootstrap/ng2-bootstrap';
-//
-// import {
-//   Component,
-//   Renderer2,
-//   ViewChild,
-//   OnInit,
-//   Output,
-//   AfterViewInit,
-//   ElementRef,
-//   EventEmitter,
-//   Input,
-//   ViewEncapsulation } from '@angular/core';
-//
-// import { AboutModalComponent } from './about-modal.component';
-// import { AboutService } from '../../shared/about.service';
-//
-// class aboutServiceMock {
-//
-//   get buildNumber(): string {
-//     return '111.000.222';
-//   }
-//
-//   get buildTimestamp(): string {
-//     return 'some time';
-//   }
-//
-//   get buildVersion(): string {
-//     return '1.0.2-dev';
-//   }
-// }
-//
-// describe('AboutModalComponent', () => {
-//
-//     let comp:    AboutModalComponent;
-//     let fixture: ComponentFixture<AboutModalComponent>;
-//     let de:      DebugElement;
-//     let el:      HTMLElement;
-//     let des:     DebugElement[];
-//
-//     beforeEach(() => {
-//
-//       let aboutServiceStub = new aboutServiceMock();
-//
-//       TestBed.configureTestingModule({
-//         declarations: [ AboutModalComponent ], // declare the test component
-//         imports: [
-//           ng2Bootstrap.Ng2BootstrapModule,
-//           ModalModule.forRoot()
-//         ],
-//         providers:  [ {provide: AboutService, useValue: aboutServiceStub } ]
-//
-//       });
-//
-//       fixture = TestBed.createComponent(AboutModalComponent);
-//
-//       comp = fixture.componentInstance; // BannerComponent test instance
-//
-//     });
-//
-//     it('should display copyright info', () => {
-//       fixture.detectChanges();
-//
-//       de = fixture.debugElement.query(By.css('.trademark-pf'));
-//       el = de.nativeElement;
-//       expect(el.textContent).toContain('Copyright');
-//       expect(el.textContent).toContain('2017 Red Hat,Inc.');
-//     });
-//
-//     it('should display build info from about service', () => {
-//       fixture.detectChanges();
-//
-//       des = fixture.debugElement.queryAll(By.css('.product-versions-pf ul li span'));
-//       // console.error('des is: ', des);
-//       el = des[0].nativeElement;
-//       expect(el.textContent).toContain('111.000.222');
-//
-//       el = des[1].nativeElement;
-//       expect(el.textContent).toContain('some time');
-//     });
-//
-//   });
+import { DebugElement, DebugNode, Renderer2 } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+import { ModalModule } from 'ngx-bootstrap/modal';
+
+import { AboutService } from '../../shared/about.service';
+import { AboutModalComponent } from './about-modal.component';
+
+
+class aboutServiceMock {
+
+  get buildNumber(): string {
+    return '111.000.222';
+  }
+
+  get buildTimestamp(): string {
+    return 'some time';
+  }
+
+  get buildVersion(): string {
+    return '1.0.2-dev';
+  }
+}
+
+describe('AboutModalComponent', () => {
+
+  let fixture: ComponentFixture<AboutModalComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+  let des: DebugElement[];
+  let component: DebugNode['componentInstance'];
+  let mockRenderer: any = jasmine.createSpy('Renderer2');
+
+  beforeEach(() => {
+    let aboutServiceStub = new aboutServiceMock();
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        ModalModule.forRoot()
+      ],
+      declarations: [AboutModalComponent],
+      providers: [
+        { provide: AboutService, useValue: aboutServiceStub },
+        { provide: Renderer2, useValue: mockRenderer }
+      ]
+    });
+    fixture = TestBed.createComponent(AboutModalComponent);
+    component = fixture.debugElement.componentInstance;
+  });
+
+  describe('#modal', () => {
+    it('should display copyright info', () => {
+      fixture.detectChanges();
+      de = fixture.debugElement.query(By.css('.trademark-pf'));
+      el = de.nativeElement;
+      expect(el.textContent).toContain('Copyright');
+      expect(el.textContent).toContain('2018 Red Hat,Inc.');
+    });
+
+    it('should display build info from about service', () => {
+      fixture.detectChanges();
+      des = fixture.debugElement.queryAll(By.css('.product-versions-pf ul li span'));
+
+      el = des[0].nativeElement;
+      expect(el.textContent).toContain('111.000.222');
+
+      el = des[1].nativeElement;
+      expect(el.textContent).toContain('some time');
+    });
+  });
+
+  describe('#open', () => {
+    it('should show the model when called', () => {
+      spyOn(component.staticModal, 'show');
+      component.open();
+      expect(component.staticModal.show).toHaveBeenCalled();
+    });
+  });
+
+});


### PR DESCRIPTION
This PR addresses [issue #923](https://github.com/openshiftio/openshift.io/issues/923)[0], and more specifically, addresses the sub-task of unit tests for the about-modal.

The unit tests for the about-modal were disabled [1] during an update to the project dependency update [2]. This PR tweaks the .spec file so the unit tests run again, updates the date in the about-modal to be 2018, and proxies the assets folder in the karma.conf so that PhantomJS doesn't crash when it is looking for the image files during the running of the unit tests.

[0] https://github.com/openshiftio/openshift.io/issues/923
[1] https://github.com/fabric8-ui/fabric8-ui/commit/9a069f83b8146b195bed81841f953cde6527ed09
[2] https://github.com/fabric8-ui/fabric8-ui/pull/2105