### PR TITLE
fix(deployments): always show resource card

### DIFF
--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,16 +1,14 @@
-<ng-container *ngIf="environment && spaceId">
-  <div class="card-pf">
-    <div class="card-pf-body resource-card-body">
-      <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment.name)"></utilization-bar>
-      <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getEnvironmentMemoryStat(spaceId, environment.name)"></utilization-bar>
-    </div>
+<div class="card-pf" *ngIf="environment && spaceId; else loading">
+  <div class="card-pf-body resource-card-body">
+    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment.name)"></utilization-bar>
+    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getEnvironmentMemoryStat(spaceId, environment.name)"></utilization-bar>
   </div>
-</ng-container>
-<ng-container *ngIf="!environment || !spaceId">
+</div>
+<ng-template #loading>
   <div class="card-pf">
     <div class="card-pf-body resource-card-body">
       <loading-utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'"></loading-utilization-bar>
       <loading-utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="'MB'"></loading-utilization-bar>
     </div>
   </div>
-</ng-container>
+</ng-template>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="active">
+<ng-container *ngIf="environment && spaceId">
   <div class="card-pf">
     <div class="card-pf-body resource-card-body">
       <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment.name)"></utilization-bar>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -56,7 +56,6 @@ describe('ResourceCardComponent', () => {
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
   let cpuStatMock: Observable<CpuStat> = Observable.of({ used: 1, quota: 2 });
   let memoryStatMock: Observable<MemoryStat> = Observable.of({ used: 3, quota: 4, units: 'GB' as MemoryUnit  });
-  let active: Subject<boolean> = new BehaviorSubject<boolean>(true);
 
   beforeEach(() => {
     mockSvc = createMock(DeploymentsService);
@@ -67,7 +66,6 @@ describe('ResourceCardComponent', () => {
     ]));
     mockSvc.getEnvironmentCpuStat.and.returnValue(cpuStatMock);
     mockSvc.getEnvironmentMemoryStat.and.returnValue(memoryStatMock);
-    mockSvc.isDeployedInEnvironment.and.returnValue(active);
   });
 
   initContext(ResourceCardComponent, HostComponent,
@@ -81,12 +79,8 @@ describe('ResourceCardComponent', () => {
     }
   );
 
-  it('should be active', function(this: Context) {
-    expect(this.testedDirective.active).toBeTruthy();
-  });
 
   it('should correctly request the deployed environment data', function(this: Context) {
-    expect(mockSvc.isDeployedInEnvironment).toHaveBeenCalledWith('spaceId', 'stage');
     expect(mockSvc.getEnvironmentCpuStat).toHaveBeenCalledWith('spaceId', 'stage');
     expect(mockSvc.getEnvironmentMemoryStat).toHaveBeenCalledWith('spaceId', 'stage');
   });
@@ -105,13 +99,4 @@ describe('ResourceCardComponent', () => {
     expect(memoryUtilBar.resourceUnit).toEqual('GB');
     expect(memoryUtilBar.stat).toEqual(memoryStatMock);
   });
-
-  describe('inactive environment', () => {
-    it('should not display', function(this: Context) {
-      active.next(false);
-      this.detectChanges();
-      expect(this.testedDirective.active).toBeFalsy();
-    });
-  });
-
 });

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -20,7 +20,6 @@ export class ResourceCardComponent implements OnInit {
   @Input() environment: Environment;
 
   memUnit: Observable<string>;
-  active: boolean = false;
 
   constructor(
     private deploymentsService: DeploymentsService
@@ -28,16 +27,9 @@ export class ResourceCardComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.spaceId && this.environment) {
-      this.deploymentsService
-      .isDeployedInEnvironment(this.spaceId, this.environment.name)
-      .subscribe((active: boolean) => {
-        this.active = active;
-        if (active) {
-          this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment.name)
-            .first()
-            .map((stat: MemoryStat) => stat.units);
-        }
-      });
+      this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment.name)
+        .first()
+        .map((stat: MemoryStat) => stat.units);
     }
   }
 }

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -28,7 +28,6 @@ export class ResourceCardComponent implements OnInit {
   ngOnInit(): void {
     if (this.spaceId && this.environment) {
       this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment.name)
-        .first()
         .map((stat: MemoryStat) => stat.units);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/2735

The resource cards are always shown. This was actually the initial behavior and then code was added (I think by me) to hide it if there were 0 deployments. The code is removed.