### PR TITLE
Memory usage warning

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -251,43 +251,6 @@ describe('DeploymentCardComponent', () => {
     expect(detailsComponent.active).toBeTruthy();
   });
 
-  describe('iconStatusLogic', () => {
-    it("should set the icon's initial value to ok", function(this: Context) {
-      expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_OK);
-      expect(this.testedDirective.toolTip).toBe('Everything is OK.');
-    });
-
-    it("should change the icon's value to warning if capacity changes", function(this: Context) {
-      mockCpuData.next([{ used: 4, quota: 5, timestamp: 2 }] as CpuStat[]);
-      this.detectChanges();
-      expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_WARN);
-      expect(this.testedDirective.toolTip).toBe('CPU usage is nearing capacity.');
-    });
-
-    it("should change the icon's value to error if capacity is exceeded", function(this: Context) {
-      mockCpuData.next([{ used: 6, quota: 5, timestamp: 2 }] as CpuStat[]);
-      this.detectChanges();
-      expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_ERR);
-      expect(this.testedDirective.toolTip).toBe('CPU usage has reached capacity.');
-    });
-
-    it('should combine warning labels if multiple resources are reaching capacity', function(this: Context) {
-      mockCpuData.next([{ used: 4, quota: 5, timestamp: 2 }] as CpuStat[]);
-      mockMemoryData.next([{ used: 4, quota: 5, timestamp: 2 }] as MemoryStat[]);
-      this.detectChanges();
-      expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_WARN);
-      expect(this.testedDirective.toolTip).toBe('CPU usage is nearing capacity. Memory usage is nearing capacity.');
-    });
-
-    it('should favour error icons over warning icons', function(this: Context) {
-      mockCpuData.next([{ used: 4, quota: 5, timestamp: 2 }] as CpuStat[]);
-      mockMemoryData.next([{ used: 5, quota: 5, timestamp: 2 }] as MemoryStat[]);
-      this.detectChanges();
-      expect(this.testedDirective.iconClass).toBe(DeploymentStatusIconComponent.CLASSES.ICON_ERR);
-      expect(this.testedDirective.toolTip).toBe('CPU usage is nearing capacity. Memory usage has reached capacity.');
-    });
-  });
-
   describe('versionLabel', () => {
     let de: DebugElement;
     let el: HTMLElement;

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -35,6 +35,7 @@ import { NotificationsService } from 'app/shared/notifications.service';
 import { CpuStat } from '../models/cpu-stat';
 import { Environment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
+import { DeploymentStatusService } from '../services/deployment-status.service';
 import { DeploymentsService } from '../services/deployments.service';
 import { DeploymentCardComponent } from './deployment-card.component';
 import { DeploymentStatusIconComponent } from './deployment-status-icon.component';
@@ -130,7 +131,8 @@ describe('DeploymentCardComponent async tests', () => {
         providers: [
           BsDropdownConfig,
           { provide: NotificationsService, useValue: notifications },
-          { provide: DeploymentsService, useValue: mockSvc }
+          { provide: DeploymentsService, useValue: mockSvc },
+          DeploymentStatusService
         ]
       });
 
@@ -234,7 +236,8 @@ describe('DeploymentCardComponent', () => {
     providers: [
       BsDropdownConfig,
       { provide: NotificationsService, useFactory: () => notifications },
-      { provide: DeploymentsService, useFactory: () => mockSvc }
+      { provide: DeploymentsService, useFactory: () => mockSvc },
+      DeploymentStatusService
     ]
   },
     (component: DeploymentCardComponent) => {

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -49,7 +49,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   iconClass: string;
   toolTip: string;
 
-  subscriptions: Array<Subscription> = [];
+  private readonly subscriptions: Array<Subscription> = [];
 
   private readonly debouncedUpdateDetails = debounce(this.updateDetails, DeploymentCardComponent.DEBOUNCE_TIME, { maxWait: DeploymentCardComponent.MAX_DEBOUNCE_TIME });
 

--- a/src/app/space/create/deployments/deployments.component.ts
+++ b/src/app/space/create/deployments/deployments.component.ts
@@ -4,6 +4,7 @@ import { Spaces } from 'ngx-fabric8-wit';
 import { Observable, Subscription } from 'rxjs';
 
 import { Environment } from './models/environment';
+import { DeploymentStatusService } from './services/deployment-status.service';
 import { DeploymentsService } from './services/deployments.service';
 
 @Component({
@@ -11,7 +12,10 @@ import { DeploymentsService } from './services/deployments.service';
   selector: 'alm-apps',
   templateUrl: 'deployments.component.html',
   styleUrls: ['./deployments.component.less'],
-  providers: [DeploymentsService]
+  providers: [
+    DeploymentStatusService,
+    DeploymentsService
+  ]
 })
 export class DeploymentsComponent implements OnDestroy, OnInit {
 

--- a/src/app/space/create/deployments/services/deployment-status.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-status.service.spec.ts
@@ -1,0 +1,154 @@
+import {
+  BehaviorSubject,
+  Observable,
+  Subject
+} from 'rxjs';
+
+import { createMock } from 'testing/mock';
+
+import { CpuStat } from '../models/cpu-stat';
+import { MemoryStat } from '../models/memory-stat';
+import {
+  DeploymentStatusService,
+  Status,
+  StatusType
+} from './deployment-status.service';
+import { DeploymentsService } from './deployments.service';
+
+describe('DeploymentStatusService', (): void => {
+
+  let svc: DeploymentStatusService;
+  let deploymentsService: jasmine.SpyObj<DeploymentsService>;
+  let cpuSubject: Subject<CpuStat[]>;
+  let memorySubject: Subject<MemoryStat[]>;
+
+  beforeEach((): void => {
+    deploymentsService = createMock(DeploymentsService);
+
+    cpuSubject = new BehaviorSubject<CpuStat[]>([{ used: 3, quota: 10 }]);
+    memorySubject = new BehaviorSubject<MemoryStat[]>([{ used: 4, quota: 10, units: 'GB' }]);
+
+    deploymentsService.getDeploymentCpuStat.and.returnValue(cpuSubject);
+    deploymentsService.getDeploymentMemoryStat.and.returnValue(memorySubject);
+
+    svc = new DeploymentStatusService(deploymentsService);
+  });
+
+  describe('#getAggregateStatus', (): void => {
+    it('should return OK status with no message when no stats are nearing quota', (done: DoneFn): void => {
+      svc.getAggregateStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.OK);
+          expect(status.message).toEqual('');
+          done();
+        });
+    });
+
+    it('should mirror single status when one stat is nearing quota', (done: DoneFn): void => {
+      cpuSubject.next([{ used: 9, quota: 10 }]);
+      Observable.combineLatest(
+        svc.getCpuStatus('foo', 'bar', 'baz'),
+        svc.getAggregateStatus('foo', 'bar', 'baz')
+      )
+        .first()
+        .subscribe((statuses: [Status, Status]): void => {
+          expect(statuses[1]).toEqual(statuses[0]);
+          done();
+        });
+    });
+
+    it('should return combined status when multiple stats are nearing quota', (done: DoneFn): void => {
+      cpuSubject.next([{ used: 9, quota: 10 }]);
+      memorySubject.next([{ used: 9, quota: 10, units: 'MB' }]);
+      svc.getAggregateStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.WARN);
+          expect(status.message).toEqual('CPU usage is nearing capacity. Memory usage is nearing capacity.');
+          done();
+        });
+    });
+
+    it('should return combined status when multiple stats are nearing or at quota', (done: DoneFn): void => {
+      cpuSubject.next([{ used: 9, quota: 10 }]);
+      memorySubject.next([{ used: 10, quota: 10, units: 'MB' }]);
+      svc.getAggregateStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.ERR);
+          expect(status.message).toEqual('CPU usage is nearing capacity. Memory usage has reached capacity.');
+          done();
+        });
+    });
+  });
+
+  describe('#getCpuStatus', (): void => {
+    it('should return OK status when not nearing quota', (done: DoneFn): void => {
+      svc.getCpuStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.OK);
+          expect(status.message).toEqual('');
+          done();
+        });
+    });
+
+    it('should return WARN status when nearing quota', (done: DoneFn): void => {
+      cpuSubject.next([{ used: 9, quota: 10 }]);
+      svc.getCpuStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.WARN);
+          expect(status.message).toEqual('CPU usage is nearing capacity.');
+          done();
+        });
+    });
+
+    it('should return ERR status when at quota', (done: DoneFn): void => {
+      cpuSubject.next([{ used: 10, quota: 10 }]);
+      svc.getCpuStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.ERR);
+          expect(status.message).toEqual('CPU usage has reached capacity.');
+          done();
+        });
+    });
+  });
+
+  describe('#getMemoryStatus', (): void => {
+    it('should return OK status when not nearing quota', (done: DoneFn): void => {
+      svc.getMemoryStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.OK);
+          expect(status.message).toEqual('');
+          done();
+        });
+    });
+
+    it('should return WARN status when nearing quota', (done: DoneFn): void => {
+      memorySubject.next([{ used: 9, quota: 10, units: 'MB' }]);
+      svc.getMemoryStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.WARN);
+          expect(status.message).toEqual('Memory usage is nearing capacity.');
+          done();
+        });
+    });
+
+    it('should return ERR status when at quota', (done: DoneFn): void => {
+      memorySubject.next([{ used: 10, quota: 10, units: 'MB' }]);
+      svc.getMemoryStatus('foo', 'bar', 'baz')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.ERR);
+          expect(status.message).toEqual('Memory usage has reached capacity.');
+          done();
+        });
+    });
+  });
+
+});

