### PR TITLE
Scale Deployments chart Y axes to quotas

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -242,6 +242,66 @@ describe('DeploymentDetailsComponent', () => {
     });
   });
 
+  describe('sparkline data', () => {
+    it('should set CPU Y axis max to quota', function(this: Context) {
+      expect(this.testedDirective.cpuConfig.axis.y.max).toEqual(2);
+    });
+
+    it('should set CPU Y axis max to maximum value or maximum quota', function(this: Context) {
+      cpuStatObservable.next([
+        {
+          used: 1,
+          quota: 100
+        },
+        {
+          used: 2,
+          quota: 200
+        },
+        {
+          used: 150,
+          quota: 200
+        },
+        {
+          used: 75,
+          quota: 100
+        }
+      ]);
+      this.detectChanges();
+      expect(this.testedDirective.cpuConfig.axis.y.max).toEqual(200);
+    });
+
+    it('should set Memory Y axis max to quota', function(this: Context) {
+      expect(this.testedDirective.memConfig.axis.y.max).toEqual(4);
+    });
+
+    it('should set Memory Y axis max to maximum value or maximum quota', function(this: Context) {
+      memStatObservable.next([
+        {
+          used: 1,
+          quota: 100,
+          units: 'MB'
+        },
+        {
+          used: 2,
+          quota: 200,
+          units: 'MB'
+        },
+        {
+          used: 150,
+          quota: 200,
+          units: 'MB'
+        },
+        {
+          used: 75,
+          quota: 100,
+          units: 'MB'
+        }
+      ]);
+      this.detectChanges();
+      expect(this.testedDirective.memConfig.axis.y.max).toEqual(200);
+    });
+  });
+
   describe('linechart data', () => {
     it('should be rounded to whole numbers when units are bytes', function(this: Context) {
       const mb = Math.pow(1024, 2);

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -24,6 +24,7 @@ import { Environment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
 import { Pods } from '../models/pods';
 import { ScaledNetworkStat } from '../models/scaled-network-stat';
+import { Stat } from '../models/stat';
 import {
   DeploymentsService,
   NetworkStat
@@ -71,7 +72,12 @@ export class DeploymentDetailsComponent {
     // Seperate charts must have unique IDs, otherwise only one will appear
     chartId: uniqueId('cpu-chart'),
     axis: {
-      type: 'timeseries'
+      type: 'timeseries',
+      y: {
+        min: 0,
+        max: 1,
+        padding: 0
+      }
     },
     tooltip: this.getTooltipContents(),
     units: 'Cores'
@@ -81,7 +87,12 @@ export class DeploymentDetailsComponent {
     // Seperate charts must have unique IDs, otherwise only one will appear
     chartId: uniqueId('mem-chart'),
     axis: {
-      type: 'timeseries'
+      type: 'timeseries',
+      y: {
+        min: 0,
+        max: 1,
+        padding: 0
+      }
     },
     tooltip: this.getTooltipContents()
   };
@@ -130,6 +141,7 @@ export class DeploymentDetailsComponent {
         this.cpuVal = last.used;
         this.cpuMax = last.quota;
         this.cpuData.total = last.quota;
+        this.cpuConfig.axis.y.max = this.getChartYAxisMax(stats);
         this.cpuData.xData = [this.cpuData.xData[0], ...stats.map((stat: CpuStat) => stat.timestamp)];
         this.cpuData.yData = [this.cpuData.yData[0], ...stats.map((stat: CpuStat) => stat.used)];
       })
@@ -141,6 +153,7 @@ export class DeploymentDetailsComponent {
         this.memVal = last.used;
         this.memMax = last.quota;
         this.memData.total = last.quota;
+        this.memConfig.axis.y.max = this.getChartYAxisMax(stats);
         this.memUnits = last.units;
         this.memData.xData = [this.memData.xData[0], ...stats.map((stat: MemoryStat) => stat.timestamp)];
         this.memData.yData = [this.memData.yData[0], ...stats.map((stat: MemoryStat) => stat.used)];
@@ -201,6 +214,16 @@ export class DeploymentDetailsComponent {
         </table>
       </div>
     `;
+  }
+
+  private getChartYAxisMax(stats: Stat[]): number {
+    const largestUsage: number = stats
+      .map((stat: Stat): number => stat.used)
+      .reduce((acc: number, next: number): number => Math.max(acc, next));
+    const largestQuota: number = stats
+      .map((stat: Stat): number => stat.quota)
+      .reduce((acc: number, next: number): number => Math.max(acc, next));
+    return Math.max(largestUsage, largestQuota);
   }
 
 }


### PR DESCRIPTION
https://github.com/openshiftio/openshift.io/issues/2521

This patch causes the Y axis for the CPU and Memory Sparkline charts to be scaled so that the maximum value of the axis is the largest of the usage and quota values for the metric over the sampling window, rather than simply the largest usage value. The change in behaviour is documented in the linked issue.