### PR TITLE
fix(profile): Verify OSO token status while retrieving OSO token in profile overview

### DIFF
--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.html
@@ -61,8 +61,8 @@
                   </div>
                   <div class="list-view-pf-additional-info">
                     <div class="list-view-pf-additional-info-item">
-                      <span *ngIf="openShiftLinked">{{contextUserName}}</span>
-                      <span *ngIf="!openShiftLinked" class="account-disconnected">Not Connected</span>
+                      <span *ngIf="openShiftLinked">{{openShiftUserName}}</span>
+                      <span *ngIf="!openShiftLinked" class="account-disconnected">{{openShiftError}}</span>
                       <button class="btn btn-link" type="button" (click)="refreshOpenShift()">
                         <span class="fa fa-refresh"></span>
                       </button>

--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.spec.ts
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.spec.ts
@@ -42,6 +42,7 @@ describe('Connected Accounts Component', () => {
       userServiceMock.loggedInUser = Observable.empty();
       userServiceMock.currentLoggedInUser = {};
       providersMock.getGitHubStatus.and.returnValue(Observable.of({'username': 'username'}));
+      providersMock.getOpenShiftStatus.and.returnValue(Observable.throw('failure'));
     });
 
     initContext(ConnectedAccountsComponent, SampleTestComponent,  {
@@ -79,6 +80,7 @@ describe('Connected Accounts Component', () => {
       userServiceMock.loggedInUser = Observable.empty();
       userServiceMock.currentLoggedInUser = ctx.user;
       providersMock.getGitHubStatus.and.returnValue(Observable.throw('failure'));
+      providersMock.getOpenShiftStatus.and.returnValue(Observable.of({'username': expectedOsoUser}));
     });
 
     initContext(ConnectedAccountsComponent, SampleTestComponent,  {
@@ -115,6 +117,7 @@ describe('Connected Accounts Component', () => {
       userServiceMock.loggedInUser = Observable.empty();
       userServiceMock.currentLoggedInUser = ctx.user;
       providersMock.getGitHubStatus.and.returnValue(Observable.of({'username': 'username'}));
+      providersMock.getOpenShiftStatus.and.returnValue(Observable.of({'username': expectedOsoUser}));
     });
 
     initContext(ConnectedAccountsComponent, SampleTestComponent,  {

--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.spec.ts
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.spec.ts
@@ -31,7 +31,7 @@ describe('Connected Accounts Component', () => {
 
     let contextsMock: any = jasmine.createSpy('Contexts');
     let authMock: any = jasmine.createSpyObj('AuthenticationService', ['isOpenShiftConnected']);
-    let providersMock: any  = jasmine.createSpyObj('ProviderService', ['getGitHubStatus']);
+    let providersMock: any  = jasmine.createSpyObj('ProviderService', ['getGitHubStatus', 'getOpenShiftStatus']);
     let userServiceMock: any = jasmine.createSpy('UserService');
 
     beforeAll(() => {
@@ -69,7 +69,7 @@ describe('Connected Accounts Component', () => {
 
     let contextsMock: any = jasmine.createSpy('Contexts');
     let authMock: any = jasmine.createSpyObj('AuthenticationService', ['isOpenShiftConnected']);
-    let providersMock: any  = jasmine.createSpyObj('ProviderService', ['getGitHubStatus']);
+    let providersMock: any  = jasmine.createSpyObj('ProviderService', ['getGitHubStatus', 'getOpenShiftStatus']);
     let userServiceMock: any = jasmine.createSpy('UserService');
 
     beforeAll(() => {
@@ -106,7 +106,7 @@ describe('Connected Accounts Component', () => {
 
     let contextsMock: any = jasmine.createSpy('Contexts');
     let authMock: any = jasmine.createSpyObj('AuthenticationService', ['isOpenShiftConnected']);
-    let providersMock: any  = jasmine.createSpyObj('ProviderService', ['getGitHubStatus']);
+    let providersMock: any  = jasmine.createSpyObj('ProviderService', ['getGitHubStatus', 'getOpenShiftStatus']);
     let userServiceMock: any = jasmine.createSpy('UserService');
 
     beforeAll(() => {

--- a/src/app/profile/overview/connected-accounts/connected-accounts.component.ts
+++ b/src/app/profile/overview/connected-accounts/connected-accounts.component.ts
@@ -19,9 +19,11 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
   subscriptions: Subscription[] = [];
 
   gitHubLinked: boolean = false;
-  openShiftLinked: boolean = false;
   gitHubUserName: string;
   gitHubError: string;
+  openShiftLinked: boolean = false;
+  openShiftUserName: string;
+  openShiftError: string;
 
   userName: string;
   contextUserName: string;
@@ -56,6 +58,7 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.userName = '';
     this.updateGitHubStatus();
+    this.updateOpenShiftStatus();
   }
 
   public disconnectGitHub(): void {
@@ -91,6 +94,16 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
     }, (error) => {
       this.gitHubError = 'Disconnected';
       this.gitHubLinked = false;
+    });
+  }
+
+  private updateOpenShiftStatus(): void {
+    this.providerService.getOpenShiftStatus(this.cluster).subscribe((result) => {
+      this.openShiftLinked = true;
+      this.openShiftUserName = result.username;
+    }, (error) => {
+      this.openShiftError = 'Not Connected';
+      this.openShiftLinked = false;
     });
   }
 }

--- a/src/app/shared/account/provider.service.ts
+++ b/src/app/shared/account/provider.service.ts
@@ -64,6 +64,14 @@ export class ProviderService {
       });
   }
 
+  getOpenShiftStatus(cluster: string): Observable<any> {
+    let tokenUrl = this.apiUrl + 'token?force_pull=true&for=' + cluster;
+    return this.http.get(tokenUrl)
+      .map((response) => {
+        return response.json();
+      });
+  }
+
   disconnectOpenShift(cluster: string): Observable<any> {
     let tokenUrl = this.apiUrl + 'token?for=' + cluster;
     return this.http


### PR DESCRIPTION
Related to https://github.com/fabric8-services/fabric8-auth/issues/320

- Adds getOpenShiftStatus()  in providerService to get auth token with new param `force_pull=true`.

- Adds updateOpenShiftStatus() in connected-accounts.component which gets called in ngOnInit()

- Updated test cases for the above changes.