### PR TITLE
fix(profile): show email on profile overview page if email is public

### DIFF
--- a/src/app/profile/overview/overview.component.html
+++ b/src/app/profile/overview/overview.component.html
@@ -20,13 +20,13 @@
         </p>
         <hr>
         <div *ngIf="(context.user.attributes.email !== undefined && context.user.attributes.email.length !== 0); then showEmail else addEmail"></div>
-        <ng-template #showEmail *ngIf="context.user.attributes.emailPrivate">
-          <p class="col-sm-12 profile-wrapper-email truncate">
+        <ng-template #showEmail>
+          <p class="col-sm-12 profile-wrapper-email truncate" *ngIf="!context.user.attributes.emailPrivate">
             <span class="fa fa-envelope"></span>
             <a href="mailto:{{context.user.attributes.email}}" class="margin-left-5 margin-right-5">{{context.user.attributes.email}}</a>
           </p>
         </ng-template>
-        <ng-template #addEmail *ngIf="!context.user.attributes.emailPrivate">
+        <ng-template #addEmail>
           <p class="col-sm-12 profile-wrapper-email">
             <span class="fa fa-envelope"></span>
             <a href="javascript:void(0)"


### PR DESCRIPTION
Fixes a bug in [PR](https://github.com/fabric8-ui/fabric8-ui/pull/2489).

- Found a bug in the logic of showing email based on private/public status of user.
- Since we're using conditional ng-template already, *ngIf on ng-template doesn't work. [Refer](https://stackoverflow.com/questions/44837756/why-ngif-doesntwork-with-ng-template)
- So, moved *ngIf to p tag inside of ng-template instead.
- Also, we don't need the condition for addEmail element since that will never be shown if user has an email.