### PR TITLE
fix(cleanup): fixed typo on cleanup page (it's -> its)

### DIFF
--- a/src/app/profile/cleanup/cleanup.component.html
+++ b/src/app/profile/cleanup/cleanup.component.html
@@ -6,7 +6,7 @@
         <strong>{{notificationTitle}}</strong> {{notificationText}}
       </div>
       <h3 *ngIf="cleanupStatus === 'notstarted'">
-        <strong>You are about to erase all of your OpenShift.io spaces</strong>, reverting your OpenShift.io environment to it's default state.
+        <strong>You are about to erase all of your OpenShift.io spaces</strong>, reverting your OpenShift.io environment to its default state.
         This action will not affect your GitHub account or repositories associated with OpenShift.io.
       </h3>
       <h3 *ngIf="cleanupStatus === 'notstarted'">Your account will be reset and the following spaces will be removed.</h3>


### PR DESCRIPTION
On Reset Environment page, changed:

"...reverting your OpenShift.io environment to it's default state."

to:

"...reverting your OpenShift.io environment to its default state."