### PR TITLE
test(deployments): correct DeploymentsService test expected values

### DIFF
--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -1096,8 +1096,8 @@ describe('DeploymentsService', () => {
         .bufferCount(2)
         .subscribe((stats: MemoryStat[]) => {
           expect(stats).toEqual([
-            new ScaledMemoryStat(4, 5, 4),
-            new ScaledMemoryStat(10, 5, 10)
+            new ScaledMemoryStat(4, 3, 4),
+            new ScaledMemoryStat(10, 3, 10)
           ]);
           subscription.unsubscribe();
           done();


### PR DESCRIPTION
Not sure how this didn't get caught on the original PR. This brings the test's expected values in line with the mocked responses.