### PR TITLE
Hierarchical areas

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "ngx-modal": "0.0.29",
     "ngx-widgets": "2.3.7",
     "offline-plugin": "4.8.4",
-    "patternfly-ng": "3.1.2",
+    "patternfly-ng": "3.1.3",
     "pluralize": "7.0.0",
     "raven-js": "3.22.1",
     "rxjs": "5.5.2",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "ngx-modal": "0.0.29",
     "ngx-widgets": "2.3.7",
     "offline-plugin": "4.8.4",
-    "patternfly-ng": "2.0.5",
+    "patternfly-ng": "3.1.2",
     "pluralize": "7.0.0",
     "raven-js": "3.22.1",
     "rxjs": "5.5.2",

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.html
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.html
@@ -1,0 +1,17 @@
+<div class="toolbar-header">
+  <pfng-toolbar
+      [config]="toolbarConfig"
+      [viewTemplate]="addAreasTemplate"
+      (onFilterChange)="filterChange($event)"
+      (onSortChange)="sortChange($event)">
+    <ng-template #addAreasTemplate>
+      <span class="with-cursor-pointer" placement="top" tooltip="Add Areas"
+            (click)="addArea($event)">
+        <span class="add-codebase-tooltip">
+          <i class="pficon pficon-add-circle-o margin-top-4"></i>
+          Add Areas
+        </span>
+      </span>
+    </ng-template>
+  </pfng-toolbar>
+</div>

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.less
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.less
@@ -1,0 +1,14 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+.toolbar-header {
+  padding: 36px 20px;
+}
+
+.toolbar-pf-action-right {
+  .add-codebase-tooltip {
+    color: @color-pf-blue-400;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.spec.ts
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.spec.ts
@@ -1,0 +1,63 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output
+} from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+  FilterEvent,
+  SortEvent
+} from 'patternfly-ng';
+
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { AreasToolbarComponent } from './areas-toolbar.component';
+
+@Component({
+  template: `<areas-toolbar
+  (onFilterChange)="filterChange($event)"
+  (onSortChange)="sortChange($event)"
+  [resultsCount]="resultsCount">
+  </areas-toolbar>`
+})
+class HostComponent {
+  public resultsCount = 0;
+  public filterChange($event: FilterEvent) { }
+  public sortChange($event: SortEvent) { }
+}
+
+@Component({
+  selector: 'pfng-toolbar',
+  template: ''
+})
+class FakePfngToolbarComponent {
+  @Input() config: any;
+  @Input() viewTemplate: any;
+  @Output() onFilterChange = new EventEmitter<FilterEvent>();
+  @Output() onSortChange = new EventEmitter<SortEvent>();
+}
+
+describe('AreasToolbarComponent', () => {
+  type Context = TestContext<AreasToolbarComponent, HostComponent>;
+  initContext(AreasToolbarComponent, HostComponent,
+  {
+    declarations: [FakePfngToolbarComponent],
+    imports: [RouterTestingModule]
+  });
+
+  it('should update filterConfig resultsCount', function(this: Context) {
+    let initialCount = 0;
+    expect(this.testedDirective.filterConfig.resultsCount).toBe(initialCount);
+
+    let nextCount = 5;
+    this.hostComponent.resultsCount = nextCount;
+    this.detectChanges();
+
+    expect(this.testedDirective.filterConfig.resultsCount).toBe(nextCount);
+  });
+});

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.ts
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.ts
@@ -1,0 +1,96 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+
+import {
+  FilterConfig,
+  FilterEvent,
+  FilterField,
+  SortConfig,
+  SortEvent,
+  ToolbarConfig
+} from 'patternfly-ng';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'areas-toolbar',
+  templateUrl: './areas-toolbar.component.html',
+  styleUrls: ['./areas-toolbar.component.less']
+})
+export class AreasToolbarComponent implements OnChanges, OnInit {
+  @Input() resultsCount: number = 0;
+
+  @Output('onAddArea') onAddArea = new EventEmitter();
+  @Output('onFilterChange') onFilterChange = new EventEmitter();
+  @Output('onSortChange') onSortChange = new EventEmitter();
+
+  @ViewChild('addAreasTemplate') addAreasTemplate: TemplateRef<any>;
+
+  filterConfig: FilterConfig;
+  isAscendingSort: boolean = true;
+  sortConfig: SortConfig;
+  toolbarConfig: ToolbarConfig;
+
+  constructor() {
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.resultsCount && this.filterConfig) {
+      this.filterConfig.resultsCount = changes.resultsCount.currentValue;
+    }
+  }
+
+  // Initialization
+
+  ngOnInit(): void {
+    this.filterConfig = {
+      fields: [{
+        id: 'area',
+        title: 'Area',
+        placeholder: 'Filter by Area...',
+        type: 'text'
+      }] as FilterField[],
+      appliedFilters: [],
+      resultsCount: 0,
+      selectedCount: 0,
+      totalCount: 0
+    } as FilterConfig;
+
+    this.sortConfig = {
+      fields: [{
+        id: 'area',
+        title:  'Area',
+        sortType: 'alpha'
+      }],
+      isAscending: this.isAscendingSort
+    } as SortConfig;
+
+    this.toolbarConfig = {
+      filterConfig: this.filterConfig,
+      sortConfig: this.sortConfig
+    } as ToolbarConfig;
+  }
+
+  // Actions
+
+  addArea($event: MouseEvent): void {
+    this.onAddArea.emit($event);
+  }
+
+  filterChange($event: FilterEvent): void {
+    this.onFilterChange.emit($event);
+  }
+
+  sortChange($event: SortEvent): void {
+    this.onSortChange.emit($event);
+  }
+}

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.module.ts
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.module.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ToolbarModule } from 'patternfly-ng';
+
+import { AreasToolbarComponent } from './areas-toolbar.component';
+
+@NgModule({
+  imports: [
+    BsDropdownModule.forRoot(),
+    CommonModule,
+    RouterModule,
+    ToolbarModule,
+    TooltipModule.forRoot()
+  ],
+  declarations: [
+    AreasToolbarComponent
+  ],
+  providers: [
+    BsDropdownConfig,
+    TooltipConfig
+  ],
+  exports: [AreasToolbarComponent]
+})
+export class AreasToolbarModule { }