--- a/src/app/space/create/deployments/services/deployment-status.service.ts
+++ b/src/app/space/create/deployments/services/deployment-status.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+
+import {
+  last,
+  reduce
+} from 'lodash';
+import { Observable } from 'rxjs';
+
+import { CpuStat } from '../models/cpu-stat';
+import { MemoryStat } from '../models/memory-stat';
+import { Stat } from '../models/stat';
+import { DeploymentsService } from './deployments.service';
+
+export enum StatusType {
+  OK,
+  WARN,
+  ERR
+}
+
+export interface Status {
+  type: StatusType;
+  message: string;
+}
+
+@Injectable()
+export class DeploymentStatusService {
+
+  static readonly WARNING_THRESHOLD = .6;
+
+  constructor(private readonly deploymentsService: DeploymentsService) { }
+
+  getCpuStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
+    return this.deploymentsService.getDeploymentCpuStat(spaceId, applicationName, environmentName, 1)
+      .map((stats: CpuStat[]): Status => this.getStatStatus(last(stats), 'CPU'));
+  }
+
+  getMemoryStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
+    return this.deploymentsService.getDeploymentMemoryStat(spaceId, applicationName, environmentName, 1)
+      .map((stats: MemoryStat[]): Status => this.getStatStatus(last(stats), 'Memory'));
+  }
+
+  getAggregateStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
+    return Observable.combineLatest(
+      this.getCpuStatus(spaceId, environmentName, applicationName),
+      this.getMemoryStatus(spaceId, environmentName, applicationName)
+    ).map((statuses: [Status, Status]): Status => {
+      const maxType: StatusType = statuses
+        .map((status: Status): StatusType => status.type)
+        .reduce((accum: StatusType, next: StatusType): StatusType => Math.max(accum, next));
+      const joinedMessage: string = statuses
+        .map((status: Status): string => status.message)
+        .join(' ')
+        .trim();
+      return {
+        type: maxType,
+        message: joinedMessage
+      };
+    });
+  }
+
+  private getStatStatus(stat: Stat, metricName: string): Status {
+    let type: StatusType;
+    let message: string;
+    if (stat.used >= stat.quota) {
+      type = StatusType.ERR;
+      message = `${metricName} usage has reached capacity.`;
+    } else if (stat.used / stat.quota >= DeploymentStatusService.WARNING_THRESHOLD) {
+      type = StatusType.WARN;
+      message = `${metricName} usage is nearing capacity.`;
+    } else {
+      type = StatusType.OK;
+      message = '';
+    }
+    return {
+      type: type,
+      message: message
+    };
+  }
+
+}


