### PR TITLE
fix(deployments): add pod quotas service and use it in deployment cards

### DIFF
--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -950,7 +950,11 @@ describe('DeploymentsService', () => {
                   deployments: [
                     {
                       attributes: {
-                        name: 'foo-env'
+                        name: 'foo-env',
+                        pods_quota: {
+                          cpucores: 3,
+                          memory: 3
+                        }
                       }
                     }
                   ]
@@ -959,20 +963,6 @@ describe('DeploymentsService', () => {
             ]
           }
         }
-      };
-      const quotaResponse = {
-        data: [{
-          attributes: {
-            name: 'foo-env',
-            quota: {
-              cpucores: {
-                quota: 3,
-                used: 2,
-                timestamp: 2
-              }
-            }
-          }
-        }]
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
@@ -987,9 +977,8 @@ describe('DeploymentsService', () => {
           responseBody = streamingTimeseriesResponse;
         } else if (deploymentRegex.test(requestUrl)) {
           responseBody = deploymentResponse;
-        } else {
-          responseBody = quotaResponse;
         }
+
         connection.mockRespond(new Response(
           new ResponseOptions({
             body: JSON.stringify(responseBody),
@@ -1065,7 +1054,11 @@ describe('DeploymentsService', () => {
                   deployments: [
                     {
                       attributes: {
-                        name: 'foo-env'
+                        name: 'foo-env',
+                        pods_quota: {
+                          cpucores: 3,
+                          memory: 3
+                        }
                       }
                     }
                   ]
@@ -1074,20 +1067,6 @@ describe('DeploymentsService', () => {
             ]
           }
         }
-      };
-      const quotaResponse = {
-        data: [{
-          attributes: {
-            name: 'foo-env',
-            quota: {
-              memory: {
-                quota: 5,
-                used: 4,
-                timestamp: 4
-              }
-            }
-          }
-        }]
       };
 
       const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
@@ -1102,9 +1081,8 @@ describe('DeploymentsService', () => {
           responseBody = streamingTimeseriesResponse;
         } else if (deploymentRegex.test(requestUrl)) {
           responseBody = deploymentResponse;
-        } else {
-          responseBody = quotaResponse;
         }
+
         connection.mockRespond(new Response(
           new ResponseOptions({
             body: JSON.stringify(responseBody),

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -237,10 +237,10 @@ export class DeploymentsService implements OnDestroy {
     return this.getEnvironmentsResponse(spaceId)
       .map((envs: EnvironmentStat[]) => envs || [])
       .map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => env.attributes))
-      .map((envs: EnvironmentAttributes[]) => envs.sort((a, b) =>  -1 * a.name.localeCompare(b.name)))
+      .map((envs: EnvironmentAttributes[]) => envs.sort((a, b) => -1 * a.name.localeCompare(b.name)))
       .map((envs: EnvironmentAttributes[]) => envs
         .filter((env: EnvironmentAttributes) => env.name !== 'test')
-        .map((env: EnvironmentAttributes) => ({ name: env.name} as ModelEnvironment))
+        .map((env: EnvironmentAttributes) => ({ name: env.name } as ModelEnvironment))
       )
       .distinctUntilChanged((p: ModelEnvironment[], q: ModelEnvironment[]) =>
         deepEqual(new Set<string>(p.map(v => v.name)), new Set<string>(q.map(v => v.name))));
@@ -252,7 +252,8 @@ export class DeploymentsService implements OnDestroy {
       .map((apps: Application[]) => apps.map((app: Application) => {
         const appName = app.attributes.name;
         const deploymentNamesAndVersions = app.attributes.deployments.map(
-          (dep: Deployment) => ({ name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
+          (dep: Deployment) => ({
+            name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
           })
         );
 
@@ -307,7 +308,7 @@ export class DeploymentsService implements OnDestroy {
       .map((attrs: DeploymentAttributes) => {
         const pods = [];
         attrs.pods.forEach(p => {
-          pods.push([ p[0], parseInt(p[1])]);
+          pods.push([p[0], parseInt(p[1])]);
         });
         return {
           total: attrs.pod_total,
@@ -324,7 +325,7 @@ export class DeploymentsService implements OnDestroy {
     const quota = this.getEnvironmentCpuStat(spaceId, environmentName)
       .map((stat: CpuStat) => stat.quota)
       .distinctUntilChanged();
-      return Observable.combineLatest(series, quota, (series: CoresSeries, quota: number) => ({ used: series.value, quota: quota, timestamp: series.time } as CpuStat));
+    return Observable.combineLatest(series, quota, (series: CoresSeries, quota: number) => ({ used: series.value, quota: quota, timestamp: series.time } as CpuStat));
   }
 
   getDeploymentMemoryStat(spaceId: string, applicationId: string, environmentName: string): Observable<MemoryStat> {
@@ -334,7 +335,7 @@ export class DeploymentsService implements OnDestroy {
     const quota = this.getEnvironment(spaceId, environmentName)
       .map((env: EnvironmentStat) => env.attributes.quota.memory.quota)
       .distinctUntilChanged();
-      return Observable.combineLatest(series, quota, (series: MemorySeries, quota: number) => new ScaledMemoryStat(series.value, quota, series.time) as MemoryStat);
+    return Observable.combineLatest(series, quota, (series: MemorySeries, quota: number) => new ScaledMemoryStat(series.value, quota, series.time) as MemoryStat);
   }
 
   getDeploymentNetworkStat(spaceId: string, applicationId: string, environmentName: string): Observable<NetworkStat> {


### PR DESCRIPTION
This addresses the UI portion for [1] and relies on the backend PR [2] to be merged first.

The deployment card quota information will now be deployment specific instead of the environment quota. See [1] for more information.

[1]
https://github.com/openshiftio/openshift.io/issues/2183
[2]
https://github.com/fabric8-services/fabric8-wit/pull/1922