### PR TITLE
fix(pipelines): fix pipeline filtering and sorting

### DIFF
--- a/src/app/space/create/pipelines/pipelines.component.spec.ts
+++ b/src/app/space/create/pipelines/pipelines.component.spec.ts
@@ -1,0 +1,420 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  Input
+} from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {
+  BehaviorSubject,
+  Observable
+} from 'rxjs';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import {
+  BsDropdownConfig,
+  BsDropdownModule
+} from 'ngx-bootstrap/dropdown';
+import { ModalModule } from 'ngx-bootstrap/modal';
+import {
+  TooltipConfig,
+  TooltipModule
+} from 'ngx-bootstrap/tooltip';
+import { AuthenticationService } from 'ngx-login-client';
+import { ToolbarModule } from 'patternfly-ng';
+
+import { BuildConfig } from 'a-runtime-console/index';
+import { Broadcaster } from 'ngx-base';
+import {
+  Context,
+  Contexts
+} from 'ngx-fabric8-wit';
+import { Fabric8UIConfig } from '../../../shared/config/fabric8-ui-config';
+import { PipelinesService } from '../../../shared/runtime-console/pipelines.service';
+import { ForgeWizardModule } from '../../forge-wizard/forge-wizard.module';
+import { PipelinesComponent } from './pipelines.component';
+
+@Component({
+  selector: 'fabric8-pipelines-list',
+  template: ''
+})
+class FakePipelinesListComponent {
+  @Input() loading: boolean;
+  @Input() pipelines: BuildConfig[];
+}
+
+@Component({
+  template: '<alm-pipelines></alm-pipelines>'
+})
+class HostComponent { }
+
+describe('PipelinesComponent', () => {
+  type TestingContext = TestContext<PipelinesComponent, HostComponent>;
+
+  let component: PipelinesComponent;
+  let fixture: ComponentFixture<PipelinesComponent>;
+
+  let contexts: Contexts;
+  let authenticationService: jasmine.SpyObj<AuthenticationService>;
+  let pipelinesService: { current: Observable<BuildConfig[]> };
+  let f8uiConfig: { openshiftConsoleUrl: string };
+  let broadcaster: { broadcast: Function };
+
+  beforeEach(() => {
+    contexts = {
+      current: new BehaviorSubject<Context>({
+        name: 'space',
+        path: '/user/space',
+        space: {
+          attributes: {
+            name: 'space'
+          }
+        }
+      } as Context),
+      recent: Observable.never(),
+      default: Observable.never()
+    };
+
+    authenticationService = createMock(AuthenticationService);
+    authenticationService.getGitHubToken.and.returnValue('some-token');
+
+    pipelinesService = {
+      current: new BehaviorSubject<any[]>([
+        {
+          id: 'app',
+          gitUrl: 'https://example.com/app.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app2',
+          gitUrl: 'https://example.com/app2.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app3',
+          gitUrl: 'https://example.com/app3.git',
+          labels: {
+            space: 'space2'
+          }
+        }
+      ])
+    };
+
+    f8uiConfig = { openshiftConsoleUrl: 'http://example.com/openshift' };
+
+    broadcaster = { broadcast: jasmine.createSpy('broadcast') };
+  });
+
+  initContext(PipelinesComponent, HostComponent, {
+    imports: [
+      BsDropdownModule.forRoot(),
+      CommonModule,
+      ToolbarModule,
+      ForgeWizardModule,
+      ModalModule.forRoot(),
+      TooltipModule.forRoot()
+    ],
+    declarations: [
+      FakePipelinesListComponent
+    ],
+    providers: [
+      BsDropdownConfig,
+      TooltipConfig,
+      { provide: Contexts, useFactory: () => contexts },
+      { provide: AuthenticationService, useFactory: () => authenticationService },
+      { provide: PipelinesService, useFactory: () => pipelinesService },
+      { provide: Fabric8UIConfig, useFactory: () => f8uiConfig },
+      { provide: Broadcaster, useFactory: () => broadcaster }
+    ]
+  });
+
+  it('should set OpenShift Console URL', function(this: TestingContext) {
+    expect(this.testedDirective.openshiftConsoleUrl).toEqual('http://example.com/openshift');
+  });
+
+  it('should only display pipelines within the current space', function(this: TestingContext) {
+    expect(this.testedDirective.pipelines as any[]).toContain({
+      id: 'app',
+      gitUrl: 'https://example.com/app.git',
+      labels: {
+        space: 'space'
+      }
+    });
+    expect(this.testedDirective.pipelines as any[]).toContain({
+      id: 'app2',
+      gitUrl: 'https://example.com/app2.git',
+      labels: {
+        space: 'space'
+      }
+    });
+    expect(this.testedDirective.pipelines as any[]).not.toContain({
+      id: 'app3',
+      gitUrl: 'https://example.com/app3.git',
+      labels: {
+        space: 'space2'
+      }
+    });
+  });
+
+  describe('filtering', () => {
+    it('should filter by application', function(this: TestingContext) {
+      this.testedDirective.filterChange(
+        {
+          appliedFilters: [
+            {
+              field: {
+                id: 'application',
+                title: 'Application',
+                placeholder: 'Filter by Application...',
+                type: 'select',
+                queries: [
+                  {
+                    id: 'app',
+                    value: 'app'
+                  },
+                  {
+                    id: 'app2',
+                    value: 'app2'
+                  }
+                ]
+              },
+              query: {
+                id: 'app2',
+                value: 'app2'
+              },
+              value: 'app2'
+            }
+          ]
+        }
+      );
+      expect(this.testedDirective.pipelines as any[]).toEqual([{
+        id: 'app2',
+        gitUrl: 'https://example.com/app2.git',
+        labels: {
+          space: 'space'
+        }
+      }]);
+      expect(this.testedDirective.toolbarConfig.filterConfig.resultsCount).toEqual(1);
+    });
+
+    it('should filter by codebase', function(this: TestingContext) {
+      this.testedDirective.filterChange(
+        {
+          appliedFilters: [
+            {
+              field: {
+                id: 'codebase',
+                title: 'Codebase',
+                placeholder: 'Filter by Codebase...',
+                type: 'select',
+                queries: [
+                  {
+                    id: 'https://example.com/app.git',
+                    value: 'https://example.com/app.git'
+                  },
+                  {
+                    id: 'https://example.com/app2.git',
+                    value: 'https://example.com/app2.git'
+                  }
+                ]
+              },
+              query: {
+                id: 'https://example.com/app2.git',
+                value: 'https://example.com/app2.git'
+              },
+              value: 'https://example.com/app2.git'
+            }
+          ]
+        }
+      );
+      expect(this.testedDirective.pipelines as any[]).toEqual([{
+        id: 'app2',
+        gitUrl: 'https://example.com/app2.git',
+        labels: {
+          space: 'space'
+        }
+      }]);
+      expect(this.testedDirective.toolbarConfig.filterConfig.resultsCount).toEqual(1);
+    });
+
+    it('should display all pipelines in space when filters cleared', function(this: TestingContext) {
+      this.testedDirective.filterChange(
+        {
+          appliedFilters: [
+            {
+              field: {
+                id: 'codebase',
+                title: 'Codebase',
+                placeholder: 'Filter by Codebase...',
+                type: 'select',
+                queries: [
+                  {
+                    id: 'https://example.com/app.git',
+                    value: 'https://example.com/app.git'
+                  },
+                  {
+                    id: 'https://example.com/app2.git',
+                    value: 'https://example.com/app2.git'
+                  }
+                ]
+              },
+              query: {
+                id: 'https://example.com/app2.git',
+                value: 'https://example.com/app2.git'
+              },
+              value: 'https://example.com/app2.git'
+            }
+          ]
+        }
+      );
+      expect(this.testedDirective.pipelines as any[]).toEqual([{
+        id: 'app2',
+        gitUrl: 'https://example.com/app2.git',
+        labels: {
+          space: 'space'
+        }
+      }]);
+      this.testedDirective.filterChange({ appliedFilters: [] });
+      expect(this.testedDirective.pipelines as any[]).toEqual([
+        {
+          id: 'app',
+          gitUrl: 'https://example.com/app.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app2',
+          gitUrl: 'https://example.com/app2.git',
+          labels: {
+            space: 'space'
+          }
+        }
+      ]);
+      expect(this.testedDirective.toolbarConfig.filterConfig.resultsCount).toEqual(2);
+    });
+  });
+
+  describe('sorting', () => {
+    it('should sort by application descending', function(this: TestingContext) {
+      this.testedDirective.sortChange({
+        field: {
+          id: 'application',
+          title: 'Application',
+          sortType: 'alpha'
+        },
+        isAscending: false
+      });
+      expect(this.testedDirective.pipelines as any[]).toEqual([
+        {
+          id: 'app2',
+          gitUrl: 'https://example.com/app2.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app',
+          gitUrl: 'https://example.com/app.git',
+          labels: {
+            space: 'space'
+          }
+        }
+      ]);
+    });
+
+    it('should sort by application ascending', function(this: TestingContext) {
+      this.testedDirective.sortChange({
+        field: {
+          id: 'application',
+          title: 'Application',
+          sortType: 'alpha'
+        },
+        isAscending: true
+      });
+      expect(this.testedDirective.pipelines as any[]).toEqual([
+        {
+          id: 'app',
+          gitUrl: 'https://example.com/app.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app2',
+          gitUrl: 'https://example.com/app2.git',
+          labels: {
+            space: 'space'
+          }
+        }
+      ]);
+    });
+
+    it('should sort by codebase descending', function(this: TestingContext) {
+      this.testedDirective.sortChange({
+        field: {
+          id: 'codebase',
+          title: 'Codebase',
+          sortType: 'alpha'
+        },
+        isAscending: false
+      });
+      expect(this.testedDirective.pipelines as any[]).toEqual([
+        {
+          id: 'app2',
+          gitUrl: 'https://example.com/app2.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app',
+          gitUrl: 'https://example.com/app.git',
+          labels: {
+            space: 'space'
+          }
+        }
+      ]);
+    });
+
+    it('should sort by codebase ascending', function(this: TestingContext) {
+      this.testedDirective.sortChange({
+        field: {
+          id: 'codebase',
+          title: 'Codebase',
+          sortType: 'alpha'
+        },
+        isAscending: true
+      });
+      expect(this.testedDirective.pipelines as any[]).toEqual([
+        {
+          id: 'app',
+          gitUrl: 'https://example.com/app.git',
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app2',
+          gitUrl: 'https://example.com/app2.git',
+          labels: {
+            space: 'space'
+          }
+        }
+      ]);
+    });
+  });
+
+});

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -237,22 +237,20 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   }
 
   private applySort(): void {
-    this._filteredPipelines.sort(this.compare.bind(this));
-  }
+    this._filteredPipelines.sort((a: BuildConfig, b: BuildConfig): number => {
+      let res = 0;
 
-  private compare(a: BuildConfig, b: BuildConfig): number {
-    let res = 0;
+      if (this._currentSortField.id === 'application' && a.id && b.id) {
+        res = a.id.localeCompare(b.id);
+      } else if (this._currentSortField.id === 'codebase' && a.gitUrl && b.gitUrl) {
+        res = a.gitUrl.localeCompare(b.gitUrl);
+      }
 
-    if (this._currentSortField.id === 'application' && a.id && b.id) {
-      res = a.id.localeCompare(b.id);
-    } else if (this._currentSortField.id === 'codebase' && a.gitUrl && b.gitUrl) {
-      res = a.gitUrl.localeCompare(b.gitUrl);
-    }
-
-    if (!this._ascending) {
-      res = res * -1;
-    }
-    return res;
+      if (!this._ascending) {
+        res = res * -1;
+      }
+      return res;
+    });
   }
 
 }

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -118,10 +118,10 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   compare(a: BuildConfig, b: BuildConfig) {
     let res = 0;
 
-    if (this._currentSortField.id === 'application' && a.labels['app'] && b.labels['app']) {
-      res = a.labels['app'].localeCompare(b.labels['app']);
-    } else if (this._currentSortField.id === 'codebase' && a.labels['codebase'] && b.labels['codebase']) {
-      res = a.labels['codebase'].localeCompare(b.labels['codebase']);
+    if (this._currentSortField.id === 'application' && a.id && b.id) {
+      res = a.id.localeCompare(b.id);
+    } else if (this._currentSortField.id === 'codebase' && a.gitUrl && b.gitUrl) {
+      res = a.gitUrl.localeCompare(b.gitUrl);
     }
 
     if (!this._ascending) {
@@ -134,7 +134,7 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   applyFilters() {
     if (this._allPipelines) {
       let filteredPipelines = [];
-      this._allPipelines.forEach(bc => {
+      this._allPipelines.forEach((bc: BuildConfig) => {
         let matches = true;
         let spaceId = '';
         if (this._context) {
@@ -152,11 +152,11 @@ export class PipelinesComponent implements OnInit, OnDestroy {
         }
         this._appliedFilters.forEach(filter => {
           if (filter.field.id === 'application') {
-            if (filter.value !== bc.labels['app']) {
+            if (filter.value !== bc.id) {
               matches = false;
             }
           } else if (filter.field.id === 'codebase') {
-            if (filter.value !== bc.labels['codebase']) {
+            if (filter.value !== bc.gitUrl) {
               matches = false;
             }
           }
@@ -166,25 +166,24 @@ export class PipelinesComponent implements OnInit, OnDestroy {
         }
       });
       this._filteredPipelines = filteredPipelines;
+      this.toolbarConfig.filterConfig.resultsCount = this.pipelines.length;
     }
   }
 
   ngOnInit() {
     this._pipelinesSubscription = this.pipelinesService.current
-      .do(val => {
-        (val as BuildConfig[])
-          .forEach(buildConfig => {
-            if (!this._apps.find(fq => fq.id === buildConfig.labels['app'])) {
-              this._apps.push({ id: buildConfig.labels['app'], value: buildConfig.labels['app'] } as FilterQuery);
-            }
-            if (!this._codebases.find(fq => fq.id === buildConfig.labels['codebase'])) {
-              this._codebases.push({ id: buildConfig.labels['codebase'], value: buildConfig.labels['codebase'] } as FilterQuery);
-            }
-          });
-      })
-      .subscribe(val => {
-        // console.log('Updating build configs:', val);
-        this._allPipelines = val;
+      .subscribe((buildConfigs: BuildConfig[]) => {
+        buildConfigs.forEach((buildConfig: BuildConfig) => {
+          const application: string = buildConfig.id;
+          const codebase: string = buildConfig.gitUrl;
+          if (!this._apps.find(fq => fq.id === application)) {
+            this._apps.push({ id: application, value: application } as FilterQuery);
+          }
+          if (!this._codebases.find(fq => fq.id === codebase)) {
+            this._codebases.push({ id: codebase, value: codebase } as FilterQuery);
+          }
+        });
+        this._allPipelines = buildConfigs;
         this.applyFilters();
         this.applySort();
         this.updateConsoleLink();

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -1,15 +1,39 @@
-import { Component, OnDestroy, OnInit, TemplateRef, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
 import { Router } from '@angular/router';
 
 import { Broadcaster } from 'ngx-base';
-import { AuthenticationService, UserService } from 'ngx-login-client';
-import { Filter, FilterConfig, FilterEvent, FilterQuery, SortEvent, SortField, ToolbarConfig } from 'patternfly-ng';
+import {
+  AuthenticationService,
+  UserService
+} from 'ngx-login-client';
+import {
+  Filter,
+  FilterConfig,
+  FilterEvent,
+  FilterQuery,
+  FilterType,
+  SortEvent,
+  SortField,
+  ToolbarConfig
+} from 'patternfly-ng';
 import { Subscription } from 'rxjs';
 
-
 import { BuildConfig } from 'a-runtime-console/index';
-import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
-import { Context, Contexts, Space } from 'ngx-fabric8-wit';
+import {
+  BsModalRef,
+  BsModalService
+} from 'ngx-bootstrap/modal';
+import {
+  Context,
+  Contexts,
+  Space
+} from 'ngx-fabric8-wit';
 import { pathJoin } from '../../../../a-runtime-console/kubernetes/model/utils';
 import { Fabric8UIConfig } from '../../../shared/config/fabric8-ui-config';
 import { PipelinesService } from '../../../shared/runtime-console/pipelines.service';
@@ -67,14 +91,14 @@ export class PipelinesComponent implements OnInit, OnDestroy {
             id: 'application',
             title: 'Application',
             placeholder: 'Filter by Application...',
-            type: 'select',
+            type: FilterType.SELECT,
             queries: this._apps
           },
           {
             id: 'codebase',
             title: 'Codebase',
             placeholder: 'Filter by Codebase...',
-            type: 'select',
+            type: FilterType.SELECT,
             queries: this._codebases
           }
         ],
@@ -100,22 +124,22 @@ export class PipelinesComponent implements OnInit, OnDestroy {
 
   }
 
-  filterChange($event: FilterEvent) {
+  filterChange($event: FilterEvent): void {
     this._appliedFilters = $event.appliedFilters;
     this.applyFilters();
   }
 
-  sortChange($event: SortEvent) {
+  sortChange($event: SortEvent): void {
     this._currentSortField = $event.field;
     this._ascending = $event.isAscending;
     this.applySort();
   }
 
-  applySort() {
-    this._filteredPipelines.sort((a: any, b: any) => this.compare(a, b));
+  applySort(): void {
+    this._filteredPipelines.sort(this.compare.bind(this));
   }
 
-  compare(a: BuildConfig, b: BuildConfig) {
+  compare(a: BuildConfig, b: BuildConfig): number {
     let res = 0;
 
     if (this._currentSortField.id === 'application' && a.id && b.id) {
@@ -131,21 +155,21 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   }
 
 
-  applyFilters() {
+  applyFilters(): void {
     if (this._allPipelines) {
-      let filteredPipelines = [];
+      const filteredPipelines = [];
       this._allPipelines.forEach((bc: BuildConfig) => {
         let matches = true;
         let spaceId = '';
         if (this._context) {
           spaceId = this._context.name;
-          let paths = this._context.path.split('/');
+          const paths = this._context.path.split('/');
           if (paths[paths.length - 1]) {
             spaceId = paths[paths.length - 1];
           }
         }
         if (spaceId) {
-          let bcSpace = bc.labels['space'];
+          const bcSpace = bc.labels['space'];
           if (bcSpace && bcSpace !== spaceId) {
             matches = false;
           }
@@ -170,7 +194,7 @@ export class PipelinesComponent implements OnInit, OnDestroy {
     }
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this._pipelinesSubscription = this.pipelinesService.current
       .subscribe((buildConfigs: BuildConfig[]) => {
         buildConfigs.forEach((buildConfig: BuildConfig) => {
@@ -189,34 +213,35 @@ export class PipelinesComponent implements OnInit, OnDestroy {
         this.updateConsoleLink();
       });
 
-    this.contextSubscription = this.contexts.current.subscribe(val => {
-      this._context = val;
-      this.space = val.space;
-    });
+    this.contextSubscription = this.contexts.current
+      .subscribe((context: Context) => {
+        this._context = context;
+        this.space = context.space;
+      });
   }
 
-  updateConsoleLink() {
+  ngOnDestroy(): void {
+    this._pipelinesSubscription.unsubscribe();
+    this.contextSubscription.unsubscribe();
+  }
+
+  updateConsoleLink(): void {
     this.openshiftConsoleUrl = this.fabric8UIConfig.openshiftConsoleUrl;
-    let pipelines = this._allPipelines;
+    const pipelines = this._allPipelines;
     if (this.openshiftConsoleUrl && pipelines && pipelines.length) {
-      let pipeline = pipelines[0];
-      let namespace = pipeline.namespace;
+      const pipeline = pipelines[0];
+      const namespace = pipeline.namespace;
       if (namespace) {
         this.openshiftConsoleUrl = pathJoin(this.openshiftConsoleUrl, '/project', namespace, '/browse/pipelines');
       }
     }
   }
 
-  ngOnDestroy() {
-    this._pipelinesSubscription.unsubscribe();
-    this.contextSubscription.unsubscribe();
-  }
-
-  get pipelines() {
+  get pipelines(): BuildConfig[] {
     return this._filteredPipelines;
   }
 
-  openForgeWizard(addSpace: TemplateRef<any>) {
+  openForgeWizard(addSpace: TemplateRef<any>): void {
     if (this.authService.getGitHubToken()) {
       this.selectedFlow = '';
       this.modalRef = this.modalService.show(addSpace, {class: 'modal-lg'});
@@ -225,11 +250,11 @@ export class PipelinesComponent implements OnInit, OnDestroy {
     }
   }
 
-  closeModal($event: any): void {
+  closeModal(): void {
     this.modalRef.hide();
   }
 
-  selectFlow($event) {
+  selectFlow($event: any): void {
     this.selectedFlow = $event.flow;
   }
 }

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -5,13 +5,9 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { Router } from '@angular/router';
 
 import { Broadcaster } from 'ngx-base';
-import {
-  AuthenticationService,
-  UserService
-} from 'ngx-login-client';
+import { AuthenticationService } from 'ngx-login-client';
 import {
   Filter,
   FilterConfig,
@@ -74,9 +70,7 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   constructor(
     private modalService: BsModalService,
     private contexts: Contexts,
-    private router: Router,
     private authService: AuthenticationService,
-    private userService: UserService,
     private pipelinesService: PipelinesService,
     private fabric8UIConfig: Fabric8UIConfig,
     private broadcaster: Broadcaster
@@ -123,6 +117,12 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.contextSubscription = this.contexts.current
+      .subscribe((context: Context) => {
+        this._context = context;
+        this.space = context.space;
+      });
+
     this._pipelinesSubscription = this.pipelinesService.current
       .subscribe((buildConfigs: BuildConfig[]) => {
         buildConfigs.forEach((buildConfig: BuildConfig) => {
@@ -139,12 +139,6 @@ export class PipelinesComponent implements OnInit, OnDestroy {
         this.applyFilters();
         this.applySort();
         this.updateConsoleLink();
-      });
-
-    this.contextSubscription = this.contexts.current
-      .subscribe((context: Context) => {
-        this._context = context;
-        this.space = context.space;
       });
   }
 


### PR DESCRIPTION
BuildConfigs do not contain expected "app" and "codebase" labels, which the Pipelines component
expects to be present and uses for filtering and sorting pipelines by their Application and
Codebase. The "id" and "gitUrl" properties of the BuildConfig are used instead.

fixes https://github.com/openshiftio/openshift.io/issues/2405

Also included are some code cleanup commits for the component.

Working on tests now, but since this is a small wrapper around a runtime-console component, it's taking a lot of time to mock up all of the runtime-console dependencies. I'll probably end up replacing the actual runtime-console child component(s) with mocks, so the only meaningful parts behind the test will have to do with this component's filtering and sorting.