### PR TITLE
fix(file name): correct file name format

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -361,7 +361,7 @@ module.exports = function (options) {
               includePaths: [
                 path.resolve(__dirname, "../node_modules/patternfly/dist/fonts/")
               ],
-              name: '_assets/fonts/[name].' + (isProd ? '[hash]' : '') + '[ext]'
+              name: '_assets/fonts/[name]' + (isProd ? '[hash]' : '') + '.[ext]'
             }
           },
           exclude: path.resolve(__dirname, "../src/assets/images/")
@@ -375,7 +375,7 @@ module.exports = function (options) {
               includePaths: [
                 path.resolve(__dirname, "../src/assets/images/")
               ],
-              name: '_assets/images/[name].' + (isProd ? '[hash]' : '') + '[ext]'
+              name: '_assets/images/[name]' + (isProd ? '[hash]' : '') + '.[ext]'
             }
           },
           exclude: path.resolve(__dirname, "../node_modules/patternfly/dist/fonts/")


### PR DESCRIPTION
This PR fix broken file names for images and fonts.
Before fix:<some_image_name>.<some_hash>png
After fix:<some_image_name><some_hash>.png

Note, the dot (.) moved before hash value to after hash value. This issue was came into attention when working on fabric8-ui/fabric8-ui-openshift-nginx#17 where browser cache setting are dependent on file extension in nginx. Currently, browser cache is NOT dependent on file extension but it's better to fix this broken name issue.