### PR TITLE
fix(codebases): handle missing GitHub repos

### DIFF
--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -3,14 +3,18 @@
     <span class="fa fa-ellipsis-v"></span>
   </button>
   <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
-    <li [ngClass]="{'disabled': workspaceBusy}"
-        [attr.role]="menuitem">
-      <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="!workspaceBusy"
+    <li [ngClass]="{'disabled': workspaceBusy || !codebase.gitHubRepo}"
+        [attr.role]="'menuitem'">
+      <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="!workspaceBusy && codebase.gitHubRepo; else createDisabled"
          (click)="createAndOpenWorkspace()">Create workspace</a>
-      <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="workspaceBusy"
-         tooltip="Waiting for Che..." disabled>Create workspace</a>
+      <ng-template #createDisabled>
+        <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="workspaceBusy"
+          tooltip="Waiting for Che..." disabled>Create workspace</a>
+        <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="!codebase.gitHubRepo"
+          tooltip="GitHub repository is not accessible" disabled>Create workspace</a>
+      </ng-template>
     </li>
-    <li [attr.role]="menuitem">
+    <li [attr.role]="'menuitem'">
       <a href="javascript:void(0)" class="dropdown-item secondary-action"
          (click)="confirmDeleteCodebase($event)">Remove codebase</a>
     </li>

--- a/src/app/space/create/codebases/codebases-item-details/codebases-item-details.component.html
+++ b/src/app/space/create/codebases/codebases-item-details/codebases-item-details.component.html
@@ -6,13 +6,14 @@
     </dl>
     <dl class="dl-horizontal" *ngIf="!isHtmlUrlInvalid()">
       <dt>Git URL</dt>
-      <dd><a [href]="htmlUrl" target="_blank">{{gitUrl}}</a></dd>
+      <dd><a [href]="codebase.gitHubRepo?.htmlUrl || codebase.name" target="_blank">{{gitUrl || codebase.name}}</a></dd>
       <dt>Latest Commit SHA1</dt>
-      <dd>{{lastCommit}}</dd>
+      <dd>{{lastCommit || 'Unavailable'}}</dd>
       <dt>Status</dt>
-      <dd>{{filesChanged}} total files changed</dd>
+      <dd *ngIf="codebase.gitHubRepo && lastCommit">{{filesChanged}} total files changed</dd>
+      <dd *ngIf="!codebase.gitHubRepo">GitHub repository is not accessible</dd>
       <dt>License</dt>
-      <dd>{{license || 'None'}}</dd>
+      <dd>{{license || 'Unavailable'}}</dd>
     </dl>
   </div>
 </div>

