### PR TITLE
Deployments warning indicators

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.html
+++ b/src/app/space/create/deployments/apps/deployment-card.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="active">
   <div class="card-pf" (click)="toggleCollapsed($event)">
     <div class="card-pf-body">
-      <div class="row mini-card-content">
+      <div class="row mini-card-content" [ngClass]="cardStatusClass">
         <div class="col-sm-2">
           <deployment-status-icon [iconClass]="iconClass" [toolTip]="toolTip"></deployment-status-icon>
         </div>

--- a/src/app/space/create/deployments/apps/deployment-card.component.less
+++ b/src/app/space/create/deployments/apps/deployment-card.component.less
@@ -12,16 +12,17 @@
   justify-content: center;
 }
 
-.status-ribbon-warn {
-  border-left-style: solid;
-  border-left-width: 4px;
-  border-left-color: @color-pf-orange-300;
-}
-
-.status-ribbon-err {
-  border-left-style: solid;
-  border-left-width: 4px;
-  border-left-color: @color-pf-red-100;
+.status-ribbon {
+  &-warn {
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-left-color: @color-pf-orange-300;
+  }
+  &-err {
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-left-color: @color-pf-red-100;
+  }
 }
 
 .deployment-dropdown {

--- a/src/app/space/create/deployments/apps/deployment-card.component.less
+++ b/src/app/space/create/deployments/apps/deployment-card.component.less
@@ -12,6 +12,18 @@
   justify-content: center;
 }
 
+.status-ribbon-warn {
+  border-left-style: solid;
+  border-left-width: 4px;
+  border-left-color: @color-pf-orange-300;
+}
+
+.status-ribbon-err {
+  border-left-style: solid;
+  border-left-width: 4px;
+  border-left-color: @color-pf-red-100;
+}
+
 .deployment-dropdown {
   transform: translateY(2em);
 }

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -278,13 +278,16 @@ describe('DeploymentCardComponent', () => {
     expect(mockStatusSvc.getAggregateStatus).toHaveBeenCalledWith('mockSpaceId', 'mockEnvironment', 'mockAppId');
     expect(this.testedDirective.toolTip).toEqual('warning message');
     expect(this.testedDirective.iconClass).toEqual('pficon-warning-triangle-o');
+    expect(this.testedDirective.cardStatusClass).toEqual('status-ribbon-warn');
 
     mockStatus.next({ type: StatusType.ERR, message: 'error message' });
     expect(this.testedDirective.toolTip).toEqual('error message');
     expect(this.testedDirective.iconClass).toEqual('pficon-error-circle-o');
+    expect(this.testedDirective.cardStatusClass).toEqual('status-ribbon-err');
 
     mockStatus.next({ type: StatusType.OK, message: '' });
     expect(this.testedDirective.toolTip).toEqual('Everything is OK.');
     expect(this.testedDirective.iconClass).toEqual('pficon-ok');
+    expect(this.testedDirective.cardStatusClass).toEqual('');
   });
 });

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -24,6 +24,12 @@ import {
 import { DeploymentsService } from '../services/deployments.service';
 import { DeploymentStatusIconComponent } from './deployment-status-icon.component';
 
+enum CardStatusClass {
+  OK = '',
+  WARN = 'status-ribbon-warn',
+  ERR = 'status-ribbon-err'
+}
+
 @Component({
   selector: 'deployment-card',
   templateUrl: 'deployment-card.component.html',
@@ -45,6 +51,8 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
   logsUrl: Observable<string>;
   consoleUrl: Observable<string>;
   appUrl: Observable<string>;
+
+  cardStatusClass: string;
 
   iconClass: string;
   toolTip: string;
@@ -103,10 +111,13 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
     this.toolTip = toolTip;
 
     if (status.type === StatusType.ERR) {
+      this.cardStatusClass = CardStatusClass.ERR;
       this.iconClass = DeploymentStatusIconComponent.CLASSES.ICON_ERR;
     } else if (status.type === StatusType.WARN) {
+      this.cardStatusClass = CardStatusClass.WARN;
       this.iconClass = DeploymentStatusIconComponent.CLASSES.ICON_WARN;
     } else {
+      this.cardStatusClass = CardStatusClass.OK;
       this.iconClass = DeploymentStatusIconComponent.CLASSES.ICON_OK;
     }
   }

--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -6,21 +6,21 @@
     <ng-container *ngIf="hasPods | async">
       <p class="resource-usage-header">Resource Usage</p>
 
-      <div class="deployment-chart">
+      <div class="deployment-chart" [ngClass]="cpuChartClass">
         <div class="chart-column-left">
           <pfng-chart-sparkline class="chart-sparkline" [config]="cpuConfig" [chartData]="cpuData"></pfng-chart-sparkline>
         </div>
         <div class="chart-column-right">
-          <deployment-graph-label type="CPU" dataMeasure="Cores" [value]="cpuVal" [valueUpperBound]="cpuMax"></deployment-graph-label>
+          <deployment-graph-label [ngClass]="cpuLabelClass" type="CPU" dataMeasure="Cores" [value]="cpuVal" [valueUpperBound]="cpuMax"></deployment-graph-label>
         </div>
       </div>
 
-      <div class="deployment-chart">
+      <div class="deployment-chart" [ngClass]="memChartClass">
         <div class="chart-column-left">
           <pfng-chart-sparkline class="chart-sparkline" [config]="memConfig" [chartData]="memData"></pfng-chart-sparkline>
         </div>
         <div class="chart-column-right">
-          <deployment-graph-label type="Memory" [dataMeasure]="memUnits" [value]="memVal" [valueUpperBound]="memMax"></deployment-graph-label>
+          <deployment-graph-label [ngClass]="memLabelClass" type="Memory" [dataMeasure]="memUnits" [value]="memVal" [valueUpperBound]="memMax"></deployment-graph-label>
         </div>
       </div>
 

--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -8,7 +8,7 @@
         Resource Usage
         <span class="badge resource-badge" *ngIf="usageMessage">
           <span class="pficon-warning-triangle-o"></span>
-          {{usageMessage}}
+          {{ usageMessage }}
         </span>
       </p>
 

--- a/src/app/space/create/deployments/apps/deployment-details.component.html
+++ b/src/app/space/create/deployments/apps/deployment-details.component.html
@@ -4,7 +4,13 @@
     <deployments-donut [applicationId]="applicationId" [environment]="environment" [spaceId]="spaceId" [mini]="false"></deployments-donut>
 
     <ng-container *ngIf="hasPods | async">
-      <p class="resource-usage-header">Resource Usage</p>
+      <p class="resource-usage-header">
+        Resource Usage
+        <span class="badge resource-badge" *ngIf="usageMessage">
+          <span class="pficon-warning-triangle-o"></span>
+          {{usageMessage}}
+        </span>
+      </p>
 
       <div class="deployment-chart" [ngClass]="cpuChartClass">
         <div class="chart-column-left">

--- a/src/app/space/create/deployments/apps/deployment-details.component.less
+++ b/src/app/space/create/deployments/apps/deployment-details.component.less
@@ -37,24 +37,26 @@
   border-color: #fef5eb;
 }
 
-.chart-warn {
-  border-left-style: solid;
-  border-left-width: 4px;
-  border-left-color: @color-pf-orange-300;
-  padding-left: 12px;
+.chart {
+  &-warn {
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-left-color: @color-pf-orange-300;
+    padding-left: 12px;
+  }
+  &-err {
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-left-color: @color-pf-red-100;
+    padding-left: 12px;
+  }
 }
 
-.chart-err {
-  border-left-style: solid;
-  border-left-width: 4px;
-  border-left-color: @color-pf-red-100;
-  padding-left: 12px;
-}
-
-.label-warn {
-  color: @color-pf-orange;
-}
-
-.label-err {
-  color: @color-pf-red-100;
+.label {
+  &-warn {
+    color: @color-pf-orange;
+  }
+  &-err {
+    color: @color-pf-red-100;
+  }
 }

--- a/src/app/space/create/deployments/apps/deployment-details.component.less
+++ b/src/app/space/create/deployments/apps/deployment-details.component.less
@@ -27,6 +27,16 @@
   }
 }
 
+.resource-badge {
+  background: #fef5eb;
+  color: black;
+  font-weight: 200;
+  font-size: 1em !important;
+  border-style: solid;
+  border-width: 3px;
+  border-color: #fef5eb;
+}
+
 .chart-warn {
   border-left-style: solid;
   border-left-width: 4px;

--- a/src/app/space/create/deployments/apps/deployment-details.component.less
+++ b/src/app/space/create/deployments/apps/deployment-details.component.less
@@ -2,6 +2,8 @@
 
 .deployment-chart {
   display: flex;
+  margin-left: -20px;
+  padding-left: 16px;
 }
 
 .resource-usage-header {
@@ -23,4 +25,26 @@
   &-right {
     width: 35%;
   }
+}
+
+.chart-warn {
+  border-left-style: solid;
+  border-left-width: 4px;
+  border-left-color: @color-pf-orange-300;
+  padding-left: 12px;
+}
+
+.chart-err {
+  border-left-style: solid;
+  border-left-width: 4px;
+  border-left-color: @color-pf-red-100;
+  padding-left: 12px;
+}
+
+.label-warn {
+  color: @color-pf-orange;
+}
+
+.label-err {
+  color: @color-pf-red-100;
 }

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -23,6 +23,7 @@ import { Environment } from '../models/environment';
 import { MemoryStat } from '../models/memory-stat';
 import { Pods } from '../models/pods';
 import { ScaledNetworkStat } from '../models/scaled-network-stat';
+import { DeploymentStatusService, StatusType } from '../services/deployment-status.service';
 import {
   DeploymentsService,
   NetworkStat
@@ -33,6 +34,7 @@ import { times } from 'lodash';
 
 // Makes patternfly charts available
 import {
+  ChartDefaults,
   ChartModule,
   SparklineConfig,
   SparklineData
@@ -99,6 +101,7 @@ class FakeDeploymentsLinechart {
 describe('DeploymentDetailsComponent', () => {
   type Context = TestContext<DeploymentDetailsComponent, HostComponent>;
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
+  let mockStatusSvc: jasmine.SpyObj<DeploymentStatusService>;
   let cpuStatObservable: BehaviorSubject<CpuStat[]>;
   let memStatObservable: BehaviorSubject<MemoryStat[]>;
   let netStatObservable: BehaviorSubject<NetworkStat[]>;
@@ -128,6 +131,11 @@ describe('DeploymentDetailsComponent', () => {
     mockSvc.deleteApplication.and.returnValue(Observable.of('mockDeletedMessage'));
     mockSvc.getDeploymentNetworkStat.and.returnValue(netStatObservable);
     mockSvc.getPods.and.returnValue(podsObservable);
+
+    mockStatusSvc = createMock(DeploymentStatusService);
+    mockStatusSvc.getAggregateStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: 'Memory usage is nearing capacity.' }));
+    mockStatusSvc.getCpuStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
+    mockStatusSvc.getMemoryStatus.and.returnValue(Observable.of({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' }));
   });
 
   initContext(DeploymentDetailsComponent, HostComponent, {
@@ -139,7 +147,9 @@ describe('DeploymentDetailsComponent', () => {
       FakeDeploymentsLinechart
     ],
     providers: [
-      { provide: DeploymentsService, useFactory: () => mockSvc }
+      { provide: DeploymentsService, useFactory: () => mockSvc },
+      { provide: DeploymentStatusService, useFactory: () => mockStatusSvc },
+      { provide: ChartDefaults, useValue: { getDefaultSparklineColor: () => ({}) } }
     ]
   });
 
@@ -157,13 +167,11 @@ describe('DeploymentDetailsComponent', () => {
     expect(container.applicationId).toEqual('mockAppId');
   });
 
-  describe('hasPods', () => {
-    it('should be false for state without pods', function(this: Context, done: DoneFn) {
-      podsObservable.next({ total: 0, pods: [] });
-      this.testedDirective.hasPods.subscribe((b: boolean) => {
-        expect(b).toBeFalsy();
-        done();
-      });
+  it('should set hasPods to false for state without pods', function(this: Context, done: DoneFn) {
+    podsObservable.next({ total: 0, pods: [] });
+    this.testedDirective.hasPods.subscribe((b: boolean) => {
+      expect(b).toBeFalsy();
+      done();
     });
   });
 
@@ -191,6 +199,11 @@ describe('DeploymentDetailsComponent', () => {
     it('should use upper bound from service result', () => {
       expect(de.componentInstance.valueUpperBound).toEqual(2);
     });
+
+    it('should be set to OK (empty) class status', function(this: Context) {
+      expect(this.testedDirective.cpuLabelClass).toEqual('');
+      expect(this.testedDirective.cpuChartClass).toEqual('');
+    });
   });
 
   describe('memory label', () => {
@@ -213,6 +226,11 @@ describe('DeploymentDetailsComponent', () => {
 
     it('should use upper bound from service result', () => {
       expect(de.componentInstance.valueUpperBound).toEqual(4);
+    });
+
+    it('should be set to WARN class status', function(this: Context) {
+      expect(this.testedDirective.memLabelClass).toEqual('label-warn');
+      expect(this.testedDirective.memChartClass).toEqual('chart-warn');
     });
   });
 

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -64,7 +64,9 @@ export class DeploymentDetailsComponent {
   @Input() environment: Environment;
   @Input() spaceId: string;
 
-  subscriptions: Array<Subscription> = [];
+  usageMessage: string = '';
+
+  private readonly subscriptions: Array<Subscription> = [];
 
   cpuData: SparklineData = {
     dataAvailable: true,
@@ -154,6 +156,19 @@ export class DeploymentDetailsComponent {
       this.deploymentsService.getPods(this.spaceId, this.applicationId, this.environment.name)
         .map((p: Pods) => p.total > 0)
         .subscribe(this.hasPods)
+    );
+
+    this.subscriptions.push(
+      this.deploymentStatusService.getAggregateStatus(this.spaceId, this.environment.name, this.applicationId)
+        .subscribe((status: Status): void => {
+          if (status.type === StatusType.OK) {
+            this.usageMessage = '';
+          } else if (status.type === StatusType.WARN) {
+            this.usageMessage = 'Nearing quota';
+          } else if (status.type === StatusType.ERR) {
+            this.usageMessage = 'Reached quota';
+          }
+        })
     );
 
     this.subscriptions.push(

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
@@ -1,12 +1,12 @@
 <div class="progress-container progress-description-left progress-label-right">
-  <div class="progress-description">
+  <div class="progress-description" [ngClass]="{ 'label-warn': warn }">
     {{ resourceTitle }} ({{ resourceUnit }})
   </div>
   <div class="progress">
     <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"
-      [ngClass]="getUtilizationClass()"
+      [ngClass]="warn ? 'utilization-warning' : 'utilization-okay'"
       [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
-      <span><b id="resourceCardLabel">{{ used }} of {{ total }}</b></span>
+      <span><b id="resourceCardLabel" [ngClass]="{ 'label-warn': warn }">{{ used }} of {{ total }}</b></span>
     </div>
     <div class="progress-bar progress-bar-remaining" role="progressbar" [attr.aria-valuenow]="unusedPercent" aria-valuemin="0" aria-valuemax="100"
       [style.width]="unusedPercent + '%'" data-toggle="tooltip" title="{{ unusedPercent }}% Available">

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.less
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.less
@@ -8,3 +8,7 @@
     background: @color-pf-orange-300;
   }
 }
+
+.label-warn {
+  color: @color-pf-orange-400;
+}

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -5,10 +5,7 @@ import { Observable } from 'rxjs';
 import { initContext, TestContext } from 'testing/test-context';
 
 import { Stat } from '../models/stat';
-import {
-  State,
-  UtilizationBarComponent
-} from './utilization-bar.component';
+import { UtilizationBarComponent } from './utilization-bar.component';
 
 @Component({
   template: '<utilization-bar></utilization-bar>'
@@ -44,13 +41,13 @@ describe('UtilizationBarComponent', () => {
       expect(el.textContent.trim()).toEqual('1 of 4');
     });
 
-    it('should set state to okay when under 75% used', function(this: Context) {
-      expect(this.testedDirective.getUtilizationClass()).toEqual(State.Okay);
+    it('should clear warning when under 60% used', function(this: Context) {
+      expect(this.testedDirective.warn).toBeFalsy();
 
-      let de = this.fixture.debugElement.query(By.css(`.${State.Okay}`));
+      let de = this.fixture.debugElement.query(By.css(`.utilization-okay`));
       expect(de).toBeTruthy();
 
-      let de2 = this.fixture.debugElement.query(By.css(`.${State.Warning}`));
+      let de2 = this.fixture.debugElement.query(By.css(`.utilization-warning`));
       expect(de2).toBeFalsy();
     });
   });
@@ -81,13 +78,13 @@ describe('UtilizationBarComponent', () => {
       expect(el.textContent.trim()).toEqual('3 of 4');
     });
 
-    it('should set state to warning to false when 75% or higher used', function(this: Context) {
-      expect(this.testedDirective.getUtilizationClass()).toEqual(State.Warning);
+    it('should set warning 60% or higher used', function(this: Context) {
+      expect(this.testedDirective.warn).toBeTruthy();
 
-      let de = this.fixture.debugElement.query(By.css(`.${State.Okay}`));
+      let de = this.fixture.debugElement.query(By.css(`.utilization-okay`));
       expect(de).toBeFalsy();
 
-      let de2 = this.fixture.debugElement.query(By.css(`.${State.Warning}`));
+      let de2 = this.fixture.debugElement.query(By.css(`.utilization-warning`));
       expect(de2).toBeTruthy();
     });
   });

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -8,11 +8,7 @@ import {
 import { Observable, Subscription } from 'rxjs';
 
 import { Stat } from '../models/stat';
-
-export enum State {
-  Okay = 'utilization-okay',
-  Warning = 'utilization-warning'
-}
+import { DeploymentStatusService } from '../services/deployment-status.service';
 
 @Component({
   selector: 'utilization-bar',
@@ -25,39 +21,28 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   @Input() resourceUnit: string;
   @Input() stat: Observable<Stat>;
 
-  private static readonly WARNING_THRESHOLD = 75;
+  warn: boolean = false;
 
   used: number;
   total: number;
   usedPercent: number;
   unusedPercent: number;
 
-  private currentState: State;
   private statSubscription: Subscription;
 
   ngOnInit(): void {
-    this.currentState = State.Okay;
-
-    this.statSubscription = this.stat.subscribe(val => {
+    this.statSubscription = this.stat.subscribe((val: Stat): void => {
       this.used = val.used;
       this.total = val.quota;
       this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
       this.unusedPercent = 100 - this.usedPercent;
 
-      if (this.usedPercent < UtilizationBarComponent.WARNING_THRESHOLD) {
-        this.currentState = State.Okay;
-      } else {
-        this.currentState = State.Warning;
-      }
+      this.warn = val.used / val.quota >= DeploymentStatusService.WARNING_THRESHOLD;
     });
   }
 
   ngOnDestroy(): void {
     this.statSubscription.unsubscribe();
-  }
-
-  getUtilizationClass(): State {
-    return this.currentState;
   }
 
 }


### PR DESCRIPTION
https://github.com/openshiftio/openshift.io/issues/2520

These patches modify the Deployments page deployment and resource usage cards to show more warning/error indicators when resources are nearing quotas, as shown in the updated designs docs linked in the above issue.

Before, without warning:
![screenshot from 2018-03-12 12-51-14](https://user-images.githubusercontent.com/3787464/37297624-85b4196c-25f4-11e8-9a05-f5e6de1be701.png)

Before, with warning (forced by setting warning threshold to 10% in local build):
![screenshot from 2018-03-12 13-07-57](https://user-images.githubusercontent.com/3787464/37298344-667e4138-25f6-11e8-9aa2-5c614a683a43.png)

After (forced warning in local build):
![screenshot from 2018-03-12 12-52-03](https://user-images.githubusercontent.com/3787464/37297651-91d8f122-25f4-11e8-9d57-109c2a74d992.png)

(After without warning looks identical to Before without warning)

One difference in the implemented "After" screenshot vs the design is the size of the warning "ribbon" on a deployment card's left edge. In the design mock this ribbon is the full height of the card component. In the actual implementation, it is only the height of the inner card content component. This is because the card component grows in height when expanded to display its charts, so implementing the ribbon to take the entire left edge results in the ribbon expanding down the length of the card when expanded as well. This should be fixable but will require some refactoring of the card component to support, so I have left it out for now. If it looks good as-is then great, otherwise I will add a commit on top of this changeset to refactor the card component so that it's possible to highlight the entire collapsed height without highlighting the expanded height.