### PR TITLE
fix(app-launcher): modified ngx-forge package module to use index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "ngx-base": "2.3.1",
     "ngx-bootstrap": "1.8.0",
     "ngx-fabric8-wit": "6.20.1",
-    "ngx-forge": "0.0.56-development",
+    "ngx-forge": "0.0.57-development",
     "ngx-login-client": "1.3.6",
     "ngx-modal": "0.0.29",
     "ngx-widgets": "2.3.7",


### PR DESCRIPTION
- Modified ngx-forge package module to use index.js instead of ngx-forge.js bundle
- Module changes (along with tree shaking) should help fabric8-ui build performance because Angular isn’t resolving duplicates.
- Allows fabric8-ui to install its own dependencies instead of packages being duplicated by the ngx-forge.js bundle.
- Eliminates the ‘multiple mobx instances’ error seen with fabric8-ui unit tests, since certain dependencies are duplicated by the ngx-forge.js bundle.

Fixes: https://github.com/openshiftio/openshift.io/issues/2461
Changes to ngx-forge can be seen here: https://github.com/fabric8-launcher/ngx-launcher/pull/96

