### PR TITLE
feat(deployments): DeploymentsService replays stat series window each…

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -34,6 +34,7 @@ import { createMock } from 'testing/mock';
 import { NotificationsService } from 'app/shared/notifications.service';
 import { CpuStat } from '../models/cpu-stat';
 import { Environment } from '../models/environment';
+import { MemoryStat } from '../models/memory-stat';
 import { DeploymentsService } from '../services/deployments.service';
 import { DeploymentCardComponent } from './deployment-card.component';
 import { DeploymentStatusIconComponent } from './deployment-status-icon.component';
@@ -89,8 +90,8 @@ function initMockSvc(): jasmine.SpyObj<DeploymentsService> {
   const mockSvc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
 
   mockSvc.getVersion.and.returnValue(Observable.of('1.2.3'));
-  mockSvc.getDeploymentCpuStat.and.returnValue(Observable.of({ used: 1, quota: 2 }));
-  mockSvc.getDeploymentMemoryStat.and.returnValue(Observable.of({ used: 3, quota: 4, units: 'GB' }));
+  mockSvc.getDeploymentCpuStat.and.returnValue(Observable.of([{ used: 1, quota: 2, timestamp: 1 }] as CpuStat[]));
+  mockSvc.getDeploymentMemoryStat.and.returnValue(Observable.of([{ used: 3, quota: 4, units: 'GB', timestamp: 1 }] as MemoryStat[]));
   mockSvc.getAppUrl.and.returnValue(Observable.of('mockAppUrl'));
   mockSvc.getConsoleUrl.and.returnValue(Observable.of('mockConsoleUrl'));
   mockSvc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
@@ -202,7 +203,7 @@ describe('DeploymentCardComponent', () => {
   let active: Subject<boolean>;
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
   let notifications: any;
-  let mockCpuData: Subject<CpuStat> = new BehaviorSubject({ used: 1, quota: 5 } as CpuStat);
+  let mockCpuData: Subject<CpuStat[]> = new BehaviorSubject([{ used: 1, quota: 5, timestamp: 1 }] as CpuStat[]);
 
   beforeEach(fakeAsync(() => {
     active = new BehaviorSubject<boolean>(true);
@@ -252,14 +253,14 @@ describe('DeploymentCardComponent', () => {
     });
 
     it('should change the button\'s value to warning if capacity changes', function(this: Context) {
-      mockCpuData.next({ used: 4, quota: 5 } as CpuStat);
+      mockCpuData.next([{ used: 4, quota: 5, timestamp: 2 }] as CpuStat[]);
       this.detectChanges();
       expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_WARN);
       expect(this.testedDirective.toolTip).toBe('CPU usage is nearing capacity.');
     });
 
     it('should change the button\s value to error if capacity is exceeded', function(this: Context) {
-      mockCpuData.next({ used: 6, quota: 5 } as CpuStat);
+      mockCpuData.next([{ used: 6, quota: 5, timestamp: 2 }] as CpuStat[]);
       this.detectChanges();
       expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_ERR);
       expect(this.testedDirective.toolTip).toBe('CPU usage has exceeded capacity.');

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -39,7 +39,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   consoleUrl: Observable<string>;
   appUrl: Observable<string>;
 
-  cpuStat: Observable<CpuStat>;
+  cpuStat: Observable<CpuStat[]>;
   iconClass: string;
   toolTip: string;
 
@@ -60,9 +60,9 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
     this.iconClass = DeploymentStatusIconComponent.CLASSES.ICON_OK;
     this.toolTip = 'Everything is ok';
 
-    this.cpuStat = this.deploymentsService.getDeploymentCpuStat(this.spaceId, this.applicationId, this.environment.name);
-    this.subscriptions.push(this.cpuStat.subscribe((stat: CpuStat) => {
-      this.changeStatus(stat);
+    this.cpuStat = this.deploymentsService.getDeploymentCpuStat(this.spaceId, this.applicationId, this.environment.name, 1);
+    this.subscriptions.push(this.cpuStat.subscribe((stat: CpuStat[]) => {
+      this.changeStatus(stat[0]);
     }));
 
     this.subscriptions.push(

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -27,7 +27,8 @@ import { ResourceCardComponent } from './resource-usage/resource-card.component'
 import { UtilizationBarComponent } from './resource-usage/utilization-bar.component';
 import {
   DeploymentsService,
-  TIMER_TOKEN
+  TIMER_TOKEN,
+  TIMESERIES_SAMPLES_TOKEN
 } from './services/deployments.service';
 
 const DEPLOYMENTS_SERVICE_POLL_TIMER = Observable
@@ -63,7 +64,8 @@ const DEPLOYMENTS_SERVICE_POLL_TIMER = Observable
   ],
   providers: [
     BsDropdownConfig,
-    { provide: TIMER_TOKEN, useValue: DEPLOYMENTS_SERVICE_POLL_TIMER }
+    { provide: TIMER_TOKEN, useValue: DEPLOYMENTS_SERVICE_POLL_TIMER },
+    { provide: TIMESERIES_SAMPLES_TOKEN, useValue: 15 }
   ]
 })
 export class DeploymentsModule {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -37,7 +37,8 @@ import { ScaledNetworkStat } from '../models/scaled-network-stat';
 import {
   DeploymentsService,
   NetworkStat,
-  TIMER_TOKEN
+  TIMER_TOKEN,
+  TIMESERIES_SAMPLES_TOKEN
 } from './deployments.service';
 
 interface MockHttpParams<U> {
@@ -90,8 +91,10 @@ describe('DeploymentsService', () => {
           provide: NotificationsService, useValue: mockNotificationsService
         },
         {
-          provide: TIMER_TOKEN,
-          useValue: serviceUpdater
+          provide: TIMER_TOKEN, useValue: serviceUpdater
+        },
+        {
+          provide: TIMESERIES_SAMPLES_TOKEN, useValue: 3
         },
         DeploymentsService
       ]
@@ -987,11 +990,10 @@ describe('DeploymentsService', () => {
         ));
       });
 
-      // FIXME: for some reason in the test environment, the first front loaded stat is dropped by Observable.combineLatest
-      svc.getDeploymentCpuStat('foo-space', 'foo-app', 'foo-env')
-        .bufferCount(2)
+      svc.getDeploymentCpuStat('foo-space', 'foo-app', 'foo-env', 3)
         .subscribe((stats: CpuStat[]) => {
           expect(stats).toEqual([
+            { used: 1, quota: 3, timestamp: 1 },
             { used: 2, quota: 3, timestamp: 2 },
             { used: 9, quota: 3, timestamp: 9 }
           ]);
@@ -1091,11 +1093,10 @@ describe('DeploymentsService', () => {
         ));
       });
 
-      // FIXME: for some reason in the test environment, the first front loaded stat is dropped by Observable.combineLatest
-      svc.getDeploymentMemoryStat('foo-space', 'foo-app', 'foo-env')
-        .bufferCount(2)
+      svc.getDeploymentMemoryStat('foo-space', 'foo-app', 'foo-env', 3)
         .subscribe((stats: MemoryStat[]) => {
           expect(stats).toEqual([
+            new ScaledMemoryStat(3, 3, 3),
             new ScaledMemoryStat(4, 3, 4),
             new ScaledMemoryStat(10, 3, 10)
           ]);
@@ -1191,8 +1192,7 @@ describe('DeploymentsService', () => {
         ));
       });
 
-      svc.getDeploymentNetworkStat('foo-space', 'foo-app', 'foo-env')
-        .bufferCount(3)
+      svc.getDeploymentNetworkStat('foo-space', 'foo-app', 'foo-env', 3)
         .subscribe((stats: NetworkStat[]) => {
           expect(stats).toEqual([
             { sent: new ScaledNetworkStat(7, 7), received: new ScaledNetworkStat(5, 5) },


### PR DESCRIPTION
… poll cycle

Replay stats series array for past 15 minute window (by default) on each
new emission so that consumer components do not need to maintain any
local state, instead simply using data "verbatim" as supplied by the
DeploymentsService.

closes https://github.com/openshiftio/openshift.io/issues/2253