### PR TITLE
app-launcher: build slow due to ngx-forge.js bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "ngx-base": "2.3.1",
     "ngx-bootstrap": "1.8.0",
     "ngx-fabric8-wit": "6.20.1",
-    "ngx-forge": "0.0.55-development",
+    "ngx-forge": "0.0.56-development",
     "ngx-login-client": "1.3.6",
     "ngx-modal": "0.0.29",
     "ngx-widgets": "2.3.7",


### PR DESCRIPTION
This fixes an issue with the fabric8-ui build running too slow.

The ngx-forge package now uses tree shaking to reduce the ngx-forge.js bundle size by half. Thus, the build no longer appears to hang while Angular resolves duplicates.