### PR DESCRIPTION
targeting https://github.com/openshiftio/openshift.io/issues/2519

This PR adds a new service, `DeploymentStatusService`, which provides information about the status of a deployment. Currently this status only reflects resource usage vs quota for CPU and Memory metrics, but the intent is for it to evolve and provide status information for all deployment failure modes (see https://github.com/openshiftio/openshift.io/issues/2086). This is implemented as a separate service building on top of the existing `DeploymentsService` since it's at a higher conceptual abstraction level, and to avoid growing the already very large DeploymentsService any further.

This new DeploymentStatus service incorporates the pre-existing logic that was contained in the DeploymentCardComponent to set the card icon state, which was determined from CPU usage vs quota only. It extends this by also including Memory usage, and providing an aggregate status as well which combines both. This aggregate status is used by the DeploymentCardComponent to set its icon state.

Additionally, the DeploymentStatusService is intended to be useful for the implementation for this separate but related issue: https://github.com/openshiftio/openshift.io/issues/2520

I have an opinion question for the reviewer(s): should the DeploymentCardComponent remain responsible for setting the icon state, or should this responsibility be rolled into the DeploymentStatusIconComponent itself? Currently the icon component is quite "dumb" and simply takes two inputs and uses them in its template directly, with no internal logic of its own.