--- a/src/app/space/create/codebases/codebases-item-details/codebases-item-details.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item-details/codebases-item-details.component.spec.ts
@@ -3,7 +3,6 @@ import { async, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
-import { Logger } from 'ngx-base';
 import { Contexts } from 'ngx-fabric8-wit';
 import { Observable } from 'rxjs';
 
@@ -18,7 +17,6 @@ describe('Codebases Item Details Component', () => {
 
   beforeEach(() => {
     gitHubServiceMock = jasmine.createSpyObj('GitHubService', ['getRepoDetailsByUrl', 'getRepoLastCommitByUrl', 'getRepoCommitStatusByUrl', 'getRepoLicenseByUrl']);
-    loggerMock = jasmine.createSpy('Logger');
 
     TestBed.configureTestingModule({
       imports: [FormsModule, HttpModule],
@@ -29,9 +27,6 @@ describe('Codebases Item Details Component', () => {
         },
         {
           provide: GitHubService, useValue: gitHubServiceMock
-        },
-        {
-          provide: Logger, useValue: loggerMock
         }
       ],
       // Tells the compiler not to error on unknown elements and attributes
@@ -40,10 +35,22 @@ describe('Codebases Item Details Component', () => {
     fixture = TestBed.createComponent(CodebasesItemDetailsComponent);
   });
 
-  it('Init component', async(() => {
+  it('Init component with valid gitHubRepo', async(() => {
     // given
     let comp = fixture.componentInstance;
-    comp.codebase = { 'id': '6f5b6738-170e-490e-b3bb-d10f56b587c8', attributes: { type: 'git', url: 'toto/toto' } };
+    comp.codebase = {
+      'id': '6f5b6738-170e-490e-b3bb-d10f56b587c8',
+      attributes: {
+        type: 'git',
+        url: 'toto/toto'
+      },
+      gitHubRepo: {
+        htmlUrl: 'htmlUrl',
+        fullName: 'fullName',
+        createdAt: 'createdAt',
+        pushedAt: 'pushedAt'
+      }
+    };
     const expectedLastCommit = {
       'ref': '',
       'url': 'toto/toto',
@@ -66,6 +73,32 @@ describe('Codebases Item Details Component', () => {
     expect(gitHubServiceMock.getRepoLastCommitByUrl).toHaveBeenCalled();
     expect(gitHubServiceMock.getRepoLicenseByUrl).toHaveBeenCalled();
     expect(gitHubServiceMock.getRepoCommitStatusByUrl).toHaveBeenCalled();
+
+    expect(comp.codebase.gitHubRepo.createdAt).toEqual(expectedGitHubRepoDetails.created_at);
+    expect(comp.codebase.gitHubRepo.fullName).toEqual(expectedGitHubRepoDetails.full_name);
+    expect(comp.codebase.gitHubRepo.htmlUrl).toEqual(expectedGitHubRepoDetails.html_url);
+    expect(comp.codebase.gitHubRepo.pushedAt).toEqual(expectedGitHubRepoDetails.pushed_at);
+  }));
+
+  it('Init component without valid gitHubRepo', async(() => {
+    // given
+    let comp = fixture.componentInstance;
+    comp.codebase = {
+      'id': '6f5b6738-170e-490e-b3bb-d10f56b587c8',
+      attributes: {
+        type: 'git',
+        url: 'toto/toto'
+      }
+    };
+    fixture.detectChanges();
+
+    // when init
+
+    // then
+    expect(gitHubServiceMock.getRepoDetailsByUrl).not.toHaveBeenCalled();
+    expect(gitHubServiceMock.getRepoLastCommitByUrl).not.toHaveBeenCalled();
+    expect(gitHubServiceMock.getRepoLicenseByUrl).not.toHaveBeenCalled();
+    expect(gitHubServiceMock.getRepoCommitStatusByUrl).not.toHaveBeenCalled();
   }));
 
 });

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.html
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.html
@@ -1,16 +1,30 @@
 <div class="list-pf-left">
     <span class="fa list-pf-icon list-pf-icon-bordered list-pf-icon-small"
-          [ngClass]="{'fa-github': codebase?.attributes?.type === 'git'}"></span>
+          [ngClass]="{
+            'list-pf-icon-bordered': codebase?.gitHubRepo && codebase?.attributes?.type === 'git',
+            'fa-github': codebase?.gitHubRepo && codebase?.attributes?.type === 'git',
+            'pficon-error-circle-o': !codebase?.gitHubRepo
+            }"></span>
 </div>
 <div class="list-pf-content-wrapper">
   <div class="list-pf-main-content">
-    <div class="list-pf-title">
-      <a [href]="codebase.gitHubRepo.htmlUrl" target="_blank">{{codebase.gitHubRepo.fullName}}</a>
-    </div>
-    <div class="list-pf-description">{{codebase.gitHubRepo.createdAt | date:'medium'}}</div>
-    <div class="list-pf-description">{{codebase.gitHubRepo.pushedAt | date:'medium'}}</div>
+    <ng-template *ngIf="codebase.gitHubRepo then valid; else invalid"></ng-template>
+    <ng-template #invalid>
+      <div class="list-pf-title">
+        <a [href]="codebase.name" target="_blank">{{codebase.name}}</a>
+      </div>
+      <div class="list-pf-description">Unavailable</div>
+      <div class="list-pf-description">Unavailable</div>
+    </ng-template>
+    <ng-template #valid>
+      <div class="list-pf-title">
+        <a [href]="codebase.gitHubRepo.htmlUrl" target="_blank">{{codebase.gitHubRepo.fullName}}</a>
+      </div>
+      <div class="list-pf-description">{{codebase.gitHubRepo.createdAt | date:'medium'}}</div>
+      <div class="list-pf-description">{{codebase.gitHubRepo.pushedAt | date:'medium'}}</div>
+    </ng-template>
   </div>
   <div class="list-pf-additional-content">
-    <codebases-item-workspaces [codebase]="codebase" [index]="index" *ngIf="cheState && cheState.running"></codebases-item-workspaces>
+    <codebases-item-workspaces [codebase]="codebase" [index]="index" *ngIf="cheState && cheState.running && codebase.gitHubRepo"></codebases-item-workspaces>
   </div>
 </div>

--- a/src/app/space/create/codebases/codebases.component.spec.ts
+++ b/src/app/space/create/codebases/codebases.component.spec.ts
@@ -216,7 +216,7 @@ describe('CodebasesComponent', () => {
   });
 
   describe('GitHub repo details', () => {
-    it('should filter Codebases where GitHub repo no longer exists', function(this: TestingContext) {
+    it('should handle Codebases where GitHub repo no longer exists', function(this: TestingContext) {
       broadcastSubject.next();
       codebasesSubject.next([
         {
@@ -231,13 +231,19 @@ describe('CodebasesComponent', () => {
         } as Codebase
       ]);
       codebasesSubject.complete();
-      expect(this.testedDirective.allCodebases.length).toEqual(1);
-      const codebase: Codebase = this.testedDirective.allCodebases[0];
-      expect(codebase.attributes.url).toEqual('https://github.com/foo-org/foo-project.git');
-      expect(codebase.gitHubRepo.htmlUrl).toEqual('https://github.com/foo-org/foo-project/html');
-      expect(codebase.gitHubRepo.fullName).toEqual('Foo Project');
-      expect(codebase.gitHubRepo.createdAt).toEqual('123');
-      expect(codebase.gitHubRepo.pushedAt).toEqual('456');
+
+      expect(this.testedDirective.allCodebases.length).toEqual(2);
+
+      const first: Codebase = this.testedDirective.allCodebases[0];
+      expect(first.attributes.url).toEqual('https://github.com/foo-org/foo-project.git');
+      expect(first.gitHubRepo.htmlUrl).toEqual('https://github.com/foo-org/foo-project/html');
+      expect(first.gitHubRepo.fullName).toEqual('Foo Project');
+      expect(first.gitHubRepo.createdAt).toEqual('123');
+      expect(first.gitHubRepo.pushedAt).toEqual('456');
+
+      const second: Codebase = this.testedDirective.allCodebases[1];
+      expect(second.attributes.url).toEqual('https://github.com/foo-org/bar-project.git');
+      expect(second.gitHubRepo).not.toBeDefined();
     });
   });
 

--- a/src/app/space/create/codebases/codebases.component.spec.ts
+++ b/src/app/space/create/codebases/codebases.component.spec.ts
@@ -1,0 +1,244 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output
+} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+  ActionModule,
+  EmptyStateModule,
+  ListModule
+} from 'patternfly-ng';
+
+import {
+  BehaviorSubject,
+  Observable,
+  Subject
+} from 'rxjs';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import {
+  Broadcaster,
+  Notifications
+} from 'ngx-base';
+import {
+  Context,
+  Contexts,
+  ContextType,
+  Space
+} from 'ngx-fabric8-wit';
+import { AuthenticationService } from 'ngx-login-client';
+
+import { ProviderService } from '../../../shared/account/provider.service';
+import { Che } from './services/che';
+import { CheService } from './services/che.service';
+import { CodebasesService } from './services/codebases.service';
+import { GitHubService } from './services/github.service';
+
+import { CodebasesComponent } from './codebases.component';
+import { Codebase } from './services/codebase';
+import { GitHubRepoDetails } from './services/github';
+
+@Component({
+  selector: 'codebases-toolbar',
+  template: ''
+})
+class FakeCodebasesToolbar {
+  @Output('onFilterChange') onFilterChange = new EventEmitter();
+  @Output('onSortChange') onSortChange = new EventEmitter();
+  @Input() resultsCount: number;
+}
+
+@Component({
+  selector: 'codebases-item-heading',
+  template: ''
+})
+class FakeCodebasesItemHeading {
+  @Input() cheState: Che;
+}
+
+@Component({
+  selector: 'codebases-item',
+  template: ''
+})
+class FakeCodebasesItem {
+  @Input() cheState: Che;
+  @Input() codebase: Codebase;
+  @Input() index: number;
+}
+
+@Component({
+  selector: 'codebases-item-actions',
+  template: ''
+})
+class FakeCodebasesItemActions {
+  @Input() cheRunning: boolean;
+  @Input() codebase: Codebase;
+  @Input() index: number = -1;
+}
+
+@Component({
+  selector: 'codebases-item-details',
+  template: ''
+})
+class FakeCodebasesItemDetails {
+  @Input() codebase: Codebase;
+}
+
+@Component({
+  template: '<codebases></codebases>'
+})
+class HostComponent { }
+
+describe('CodebasesComponent', () => {
+  type TestingContext = TestContext<CodebasesComponent, HostComponent>;
+
+  let component: CodebasesComponent;
+  let fixture: ComponentFixture<CodebasesComponent>;
+
+  let broadcaster: jasmine.SpyObj<Broadcaster>;
+  let broadcastSubject: Subject<any>;
+
+  let contexts: Contexts;
+
+  let cheService: jasmine.SpyObj<CheService>;
+
+  let codebasesService: jasmine.SpyObj<CodebasesService>;
+  let codebasesSubject: Subject<Codebase[]>;
+
+  let gitHubService: jasmine.SpyObj<GitHubService>;
+
+  let notifications: jasmine.SpyObj<Notifications>;
+
+  let authenticationService: AuthenticationService;
+
+  let providerService: jasmine.SpyObj<ProviderService>;
+
+  beforeAll(() => {
+    broadcaster = createMock(Broadcaster);
+    broadcastSubject = new Subject<any>();
+    broadcaster.on.and.callFake((event: string): Observable<any> => {
+      if (event === 'CodebaseAdded') {
+        return broadcastSubject;
+      }
+      return Observable.never();
+    });
+
+    contexts = {
+      current: Observable.of({
+        space: {
+          id: 'foo-space'
+        } as Space
+      } as Context)
+    } as Contexts;
+
+    cheService = createMock(CheService);
+    cheService.getState.and.returnValue(Observable.of({ running: false, multiTenant: false }));
+    cheService.start.and.returnValue(Observable.of({ running: true, multiTenant: false }));
+
+    codebasesService = createMock(CodebasesService);
+    codebasesSubject = new BehaviorSubject<Codebase[]>([{
+      attributes: {
+        url: 'https://github.com/foo-org/foo-project.git'
+      }
+    } as Codebase]);
+    codebasesService.getCodebases.and.returnValue(codebasesSubject);
+
+    gitHubService = createMock(GitHubService);
+    gitHubService.clearCache.and.stub();
+    gitHubService.ngOnDestroy.and.stub();
+    gitHubService.getRepoDetailsByUrl.and.callFake((url: string): Observable<GitHubRepoDetails> => {
+      if (url === 'https://github.com/foo-org/foo-project.git') {
+        const details: GitHubRepoDetails = new GitHubRepoDetails();
+        details.html_url = 'https://github.com/foo-org/foo-project/html';
+        details.full_name = 'Foo Project';
+        details.created_at = '123';
+        details.pushed_at = '456';
+        return Observable.of(details);
+      } else if (url === 'https://github.com/foo-org/bar-project.git') {
+        return Observable.throw(new Error('404 error'));
+      } else {
+        throw new Error('Unexpected codebase URL');
+      }
+    });
+
+    notifications = createMock(Notifications);
+    notifications.message.and.stub();
+
+    authenticationService = {
+      gitHubToken: Observable.of('github-token')
+    } as AuthenticationService;
+
+    providerService = createMock(ProviderService);
+    providerService.linkGitHub.and.stub();
+  });
+
+  beforeEach(async(() => {
+    TestBed.overrideProvider(CheService, { useFactory: () => cheService, deps: [] });
+    TestBed.overrideProvider(CodebasesService, { useFactory: () => codebasesService, deps: [] });
+    TestBed.overrideProvider(GitHubService, { useFactory: () => gitHubService, deps: [] });
+  }));
+
+  initContext(CodebasesComponent, HostComponent, {
+    providers: [
+      { provide: Broadcaster, useFactory: () => broadcaster },
+      { provide: Contexts, useFactory: () => contexts },
+      { provide: Notifications, useFactory: () => notifications },
+      { provide: AuthenticationService, useFactory: () => authenticationService },
+      { provide: ProviderService, useFactory: () => providerService }
+    ],
+    declarations: [
+      FakeCodebasesToolbar,
+      FakeCodebasesItemHeading,
+      FakeCodebasesItem,
+      FakeCodebasesItemActions,
+      FakeCodebasesItemDetails
+    ],
+    imports: [
+      ActionModule,
+      EmptyStateModule,
+      ListModule,
+      RouterTestingModule.withRoutes([])
+    ]
+  });
+
+  describe('GitHub repo details', () => {
+    it('should filter Codebases where GitHub repo no longer exists', function(this: TestingContext) {
+      broadcastSubject.next();
+      codebasesSubject.next([
+        {
+          attributes: {
+            url: 'https://github.com/foo-org/foo-project.git'
+          }
+        } as Codebase,
+        {
+          attributes: {
+            url: 'https://github.com/foo-org/bar-project.git'
+          }
+        } as Codebase
+      ]);
+      codebasesSubject.complete();
+      expect(this.testedDirective.allCodebases.length).toEqual(1);
+      const codebase: Codebase = this.testedDirective.allCodebases[0];
+      expect(codebase.attributes.url).toEqual('https://github.com/foo-org/foo-project.git');
+      expect(codebase.gitHubRepo.htmlUrl).toEqual('https://github.com/foo-org/foo-project/html');
+      expect(codebase.gitHubRepo.fullName).toEqual('Foo Project');
+      expect(codebase.gitHubRepo.createdAt).toEqual('123');
+      expect(codebase.gitHubRepo.pushedAt).toEqual('456');
+    });
+  });
+
+});

--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -327,17 +327,18 @@ export class CodebasesComponent implements OnDestroy, OnInit {
       return Observable.forkJoin(
         codebases.map((codebase: Codebase) => {
           if (!this.isGitHubHtmlUrlInvalid(codebase)) {
-            return this.gitHubService.getRepoDetailsByUrl(codebase.attributes.url).map(gitHubRepoDetails => {
-              codebase.gitHubRepo = {};
-              codebase.gitHubRepo.htmlUrl = gitHubRepoDetails.html_url;
-              codebase.gitHubRepo.fullName = gitHubRepoDetails.full_name;
-              codebase.gitHubRepo.createdAt = gitHubRepoDetails.created_at;
-              codebase.gitHubRepo.pushedAt = gitHubRepoDetails.pushed_at;
-              return codebase;
-            })
+            return this.gitHubService.getRepoDetailsByUrl(codebase.attributes.url)
+              .map(gitHubRepoDetails => {
+                codebase.gitHubRepo = {};
+                codebase.gitHubRepo.htmlUrl = gitHubRepoDetails.html_url;
+                codebase.gitHubRepo.fullName = gitHubRepoDetails.full_name;
+                codebase.gitHubRepo.createdAt = gitHubRepoDetails.created_at;
+                codebase.gitHubRepo.pushedAt = gitHubRepoDetails.pushed_at;
+                return codebase;
+              })
               .catch(err => {
-                this.handleError(err, NotificationType.WARNING);
-                return Observable.of(null);
+                // this.handleError(err, NotificationType.WARNING);
+                return Observable.of(codebase);
               })
               .first();
           } else {
@@ -346,8 +347,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
         })
       );
     })
-      .last()
-      .map(codebases => codebases.filter(c => c !== null));
+      .last();
   }
 
   /**

--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -334,13 +334,20 @@ export class CodebasesComponent implements OnDestroy, OnInit {
               codebase.gitHubRepo.createdAt = gitHubRepoDetails.created_at;
               codebase.gitHubRepo.pushedAt = gitHubRepoDetails.pushed_at;
               return codebase;
-            }).first();
+            })
+              .catch(err => {
+                this.handleError(err, NotificationType.WARNING);
+                return Observable.of(null);
+              })
+              .first();
           } else {
             this.handleError(`Invalid URL: ${codebase.attributes.url}`, NotificationType.WARNING);
           }
         })
       );
-    }).last();
+    })
+      .last()
+      .map(codebases => codebases.filter(c => c !== null));
   }
 
   /**

--- a/src/app/space/create/codebases/services/github.service.spec.ts
+++ b/src/app/space/create/codebases/services/github.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 import { Headers, HttpModule, Response, ResponseOptions, XHRBackend } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 
-import { Logger } from 'ngx-base';
 import { Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { Observable } from 'rxjs';
@@ -12,13 +11,10 @@ import { GitHubService } from './github.service';
 import { ContextsMock, expectedGitHubRepo, expectedGitHubRepoCommit, expectedGitHubRepoDetails, expectedGitHubRepoLicense } from './github.service.mock';
 
 
-function initTestBed(mockLog, mockAuthService) {
+function initTestBed(mockAuthService) {
   TestBed.configureTestingModule({
     imports: [HttpModule],
     providers: [
-      {
-        provide: Logger, useValue: mockLog
-      },
       {
         provide: Contexts, useClass: ContextsMock
       },
@@ -35,17 +31,15 @@ function initTestBed(mockLog, mockAuthService) {
 }
 
 describe('Github: GitHubService', () => {
-  let mockLog: any;
   let mockContexts: any;
   let mockAuthService: any;
   let mockService: MockBackend;
   let ghService: GitHubService;
 
   beforeEach(() => {
-    mockLog = jasmine.createSpyObj('Logger', ['error']);
     mockContexts = jasmine.createSpy('Contexts');
     mockAuthService = jasmine.createSpyObj('AuthenticationService', ['getToken']);
-    initTestBed(mockLog, mockAuthService);
+    initTestBed(mockAuthService);
     ghService = TestBed.get(GitHubService);
     mockService = TestBed.get(XHRBackend);
     const fakeHeaderObservable = Observable.of({
@@ -404,18 +398,16 @@ describe('Github: GitHubService', () => {
 
 
 describe('Github: GitHubService', () => {
-  let mockLog: any;
   let mockContexts: any;
   let mockAuthService: any;
   let mockService: MockBackend;
   let ghService: GitHubService;
 
   beforeEach(() => {
-    mockLog = jasmine.createSpyObj('Logger', ['error']);
     mockContexts = jasmine.createSpy('Contexts');
     mockAuthService = jasmine.createSpy('AuthenticationService');
     mockAuthService.gitHubToken = Observable.of('XXX');
-    initTestBed(mockLog, mockAuthService);
+    initTestBed(mockAuthService);
     ghService = TestBed.get(GitHubService);
     mockService = TestBed.get(XHRBackend);
   });

--- a/src/app/space/create/codebases/services/github.service.ts
+++ b/src/app/space/create/codebases/services/github.service.ts
@@ -2,7 +2,6 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { Headers, Http } from '@angular/http';
 
 import { cloneDeep } from 'lodash';
-import { Logger } from 'ngx-base';
 import { Context, Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { Observable, Subscription } from 'rxjs';
@@ -37,8 +36,8 @@ export class GitHubService implements OnDestroy {
   constructor(
     private authService: AuthenticationService,
       private contexts: Contexts,
-      private http: Http,
-      private logger: Logger) {
+      private http: Http
+      ) {
     this.subscriptions.push(this.contexts.current.subscribe(val => this.context = val));
     this.gitHubUrl = 'https://api.github.com';
     this.cache = new Map();
@@ -289,7 +288,6 @@ export class GitHubService implements OnDestroy {
   }
 
   private handleError(error: any) {
-    this.logger.error(error);
     return Observable.throw(error.message || error);
   }
 


### PR DESCRIPTION
Handle case where a GitHub repo has been deleted without being removed from a Space by sending a
notification and continuing to process other codebases in the space

fixes https://github.com/openshiftio/openshift.io/issues/2548

The root of the problem is that a Codebase's GitHub repository may disappear, but the existing logic in this component assumes that all Codebases will have a valid GitHub link.

When a repo is deleted the GitHubService `getRepoDetailsByUrl` requests for the repository's URL will fail with a 404. This becomes an error emission on the returned Observable. The component tries to fetch details for all of its known Codebases, which is done sequentially. If any of these requests fail and emits an error then the `Observable.forkJoin` errors out early as well, emitting no `Codebase[]` value, leaving the template in its empty state. The solution here sends a notification to alert the user that some Codebases details are not shown because they could not be retrieved from GitHub and maps the result to `null` instead (rather than an error emission). This allows the `forkJoin` to continue working as expected. The result emitted from the forkJoin is then remapped to filter out the null results so that all that remains are the valid Codebases where the repository details could be fetched from GitHub.