### PR TITLE
fix(deployments): truncate graph labels for width constraint

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-graph-label.component.html
+++ b/src/app/space/create/deployments/apps/deployment-graph-label.component.html
@@ -1,7 +1,7 @@
 <div class="chart-text">
   <p class="chart-info-header">{{ type }} ({{ dataMeasure }})</p>
-  <p *ngIf="valueUpperBound; else noLimit">{{ value }} of {{ valueUpperBound }}</p>
+  <p *ngIf="valueUpperBound; else noLimit">{{ value | number }} of {{ valueUpperBound | number }}</p>
   <ng-template #noLimit>
-    <p>{{ value }} {{ dataMeasure }}</p>
+    <p>{{ value | number }} {{ dataMeasure }}</p>
   </ng-template>
 </div>


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/2541

This uses the Angular "number" pipe (`DecimalPipe`: https://angular.io/api/common/DecimalPipe) to display a maximum number of fraction digits so that numbers like 2.0000001 don't force the text too wide for the card width.