### PR TITLE
fix(header): fix onDocumentationListVisible is not a function error

### DIFF
--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -27,6 +27,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   title = 'Almighty';
   imgLoaded: Boolean = false;
   statusListVisible = false;
+  documentationListVisible: Boolean = false;
   modalRef: BsModalRef;
   isIn = false;   // store state
   toggleState() { // click handler
@@ -38,6 +39,9 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.statusListVisible = flag;
   }
 
+  onDocumentationListVisible = (flag: boolean) => {
+    this.documentationListVisible = flag;
+  }
 
   menuCallbacks = new Map<String, MenuHiddenCallback>([
     [


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/2698

The header.component is missing the function `onDocumentationListVisible()`[0] which similar to `onStatusListVisible` should toggle a boolean variable when the dropdown is shown. This PR adds the function and associated boolean variable.

[0] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/layout/header/header.component.html#L134