--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-sm-12">
-      <pfng-tree-list *ngIf="showTree === true"
+      <pfng-tree-list
           [actionTemplate]="actionTemplate"
           [config]="treeListConfig"
           [itemTemplate]="itemTemplate"

--- a/src/app/space/settings/areas/areas.component.html
+++ b/src/app/space/settings/areas/areas.component.html
@@ -1,47 +1,39 @@
+<areas-toolbar
+    (onAddArea)="addChildArea()"
+    (onFilterChange)="filterChange($event)"
+    (onSortChange)="sortChange($event)"
+    [resultsCount]="resultsCount">
+</areas-toolbar>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-xs-8 col-sm-8 col-md-9">
-      <h3 class="areas-header">Areas that make up the {{context.space.attributes.name | spaceName}} Space:</h3>
-    </div>
-    <div class="col-xs-4 col-sm-4 col-md-3">
-      <div class="table-action-heading" (click)="addChildArea()">
-        <a><i class="pficon pficon-add-circle-o"></i> Add Areas</a>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <pfng-list
-        [config]="listConfig"
-        [itemTemplate]="itemTemplate"
-        [actionTemplate]="actionTemplate"
-        [items]="areas" >
-        <ng-template #itemTemplate let-item="item" let-index="index">
+    <div class="col-sm-12">
+      <pfng-tree-list *ngIf="showTree === true"
+          [actionTemplate]="actionTemplate"
+          [config]="treeListConfig"
+          [itemTemplate]="itemTemplate"
+          [items]="treeAreas"
+          (onActionSelect)="handleAction($event)">
+        <ng-template #itemTemplate let-node="node" let-index="index">
           <div class="list-pf-content-wrapper">
             <div class="list-pf-main-content">
