### PR TITLE
fix(webpack): resolve webpack sourcemap and dependency warnings

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -414,7 +414,7 @@ module.exports = function (options) {
        */
       new ContextReplacementPlugin(
         // The (\\|\/) piece accounts for path separators in *nix and Windows
-        /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
+        /(.+)?angular(\\|\/)core(.+)?/,
         path.resolve(__dirname, 'src') // location of your src
       ),
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -150,7 +150,11 @@ module.exports = function (options) {
             helpers.nodeModulePath("ngx-dropdown"),
             helpers.nodeModulePath("ngx-modal"),
             helpers.nodeModulePath("ngx-modal"),
-            helpers.nodeModulePath("ng2-dnd")
+            helpers.nodeModulePath("ng2-dnd"),
+            helpers.nodeModulePath("jw-bootstrap-switch-ng2"),
+            helpers.nodeModulePath("ng2-truncate"),
+            helpers.nodeModulePath("angular-2-dropdown-multiselect"),
+            helpers.nodeModulePath("@angular")
           ],
           use: ["source-map-loader"],
           enforce: "pre"

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <base href="/">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0,">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!-- <title><%= htmlWebpackPlugin.options.title %></title> -->
     <title>Loading...</title>


### PR DESCRIPTION
This PR addresses the warnings in the console when running a local version of f8-ui. This is resolved in two parts: the `ContextReplacementPlugin` regex needed to be updated [0], and there were 5 dependencies that needed to be excluded in the webpack source-map-loader.

Additionally, there was a an extra comma at the end of the name tag in `index.ejs` which was causing the 

> "The key "" is not recognized and ignored."

 warning, and this persists in production so this fix should clean up the console. 

Here are a couple of screen-shots to show what my console looked like before and after this PR:

Before (there were 12 of these warning messages):
![before](https://user-images.githubusercontent.com/10425301/37408923-7ebf7a72-2773-11e8-973c-7a1713d17361.png)

After:
![after](https://user-images.githubusercontent.com/10425301/37408947-8b71c2a2-2773-11e8-9d78-66741f087791.png)

[0] https://github.com/angular/angular/issues/11580#issuecomment-367296829
