### PR TITLE
patternfly-ng: import individual modules 

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,7 +9,8 @@ import { Broadcaster } from 'ngx-base';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { Spaces } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
-import { ActionConfig, EmptyStateConfig } from 'patternfly-ng';
+import { ActionConfig } from 'patternfly-ng/action';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
 
 import { OnLogin } from '../a-runtime-console/index';
 import { FeatureFlagConfig } from './models/feature-flag-config';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,14 +30,11 @@ import {
   UserService
 } from 'ngx-login-client';
 import { WidgetsModule } from 'ngx-widgets';
-import {
-  ActionModule,
-  ChartModule,
-  EmptyStateModule,
-  ListModule,
-  PatternFlyNgModule,
-  TreeListComponent
-} from 'patternfly-ng';
+
+import { ActionModule } from 'patternfly-ng/action';
+import { EmptyStateModule } from 'patternfly-ng/empty-state';
+import { NotificationModule } from 'patternfly-ng/notification';
+
 import {
   // Base functionality for the runtime console
   KubernetesRestangularModule,
@@ -144,20 +141,19 @@ export type StoreType = {
     BrowserAnimationsModule,
     BrowserModule,
     BsDropdownModule.forRoot(),
-    ChartModule,
     EffectsModule.forRoot([]),
     EmptyStateModule,
     FormsModule,
     HttpModule,
     KubernetesRestangularModule,
     KubernetesStoreModule,
-    ListModule,
     LocalStorageModule.withConfig({
       prefix: 'fabric8',
       storageType: 'localStorage'
     }),
     ModalModule.forRoot(),
     MomentModule,
+    NotificationModule,
     ReactiveFormsModule,
     RestangularModule,
     RouterModule,
@@ -165,7 +161,6 @@ export type StoreType = {
     ForgeWizardModule,
     StackDetailsModule,
     WidgetsModule,
-    PatternFlyNgModule,
     StatusListModule,
     StoreModule.forRoot({}),
     // AppRoutingModule must appear last
@@ -251,7 +246,6 @@ export type StoreType = {
       useClass: Fabric8UISpaceNamespace
     },
     ssoApiUrlProvider,
-    TreeListComponent,
     UserService,
     witApiUrlProvider,
     realmProvider

--- a/src/app/profile/cleanup/cleanup.component.ts
+++ b/src/app/profile/cleanup/cleanup.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@ang
 import { Router } from '@angular/router';
 
 import { Contexts, Space, SpaceService } from 'ngx-fabric8-wit';
-import { ListConfig } from 'patternfly-ng';
+import { ListConfig } from 'patternfly-ng/list';
 import { Observable, Subscription } from 'rxjs';
 
 import { EventService } from '../../shared/event.service';

--- a/src/app/profile/cleanup/cleanup.module.ts
+++ b/src/app/profile/cleanup/cleanup.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http, HttpModule } from '@angular/http';
 
 import { ModalModule } from 'ngx-modal';
-import { ListModule } from 'patternfly-ng';
+import { ListModule } from 'patternfly-ng/list';
 
 import { CleanupRoutingModule } from './cleanup-routing.module';
 import { CleanupComponent } from './cleanup.component';

--- a/src/app/profile/my-spaces/my-spaces-item-actions/my-spaces-item-actions.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-item-actions/my-spaces-item-actions.component.ts
@@ -10,7 +10,7 @@ import {
 
 import { has } from 'lodash';
 import { Context, Contexts, Space } from 'ngx-fabric8-wit';
-import { Action, ActionConfig } from 'patternfly-ng';
+import { Action, ActionConfig } from 'patternfly-ng/action';
 import { Subscription } from 'rxjs';
 
 @Component({

--- a/src/app/profile/my-spaces/my-spaces-item-actions/my-spaces-item-actions.module.ts
+++ b/src/app/profile/my-spaces/my-spaces-item-actions/my-spaces-item-actions.module.ts
@@ -7,7 +7,7 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { DialogModule } from 'ngx-widgets';
-import { ActionModule } from 'patternfly-ng';
+import { ActionModule } from 'patternfly-ng/action';
 
 import { MySpacesItemActionsComponent } from './my-spaces-item-actions.component';
 

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.spec.ts
@@ -5,7 +5,8 @@ import {
   Output
 } from '@angular/core';
 
-import { FilterEvent, SortEvent } from 'patternfly-ng';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { SortEvent } from 'patternfly-ng/sort';
 import { initContext, TestContext } from '../../../../testing/test-context';
 
 import { MySpacesToolbarComponent } from './my-spaces-toolbar.component';

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
@@ -11,14 +11,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import {
-  FilterConfig,
-  FilterEvent,
-  FilterField,
-  SortConfig,
-  SortEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+import { FilterConfig, FilterEvent, FilterField } from 'patternfly-ng/filter';
+import { SortConfig, SortEvent } from 'patternfly-ng/sort';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.module.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.module.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { SpaceWizardModule } from '../../space/wizard/space-wizard.module';
 import { MySpacesToolbarComponent } from './my-spaces-toolbar.component';

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -6,23 +6,19 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { cloneDeep, findIndex, has } from 'lodash';
 import { Logger } from 'ngx-base';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { Context, Contexts, Space, SpaceService } from 'ngx-fabric8-wit';
 import { User, UserService } from 'ngx-login-client';
-import {
-  Action,
-  ActionConfig,
-  EmptyStateConfig,
-  Filter,
-  FilterEvent,
-  ListConfig,
-  SortEvent,
-  SortField
-} from 'patternfly-ng';
-import { Subscription } from 'rxjs';
+
+import { Action, ActionConfig } from 'patternfly-ng/action';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
+import { Filter, FilterEvent } from 'patternfly-ng/filter';
+import { ListConfig } from 'patternfly-ng/list';
+import { SortEvent, SortField } from 'patternfly-ng/sort';
 
 import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { EventService } from '../../shared/event.service';

--- a/src/app/profile/my-spaces/my-spaces.module.ts
+++ b/src/app/profile/my-spaces/my-spaces.module.ts
@@ -5,7 +5,7 @@ import { Http } from '@angular/http';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { InfiniteScrollModule } from 'ngx-widgets';
-import { ListModule } from 'patternfly-ng';
+import { ListModule } from 'patternfly-ng/list';
 
 import { ForgeWizardModule } from '../../space/forge-wizard/forge-wizard.module';
 import { SpaceWizardModule } from '../../space/wizard/space-wizard.module';

--- a/src/app/profile/tenant/tenant.module.ts
+++ b/src/app/profile/tenant/tenant.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http, HttpModule } from '@angular/http';
 
 import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
-import { RemainingCharsCountModule } from 'patternfly-ng';
+import { RemainingCharsCountModule } from 'patternfly-ng/remaining-chars-count';
 
 import { TenantRoutingModule } from './tenant-routing.module';
 import { TenantComponent } from './tenant.component';

--- a/src/app/profile/update/update.module.ts
+++ b/src/app/profile/update/update.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http, HttpModule } from '@angular/http';
 
 import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
-import { RemainingCharsCountModule } from 'patternfly-ng';
+import { RemainingCharsCountModule } from 'patternfly-ng/remaining-chars-count';
 
 import { OwnerGuard } from '../../shared/owner-guard.service';
 import { UpdateRoutingModule } from './update-routing.module';

--- a/src/app/shared/notifications.service.ts
+++ b/src/app/shared/notifications.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { Notification, NotificationAction, Notifications } from 'ngx-base';
-import { NotificationService } from 'patternfly-ng';
+import { NotificationService } from 'patternfly-ng/notification';
 import { Observable, Subject } from 'rxjs';
 
 @Injectable()

--- a/src/app/space/create/codebases/codebases-item-heading/codebases-item-heading.component.ts
+++ b/src/app/space/create/codebases/codebases-item-heading/codebases-item-heading.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { NotificationType } from 'patternfly-ng';
+import { NotificationType } from 'patternfly-ng/notification';
 
 import { Che } from '../services/che';
 

--- a/src/app/space/create/codebases/codebases-item-heading/codebases-item-heading.module.ts
+++ b/src/app/space/create/codebases/codebases-item-heading/codebases-item-heading.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { NotificationModule } from 'patternfly-ng';
+import { NotificationModule } from 'patternfly-ng/notification';
 
 import { WorkspacesNotificationModule } from '../workspaces-notification/workspaces-notification.module';
 import { CodebasesItemHeadingComponent } from './codebases-item-heading.component';

--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.spec.ts
@@ -6,10 +6,9 @@ import {
 } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import {
-  FilterEvent,
-  SortEvent
-} from 'patternfly-ng';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { SortEvent } from 'patternfly-ng/sort';
+
 import {
   initContext,
   TestContext

--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
@@ -11,14 +11,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import {
-  FilterConfig,
-  FilterEvent,
-  FilterField,
-  SortConfig,
-  SortEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+import { FilterConfig, FilterEvent, FilterField } from 'patternfly-ng/filter';
+import { SortConfig, SortEvent } from 'patternfly-ng/sort';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.module.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.module.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { CodebasesToolbarComponent } from './codebases-toolbar.component';
 

--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -14,16 +14,12 @@ import { Codebase } from './services/codebase';
 import { CodebasesService } from './services/codebases.service';
 import { GitHubService } from './services/github.service';
 
+import { ActionConfig } from 'patternfly-ng/action';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
+import { Filter, FilterEvent } from 'patternfly-ng/filter';
+import { ListConfig } from 'patternfly-ng/list';
+import { SortEvent, SortField } from 'patternfly-ng/sort';
 
-import {
-  ActionConfig,
-  EmptyStateConfig,
-  Filter,
-  FilterEvent,
-  ListConfig,
-  SortEvent,
-  SortField
-} from 'patternfly-ng';
 import { ProviderService } from '../../../shared/account/provider.service';
 
 @Component({

--- a/src/app/space/create/codebases/codebases.module.ts
+++ b/src/app/space/create/codebases/codebases.module.ts
@@ -5,7 +5,9 @@ import { Http } from '@angular/http';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ActionModule, EmptyStateModule, ListModule } from 'patternfly-ng';
+import { ActionModule } from 'patternfly-ng/action';
+import { EmptyStateModule } from 'patternfly-ng/empty-state';
+import { ListModule } from 'patternfly-ng/list';
 
 import { CodebasesAddModule } from './codebases-add/codebases-add.module';
 import { CodebaseDeleteDialogModule } from './codebases-delete/codebase-delete-dialog.module';

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.ts
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit
 } from '@angular/core';
 
-import { NotificationType } from 'patternfly-ng';
+import { NotificationType } from 'patternfly-ng/notification';
 
 @Component({
   selector: 'f8-workspaces-notification',

--- a/src/app/space/create/codebases/workspaces-notification/workspaces-notification.module.ts
+++ b/src/app/space/create/codebases/workspaces-notification/workspaces-notification.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 
-import { NotificationModule } from 'patternfly-ng';
+import { NotificationModule } from 'patternfly-ng/notification';
 
 import { WorkspacesNotificationComponent } from './workspaces-notification.component';
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -26,7 +26,7 @@ import {
 } from 'ngx-bootstrap/dropdown';
 import { ModalDirective, ModalModule } from 'ngx-bootstrap/modal';
 
-import { ChartModule } from 'patternfly-ng';
+import { ChartModule } from 'patternfly-ng/chart';
 import 'patternfly/dist/js/patternfly-settings.js';
 import {
   BehaviorSubject,

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -42,7 +42,7 @@ import {
   ChartModule,
   SparklineConfig,
   SparklineData
-} from 'patternfly-ng';
+} from 'patternfly-ng/chart';
 import 'patternfly/dist/js/patternfly-settings.js';
 
 @Component({

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -11,7 +11,7 @@ import {
   ChartDefaults,
   SparklineConfig,
   SparklineData
-} from 'patternfly-ng';
+} from 'patternfly-ng/chart';
 import 'patternfly/dist/js/patternfly-settings.js';
 import {
   Observable,

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -7,10 +7,8 @@ import {
 } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
-import {
-  FilterEvent,
-  SortEvent
-} from 'patternfly-ng';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { SortEvent } from 'patternfly-ng/sort';
 import { Observable } from 'rxjs';
 import {
   initContext,

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -6,12 +6,8 @@ import {
 } from '@angular/core';
 
 import { cloneDeep } from 'lodash';
-import {
-  Filter,
-  FilterEvent,
-  SortEvent,
-  SortField
-} from 'patternfly-ng';
+import { Filter, FilterEvent } from 'patternfly-ng/filter';
+import { SortEvent, SortField } from 'patternfly-ng/sort';
 import {
   Observable,
   Subscription

--- a/src/app/space/create/deployments/deployments-linechart/deployments-linechart-config.ts
+++ b/src/app/space/create/deployments/deployments-linechart/deployments-linechart-config.ts
@@ -1,4 +1,4 @@
-import { ChartConfig } from 'patternfly-ng';
+import { ChartConfig } from 'patternfly-ng/chart';
 
 export class DeploymentsLinechartConfig extends ChartConfig {
   axis?: any;

--- a/src/app/space/create/deployments/deployments-linechart/deployments-linechart.component.ts
+++ b/src/app/space/create/deployments/deployments-linechart/deployments-linechart.component.ts
@@ -9,7 +9,7 @@ import {
 import {
   ChartBase,
   ChartDefaults
-} from 'patternfly-ng';
+} from 'patternfly-ng/chart';
 
 import {
   cloneDeep,

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.spec.ts
@@ -5,7 +5,9 @@ import {
   Output
 } from '@angular/core';
 
-import { FilterEvent, SortEvent } from 'patternfly-ng';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { SortEvent } from 'patternfly-ng/sort';
+
 import { initContext, TestContext } from 'testing/test-context';
 
 import { DeploymentsToolbarComponent } from './deployments-toolbar.component';

--- a/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
+++ b/src/app/space/create/deployments/deployments-toolbar/deployments-toolbar.component.ts
@@ -9,15 +9,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import {
-  FilterConfig,
-  FilterEvent,
-  FilterField,
-  FilterType,
-  SortConfig,
-  SortEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+import { FilterConfig, FilterEvent, FilterField, FilterType } from 'patternfly-ng/filter';
+import { SortConfig, SortEvent } from 'patternfly-ng/sort';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -9,7 +9,8 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ChartModule, ToolbarModule } from 'patternfly-ng';
+import { ChartModule } from 'patternfly-ng/chart';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { DeleteDeploymentModal } from './apps/delete-deployment-modal.component';
 import { DeploymentCardContainerComponent } from './apps/deployment-card-container.component';

--- a/src/app/space/create/pipelines/pipelines.component.spec.ts
+++ b/src/app/space/create/pipelines/pipelines.component.spec.ts
@@ -29,7 +29,7 @@ import {
   TooltipModule
 } from 'ngx-bootstrap/tooltip';
 import { AuthenticationService } from 'ngx-login-client';
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { BuildConfig } from 'a-runtime-console/index';
 import { Broadcaster } from 'ngx-base';

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -8,17 +8,11 @@ import {
 
 import { Broadcaster } from 'ngx-base';
 import { AuthenticationService } from 'ngx-login-client';
-import {
-  Filter,
-  FilterConfig,
-  FilterEvent,
-  FilterQuery,
-  FilterType,
-  SortEvent,
-  SortField,
-  ToolbarConfig
-} from 'patternfly-ng';
 import { Subscription } from 'rxjs';
+
+import { Filter, FilterConfig, FilterEvent, FilterQuery, FilterType } from 'patternfly-ng/filter';
+import { SortEvent, SortField } from 'patternfly-ng/sort';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 import { BuildConfig } from 'a-runtime-console/index';
 import {

--- a/src/app/space/create/pipelines/pipelines.module.ts
+++ b/src/app/space/create/pipelines/pipelines.module.ts
@@ -5,7 +5,7 @@ import { Http } from '@angular/http';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 
 import { PipelineModule } from 'a-runtime-console/index';

--- a/src/app/space/forge-wizard/abstract-wizard.component.ts
+++ b/src/app/space/forge-wizard/abstract-wizard.component.ts
@@ -18,7 +18,7 @@ import {
   WizardStep,
   WizardStepComponent,
   WizardStepConfig
-} from 'patternfly-ng';
+} from 'patternfly-ng/wizard';
 import { Observable } from 'rxjs';
 import { isNullOrUndefined } from 'util';
 

--- a/src/app/space/forge-wizard/forge-wizard.module.ts
+++ b/src/app/space/forge-wizard/forge-wizard.module.ts
@@ -15,7 +15,8 @@ import {
   VisibleItemsPipe
 } from 'ngx-forge';
 import { AuthenticationService } from 'ngx-login-client';
-import { FilterModule, WizardModule } from 'patternfly-ng';
+import { FilterModule } from 'patternfly-ng/filter';
+import { WizardModule } from 'patternfly-ng/wizard';
 
 import { FlowSelectorComponent } from './components/flow-selector/flow-selector.component';
 import { SingleInputComponent } from './components/single-input/single-input.component';

--- a/src/app/space/forge-wizard/import-wizard.component.spec.ts
+++ b/src/app/space/forge-wizard/import-wizard.component.spec.ts
@@ -1,6 +1,6 @@
 import { async } from '@angular/core/testing';
 
-import { WizardComponent, WizardConfig, WizardStep, WizardStepComponent, WizardStepConfig } from 'patternfly-ng';
+import { WizardComponent, WizardConfig, WizardStep, WizardStepComponent, WizardStepConfig } from 'patternfly-ng/wizard';
 
 import { flattenWizardSteps, getParentStep } from './abstract-wizard.component';
 

--- a/src/app/space/forge-wizard/import-wizard.config.ts
+++ b/src/app/space/forge-wizard/import-wizard.config.ts
@@ -1,4 +1,4 @@
-import { WizardStepConfig } from 'patternfly-ng';
+import { WizardStepConfig } from 'patternfly-ng/wizard';
 
 export function configureSteps(): WizardStepConfig[] {
   let steps: WizardStepConfig[] = [];

--- a/src/app/space/forge-wizard/quickstart-pages/step1/choose-quickstart.component.ts
+++ b/src/app/space/forge-wizard/quickstart-pages/step1/choose-quickstart.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 import { Gui, Input as ForgeInput, Option, ProjectSelectConfig } from 'ngx-forge';
-import { Filter, FilterConfig, FilterEvent, FilterField } from 'patternfly-ng';
+import { Filter, FilterConfig, FilterEvent, FilterField } from 'patternfly-ng/filter';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/space/forge-wizard/quickstart-wizard.config.ts
+++ b/src/app/space/forge-wizard/quickstart-wizard.config.ts
@@ -1,4 +1,4 @@
-import { WizardStepConfig } from 'patternfly-ng';
+import { WizardStepConfig } from 'patternfly-ng/wizard';
 
 export function configureSteps(): WizardStepConfig[] {
   let steps: WizardStepConfig[] = [];

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.spec.ts
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.spec.ts
@@ -6,10 +6,8 @@ import {
 } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import {
-  FilterEvent,
-  SortEvent
-} from 'patternfly-ng';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { SortEvent } from 'patternfly-ng/sort';
 
 import {
   initContext,

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.ts
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.ts
@@ -11,14 +11,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import {
-  FilterConfig,
-  FilterEvent,
-  FilterField,
-  SortConfig,
-  SortEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+import { FilterConfig, FilterEvent, FilterField } from 'patternfly-ng/filter';
+import { SortConfig, SortEvent } from 'patternfly-ng/sort';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/space/settings/areas/areas-toolbar/areas-toolbar.module.ts
+++ b/src/app/space/settings/areas/areas-toolbar/areas-toolbar.module.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { AreasToolbarComponent } from './areas-toolbar.component';
 

--- a/src/app/space/settings/areas/areas.component.ts
+++ b/src/app/space/settings/areas/areas.component.ts
@@ -3,16 +3,11 @@ import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaService, Context } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
 
-import {
-  Action,
-  ActionConfig,
-  EmptyStateConfig,
-  Filter,
-  FilterEvent,
-  SortEvent,
-  SortField,
-  TreeListConfig
-} from 'patternfly-ng';
+import { Action, ActionConfig } from 'patternfly-ng/action';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
+import { Filter, FilterEvent } from 'patternfly-ng/filter';
+import { TreeListConfig } from 'patternfly-ng/list';
+import { SortEvent, SortField } from 'patternfly-ng/sort';
 
 import { ContextService } from '../../../shared/context.service';
 import { CreateAreaDialogComponent } from './create-area-dialog/create-area-dialog.component';

--- a/src/app/space/settings/areas/areas.module.ts
+++ b/src/app/space/settings/areas/areas.module.ts
@@ -5,7 +5,9 @@ import { Http } from '@angular/http';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
-import { ActionModule, ListModule } from 'patternfly-ng';
+
+import { ActionModule } from 'patternfly-ng/action';
+import { ListModule } from 'patternfly-ng/list';
 
 import { AreasRoutingModule } from './areas-routing.module';
 import { AreasToolbarModule } from './areas-toolbar/areas-toolbar.module';

--- a/src/app/space/settings/collaborators/collaborators.component.ts
+++ b/src/app/space/settings/collaborators/collaborators.component.ts
@@ -4,7 +4,8 @@ import { find } from 'lodash';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { CollaboratorService, Context } from 'ngx-fabric8-wit';
 import { User } from 'ngx-login-client';
-import { EmptyStateConfig, ListConfig } from 'patternfly-ng';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
+import { ListConfig } from 'patternfly-ng/list';
 import { Subscription } from 'rxjs';
 
 import { ContextService } from '../../../shared/context.service';

--- a/src/app/space/settings/collaborators/collaborators.module.ts
+++ b/src/app/space/settings/collaborators/collaborators.module.ts
@@ -6,7 +6,7 @@ import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { InfiniteScrollModule } from 'ngx-widgets';
-import { ListModule } from 'patternfly-ng';
+import { ListModule } from 'patternfly-ng/list';
 
 import { AddCollaboratorsDialogModule } from './add-collaborators-dialog/add-collaborators-dialog.module';
 import { CollaboratorsRoutingModule } from './collaborators-routing.module';


### PR DESCRIPTION
Taking advantage of patternfly-ng's individual modules so fabric8-ui imports only what’s used in the UI.

Fixes: https://github.com/openshiftio/openshift.io/issues/270
Fixes: https://github.com/openshiftio/openshift.io/issues/2499
