### PR TITLE
Added ids to pod status entires.

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.html
@@ -14,7 +14,7 @@
     <ng-template #elsePods>
       <div>
         Pod status:
-        <li *ngFor="let column of pods.pods">
+        <li *ngFor="let column of pods.pods"  [attr.id]="'pod_status_' + column[0]">
           <span>{{ column[1] ? column[1] + ' ' + column[0] : '0 ' + column[0] }}</span>
         </li>
       </div>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut-chart/deployments-donut-chart.component.spec.ts
@@ -70,6 +70,16 @@ describe('DeploymentsDonutChartComponent', () => {
       expect(textEl.innerText).toEqual('2 pods');
     });
 
+    it('should show pods status', function(this: Context) {
+      let runningText = this.fixture.debugElement.query(By.css('#pod_status_Running'));
+      expect(runningText).toBeTruthy();
+      expect(runningText.nativeElement.innerText).toBe('1 Running');
+
+      let terminating = this.fixture.debugElement.query(By.css('#pod_status_Terminating'));
+      expect(terminating).toBeTruthy();
+      expect(terminating.nativeElement.innerText).toBe('1 Terminating');
+    });
+
     describe('Mini Idle chart', () => {
       beforeEach(function(this: Context) {
         this.hostComponent.isIdled = true;


### PR DESCRIPTION
I need to add some ids to the Deployments page for E2E testing. I've tried to do it myself but I am not sure if it works correctly and/or it is done right. So, any inputs would be appreciated. 