-              <div class="list-pf-title">{{itemPath(item.attributes)}}</div>
+              <div class="list-pf-title">{{node.data?.attributes?.name}}</div>
             </div>
           </div>
         </ng-template>
-        <ng-template #actionTemplate let-item="item" let-index="index">
-          <span class="dropdown-kebab-pf areas-display dropdown" dropdown>
-            <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
-              <span class="fa fa-ellipsis-v"></span>
-            </button>
-            <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
-              <li role="menuitem"><a href="javascript:void(0)" class="secondary-action" (click)="addChildArea(item.id)">Add Child Area</a></li>
-            </ul>
-          </span>
+        <ng-template #actionTemplate let-node="node" let-index="index">
+          <pfng-action class="list-pf-actions"
+                       [config]="actionConfig"
+                       (onActionSelect)="handleAction($event, node)">
+          </pfng-action>
         </ng-template>
-      </pfng-list>
+      </pfng-tree-list>
     </div>
   </div>
 </div>
-
 <div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="createAreaDialog.onOpen()" (onHide)="createAreaDialog.onClose()">
   <div class="modal-dialog">
     <div class="modal-content">
-      <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="areas" (onAdded)="addArea($event)"></create-area-dialog>
+      <create-area-dialog #createAreaDialog [host]="modal" [parentId]="selectedAreaId" [areas]="allAreas" (onAdded)="addArea($event)"></create-area-dialog>
     </div>
   </div>
 </div>

--- a/src/app/space/settings/areas/areas.component.less
+++ b/src/app/space/settings/areas/areas.component.less
@@ -15,4 +15,10 @@
   .pficon { color: @color-pf-blue-300; }
 }
 
-.list-pf-item { background-color: @color-pf-white; }
+/* Override angular-tree-component */
+.list-pf tree-viewport {
+  overflow: initial;
+  .tree-children {
+    overflow: initial;
+  }
+}

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -57,7 +57,6 @@ export class AreasComponent implements OnInit, OnDestroy {
   selectedAreaId: string;
   subscriptions: Subscription[] = [];
   resultsCount: number = 0;
-  showTree: boolean = true;
   treeListConfig: TreeListConfig;
 
   constructor(private contexts: ContextService,
@@ -132,15 +131,10 @@ export class AreasComponent implements OnInit, OnDestroy {
 
   addArea(area: ExtArea): void {
     this.allAreas.push(area);
-    this.showTree = false;
 
-    // Hide the tree list to rerender existing toggles in expanded state
-    setTimeout(() => {
-      // Reapply sort and filter, if any
-      this.allAreas.sort((area1: Area, area2: Area) => this.compare(area1, area2));
-      this.applyFilters(this.appliedFilters);
-      this.showTree = true;
-    }, 10);
+    // Reapply sort and filter, if any
+    this.allAreas.sort((area1: Area, area2: Area) => this.compare(area1, area2));
+    this.applyFilters(this.appliedFilters);
   }
 
   // Filter
@@ -214,7 +208,6 @@ export class AreasComponent implements OnInit, OnDestroy {
         let children = this.getNestedChildren(elements, element);
         if (children.length > 0) {
           element.children = children;
-          element.expanded = true;
         }
         tree.push(element);
       }
@@ -229,7 +222,6 @@ export class AreasComponent implements OnInit, OnDestroy {
         let children = this.getNestedChildren(elements, element);
         if (children.length > 0) {
           element.children = children;
-          element.expanded = true;
         }
         areas.push(element);
       }

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -19,6 +19,19 @@ import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dial
 
 import { cloneDeep } from 'lodash';
 
+// Interface to extend Area of ngx-fabric8-wit
+export interface ExtArea extends Area {
+  expanded: boolean;
+  children: Area[];
+}
+
+// Interface for the node object of angular-tree-component
+export interface Node {
+ data: {
+   id: string;
+ };
+}
+
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'alm-areas',
@@ -30,22 +43,22 @@ export class AreasComponent implements OnInit, OnDestroy {
   @ViewChild(CreateAreaDialogComponent) createAreaDialog: CreateAreaDialogComponent;
   @ViewChild(ModalDirective) modal: ModalDirective;
 
-  private allAreas: Area[]; // flat array obtained directly from API
-  private filteredAreas: Area[]; // flat array filtered and sorted
-  private treeAreas: Area[]; // transformed flat array into tree list
+  allAreas: ExtArea[]; // flat array obtained directly from API
+  filteredAreas: ExtArea[]; // flat array filtered and sorted
+  treeAreas: ExtArea[]; // transformed flat array into tree list
 
-  private actionConfig: ActionConfig;
-  private appliedFilters: Filter[];
-  private context: Context;
-  private currentSortField: SortField;
-  private defaultArea: string;
-  private emptyStateConfig: EmptyStateConfig;
-  private isAscendingSort: boolean = true;
-  private selectedAreaId: string;
-  private subscriptions: Subscription[] = [];
-  private resultsCount: number = 0;
-  private showTree: boolean = true;
-  private treeListConfig: TreeListConfig;
+  actionConfig: ActionConfig;
+  appliedFilters: Filter[];
+  context: Context;
+  currentSortField: SortField;
+  defaultArea: string;
+  emptyStateConfig: EmptyStateConfig;
+  isAscendingSort: boolean = true;
+  selectedAreaId: string;
+  subscriptions: Subscription[] = [];
+  resultsCount: number = 0;
+  showTree: boolean = true;
+  treeListConfig: TreeListConfig;
 
   constructor(private contexts: ContextService,
               private areaService: AreaService) {
@@ -94,7 +107,7 @@ export class AreasComponent implements OnInit, OnDestroy {
           this.defaultArea = area.id;
         }
       });
-      this.allAreas = areas; // store all areas for filter/sort
+      this.allAreas = areas as ExtArea[]; // store all areas for filter/sort
       this.treeAreas = this.buildTree(this.allAreas); // transform flat array into tree list
     }));
   }
@@ -117,7 +130,7 @@ export class AreasComponent implements OnInit, OnDestroy {
     this.openModal();
   }
 
-  addArea(area: Area): void {
+  addArea(area: ExtArea): void {
     this.allAreas.push(area);
     this.showTree = false;
 
@@ -195,7 +208,7 @@ export class AreasComponent implements OnInit, OnDestroy {
 
   // Transform flat array into tree list
 
-  private buildTree(elements: any[], tree = []): any[] {
+  private buildTree(elements: ExtArea[], tree = []): ExtArea[] {
     elements.forEach((element) => {
       if (element.relationships.parent === undefined) {
         let children = this.getNestedChildren(elements, element);
@@ -209,7 +222,7 @@ export class AreasComponent implements OnInit, OnDestroy {
     return tree;
   }
 
-  private getNestedChildren(elements: any[], parent: Area): any[] {
+  private getNestedChildren(elements: ExtArea[], parent: Area): ExtArea[] {
     let areas = [];
     elements.forEach((element) => {
       if (element.relationships.parent !== undefined && element.relationships.parent.data.id === parent.id) {
@@ -226,7 +239,7 @@ export class AreasComponent implements OnInit, OnDestroy {
 
   // Transform filtered flat array into tree list
 
-  private buildFilteredTree(elements: any[]): any[] {
+  private buildFilteredTree(elements: ExtArea[]): ExtArea[] {
     // Reassign filtered parents using closest ancestor
     elements.forEach((element) => {
       element.children = undefined;
@@ -243,7 +256,7 @@ export class AreasComponent implements OnInit, OnDestroy {
     return this.buildTree(elements);
   }
 
-  private getClosestAncestor(elements: any[], parent: Area): Area {
+  private getClosestAncestor(elements: ExtArea[], parent: Area): Area {
     let area;
     for (let i = 0; i < elements.length; i++) {
       if (elements[i].id === parent.id) {
@@ -270,7 +283,7 @@ export class AreasComponent implements OnInit, OnDestroy {
 
   // Actions
 
-  handleAction($event: Action, node: any): void {
+  handleAction($event: Action, node: Node): void {
     if ($event.id === 'addChildArea') {
       this.addChildArea(node.data.id);
     } else if ($event.id === 'addArea') {

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -1,11 +1,23 @@
 import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ModalDirective } from 'ngx-bootstrap/modal';
-import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
-import { EmptyStateConfig, ListConfig } from 'patternfly-ng';
+import { Area, AreaService, Context } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
+
+import {
+  Action,
+  ActionConfig,
+  EmptyStateConfig,
+  Filter,
+  FilterEvent,
+  SortEvent,
+  SortField,
+  TreeListConfig
+} from 'patternfly-ng';
 
 import { ContextService } from '../../../shared/context.service';
 import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dialog.component';
+
+import { cloneDeep } from 'lodash';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -18,32 +30,63 @@ export class AreasComponent implements OnInit, OnDestroy {
   @ViewChild(CreateAreaDialogComponent) createAreaDialog: CreateAreaDialogComponent;
   @ViewChild(ModalDirective) modal: ModalDirective;
 
-  private context: Context;
-  private areas: Area[];
-  private emptyStateConfig: EmptyStateConfig;
-  private listConfig: ListConfig;
-  private areaSubscription: Subscription;
-  private selectedAreaId: string;
-  private defaultArea: string;
+  private allAreas: Area[]; // flat array obtained directly from API
+  private filteredAreas: Area[]; // flat array filtered and sorted
+  private treeAreas: Area[]; // transformed flat array into tree list
 
-  constructor(
-    private contexts: ContextService,
-    private areaService: AreaService) {
+  private actionConfig: ActionConfig;
+  private appliedFilters: Filter[];
+  private context: Context;
+  private currentSortField: SortField;
+  private defaultArea: string;
+  private emptyStateConfig: EmptyStateConfig;
+  private isAscendingSort: boolean = true;
+  private selectedAreaId: string;
+  private subscriptions: Subscription[] = [];
+  private resultsCount: number = 0;
+  private showTree: boolean = true;
+  private treeListConfig: TreeListConfig;
+
+  constructor(private contexts: ContextService,
+              private areaService: AreaService) {
     this.contexts.current.subscribe(val => this.context = val);
   }
 
   ngOnInit() {
-    this.listConfig = {
+    this.actionConfig = {
+      moreActions: [{
+        id: 'addChildArea',
+        title: 'Add Child Area',
+        tooltip: 'Add Child Area'
+      }]
+    } as ActionConfig;
+
+    this.emptyStateConfig = {
+      actions: {
+        primaryActions: [{
+          id: 'addArea',
+          title: 'Add Area',
+          tooltip: 'Add Area'
+        }],
+        moreActions: []
+      } as ActionConfig,
+      title: 'Add Area',
+      info: 'Start by adding an area.'
+    } as EmptyStateConfig;
+
+    this.treeListConfig = {
       dblClick: false,
-      dragEnabled: false,
       emptyStateConfig: this.emptyStateConfig,
       multiSelect: false,
       selectItems: false,
       showCheckbox: false,
-      useExpandItems: false
-    } as ListConfig;
+      treeOptions: {
+        allowDrag: false,
+        isExpandedField: 'expanded'
+      }
+    } as TreeListConfig;
 
-    this.areaSubscription = this.areaService.getAllBySpaceId(this.context.space.id).subscribe(areas => {
+    this.subscriptions.push(this.areaService.getAllBySpaceId(this.context.space.id).subscribe(areas => {
       this.selectedAreaId = this.context.space.id;
       areas.forEach((area) => {
         if (area.attributes.parent_path == '/') {
@@ -51,19 +94,22 @@ export class AreasComponent implements OnInit, OnDestroy {
           this.defaultArea = area.id;
         }
       });
-      this.areas = areas;
-    });
+      this.allAreas = areas; // store all areas for filter/sort
+      this.treeAreas = this.buildTree(this.allAreas); // transform flat array into tree list
+    }));
   }
 
   ngOnDestroy() {
-    this.areaSubscription.unsubscribe();
+    this.subscriptions.forEach(sub => {
+      sub.unsubscribe();
+    });
   }
 
-  openModal() {
+  openModal(): void {
     this.modal.show();
   }
 
-  addChildArea(id: string) {
+  addChildArea(id: string): void {
     this.selectedAreaId = this.defaultArea;
     if (id) {
       this.selectedAreaId = id;
@@ -71,16 +117,164 @@ export class AreasComponent implements OnInit, OnDestroy {
     this.openModal();
   }
 
-  itemPath(item: AreaAttributes) {
-    // remove slash from start of string
-    let parentPath = item.parent_path_resolved.slice(1, item.parent_path_resolved.length);
-    if (parentPath === '') {
-      return item.name;
-    }
-    return parentPath + '/' + item.name;
+  addArea(area: Area): void {
+    this.allAreas.push(area);
+    this.showTree = false;
+
+    // Hide the tree list to rerender existing toggles in expanded state
+    setTimeout(() => {
+      // Reapply sort and filter, if any
+      this.allAreas.sort((area1: Area, area2: Area) => this.compare(area1, area2));
+      this.applyFilters(this.appliedFilters);
+      this.showTree = true;
+    }, 10);
   }
 
-  addArea(area: Area) {
-    this.areas.push(area);
+  // Filter
+
+  applyFilters(filters: Filter[]): void {
+    this.appliedFilters = filters;
+    this.filteredAreas = [];
+    if (filters && filters.length > 0) {
+      this.allAreas.forEach((area) => {
+        if (this.matchesFilters(area, filters)) {
+          this.filteredAreas.push(cloneDeep(area));
+        }
+      });
+      this.treeAreas = this.buildFilteredTree(this.filteredAreas);
+    } else {
+      this.treeAreas = this.buildTree(this.allAreas);
+    }
+    this.resultsCount = this.filteredAreas.length;
+  }
+
+  filterChange($event: FilterEvent): void {
+    this.applyFilters($event.appliedFilters);
+  }
+
+  matchesFilter(area: Area, filter: Filter): boolean {
+    let match = true;
+
+    if (filter.field.id === 'area') {
+      match = area.attributes.name.match(filter.value) !== null;
+    }
+    return match;
+  }
+
+  matchesFilters(area: Area, filters: Filter[]): boolean {
+    let matches = true;
+
+    filters.forEach((filter) => {
+      if (!this.matchesFilter(area, filter)) {
+        matches = false;
+        return false;
+      }
+    });
+    return matches;
+  }
+
+  // Sort
+
+  compare(area1: Area, area2: Area): number {
+    var compValue = 0;
+    if (this.currentSortField === undefined || this.currentSortField.id === 'area') {
+      compValue = area1.attributes.name.localeCompare(area2.attributes.name);
+    }
+    if (!this.isAscendingSort) {
+      compValue = compValue * -1;
+    }
+    return compValue;
+  }
+
+  sortChange($event: SortEvent): void {
+    this.currentSortField = $event.field;
+    this.isAscendingSort = $event.isAscending;
+    this.allAreas.sort((area1: Area, area2: Area) => this.compare(area1, area2));
+    this.applyFilters(this.appliedFilters); // Reapply filters, if any
+  }
+
+  // Transform flat array into tree list
+
+  private buildTree(elements: any[], tree = []): any[] {
+    elements.forEach((element) => {
+      if (element.relationships.parent === undefined) {
+        let children = this.getNestedChildren(elements, element);
+        if (children.length > 0) {
+          element.children = children;
+          element.expanded = true;
+        }
+        tree.push(element);
+      }
+    });
+    return tree;
+  }
+
+  private getNestedChildren(elements: any[], parent: Area): any[] {
+    let areas = [];
+    elements.forEach((element) => {
+      if (element.relationships.parent !== undefined && element.relationships.parent.data.id === parent.id) {
+        let children = this.getNestedChildren(elements, element);
+        if (children.length > 0) {
+          element.children = children;
+          element.expanded = true;
+        }
+        areas.push(element);
+      }
+    });
+    return areas;
+  }
+
+  // Transform filtered flat array into tree list
+
+  private buildFilteredTree(elements: any[]): any[] {
+    // Reassign filtered parents using closest ancestor
+    elements.forEach((element) => {
+      element.children = undefined;
+      if (element.relationships.parent !== undefined) {
+        let area = this.getClosestAncestor(elements,
+          this.getArea(element.relationships.parent.data.id));
+        if (area !== undefined) {
+          element.relationships.parent.data = area;
+        } else {
+          element.relationships.parent = undefined;
+        }
+      }
+    });
+    return this.buildTree(elements);
+  }
+
+  private getClosestAncestor(elements: any[], parent: Area): Area {
+    let area;
+    for (let i = 0; i < elements.length; i++) {
+      if (elements[i].id === parent.id) {
+        area = parent;
+        break;
+      }
+    }
+    if (area === undefined && parent.relationships.parent !== undefined) {
+      area = this.getClosestAncestor(elements,
+        this.getArea(parent.relationships.parent.data.id));
+    }
+    return area;
+  }
+
+  private getArea(id: string): Area {
+    let area;
+    for (let i = 0; i < this.allAreas.length; i++) {
+      if (this.allAreas[i].id === id) {
+        area = this.allAreas[i];
+      }
+    }
+    return area;
+  }
+
+  // Actions
+
+  handleAction($event: Action, node: any): void {
+    if ($event.id === 'addChildArea') {
+      this.addChildArea(node.data.id);
+    } else if ($event.id === 'addArea') {
+      this.addChildArea(this.defaultArea);
+    }
   }
 }

--- a/src/app/space/settings/areas/areas.module.ts
+++ b/src/app/space/settings/areas/areas.module.ts
@@ -5,22 +5,24 @@ import { Http } from '@angular/http';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
-import { ListModule } from 'patternfly-ng';
+import { ActionModule, ListModule } from 'patternfly-ng';
 
 import { AreasRoutingModule } from './areas-routing.module';
+import { AreasToolbarModule } from './areas-toolbar/areas-toolbar.module';
 import { AreasComponent } from './areas.component';
-import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dialog.component';
 import { CreateAreaDialogModule } from './create-area-dialog/create-area-dialog.module';
 
 @NgModule({
   imports: [
+    ActionModule,
+    AreasToolbarModule,
+    AreasRoutingModule,
     BsDropdownModule.forRoot(),
     CommonModule,
-    AreasRoutingModule,
-    ListModule,
     CreateAreaDialogModule,
-    ModalModule.forRoot(),
-    Fabric8WitModule
+    Fabric8WitModule,
+    ListModule,
+    ModalModule.forRoot()
   ],
   declarations: [
     AreasComponent

--- a/src/vendor.browser.ts
+++ b/src/vendor.browser.ts
@@ -28,6 +28,7 @@ import 'ngx-bootstrap';
 /* tslint:disable:ordered-imports */
 import '../node_modules/patternfly/dist/css/patternfly.min.css';
 import '../node_modules/patternfly/dist/css/patternfly-additions.min.css';
+import '../node_modules/patternfly-ng/dist/css/patternfly-ng.min.css';
 
 if ('production' === ENV) {
   // Production


### PR DESCRIPTION
Replaced the existing list with pfng-tree-list to better show hierarchical areas. Also added a toolbar with filter/sort/add controls and spec.

Note: This updates patternfly-ng to 3.1.2 since the current version is missing CSS styles.

Fixes: https://github.com/fabric8-ui/fabric8-ux/issues/835

