### PR TITLE
Codebases dashboard widget updates immediately after forge wizard completion

### DIFF
--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
@@ -11,7 +11,7 @@
       </h2>
     </div>
     <div class="card-pf-body f8-card-body">
-      <div class="f8-blank-slate-card" *ngIf="codebaseCount === 0">
+      <div class="f8-blank-slate-card" *ngIf="codebases.length === 0">
         <h3>This Space has no Codebases</h3>
         <div class="f8-blank-slate-main-action">
           <button id="spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
@@ -20,7 +20,7 @@
           <button id="spacehome-codebases-import-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-codebase' } }]">Import Codebase</button>
         </div>
       </div>
-      <div id="spacehome-codebases-card-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebaseCount > 0">
+      <div id="spacehome-codebases-card-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
         <div class="list-group-item list-view-pf-stacked list-view-pf-top-align" *ngFor="let codebase of codebases">
           <div class="list-view-pf-checkbox f8-card-list-view-pf-checkbox-icon">
             <span class="avatar fa" [ngClass]="{'fa-github fa-2x': codebase.attributes.type === 'git'}"></span>
@@ -50,11 +50,11 @@
       </div>
       <h2 class="card-pf-title">
         <a id="spacehome-codebases-title" href="#" [routerLink]="[contextPath, 'create']">Codebases</a>
-        <span id="spacehome-codebases-badge" class="badge f8-card-badge">{{codebaseCount}}</span>
+        <span id="spacehome-codebases-badge" class="badge f8-card-badge">{{codebases.length}}</span>
       </h2>
     </div>
     <div class="card-pf-body f8-card-body">
-      <div class="f8-blank-slate-card" *ngIf="codebaseCount === 0">
+      <div class="f8-blank-slate-card" *ngIf="codebases.length === 0">
         <h3>This Space has no Codebases</h3>
         <div class="f8-blank-slate-main-action">
           <button id="spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
@@ -63,7 +63,7 @@
           <button id="spacehome-my-codebases-import-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-codebase' } }]">Import Codebase</button>
         </div>
       </div>
-      <ul id="spacehome-codebases-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebaseCount > 0">
+      <ul id="spacehome-codebases-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
         <li class="list-group-item" *ngFor="let codebase of codebases">
           <div class="list-view-pf-main-info">
             <div class="list-view-pf-body">

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.spec.ts
@@ -1,0 +1,210 @@
+import {
+  Component,
+  NO_ERRORS_SCHEMA
+} from '@angular/core';
+
+import {
+  Observable,
+  Subject
+} from 'rxjs';
+
+import { Broadcaster } from 'ngx-base';
+import {
+  Context,
+  Contexts
+} from 'ngx-fabric8-wit';
+
+import { Codebase } from '../../space/create/codebases/services/codebase';
+import { CodebasesService } from '../../space/create/codebases/services/codebases.service';
+import { AddCodebaseWidgetComponent } from './add-codebase-widget.component';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+@Component({
+  template: '<fabric8-add-codebase-widget></fabric8-add-codebase-widget>'
+})
+class HostComponent { }
+
+describe('AddCodebaseWidgetComponent', () => {
+  type TestingContext = TestContext<AddCodebaseWidgetComponent, HostComponent>;
+
+  let mockBroadcaster: jasmine.SpyObj<Broadcaster>;
+  let codebaseAddedSubject: Subject<Codebase>;
+  let codebaseDeletedSubject: Subject<Codebase>;
+
+  let mockContexts: Contexts;
+  let contextSubject: Subject<Context>;
+
+  let mockCodebasesService: jasmine.SpyObj<CodebasesService>;
+  let codebasesSubject: Subject<Codebase[]>;
+
+  beforeEach(() => {
+    mockBroadcaster = createMock(Broadcaster);
+    codebaseAddedSubject = new Subject<Codebase>();
+    codebaseDeletedSubject = new Subject<Codebase>();
+    mockBroadcaster.on.and.callFake((key: string): Observable<Codebase> => {
+      if (key === 'codebaseAdded') {
+        return codebaseAddedSubject;
+      } else if (key === 'codebaseDeleted') {
+        return codebaseDeletedSubject;
+      } else {
+        throw new Error(`Unknown broadcast key ${key}`);
+      }
+    });
+
+    contextSubject = new Subject<Context>();
+    mockContexts = {
+      current: contextSubject,
+      recent: Observable.empty(),
+      default: Observable.empty()
+    } as Contexts;
+
+    mockCodebasesService = createMock(CodebasesService);
+    codebasesSubject = new Subject<Codebase[]>();
+    mockCodebasesService.getCodebases.and.returnValue(codebasesSubject);
+  });
+
+  initContext(AddCodebaseWidgetComponent, HostComponent, {
+    providers: [
+      { provide: Broadcaster, useFactory: () => mockBroadcaster },
+      { provide: Contexts, useFactory: () => mockContexts },
+      { provide: CodebasesService, useFactory: () => mockCodebasesService }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
+
+  it('should be instantiable', function(this: TestingContext) {
+    expect(this.testedDirective).toBeTruthy();
+  });
+
+  it('should listen for codebaseAdded events', function(this: TestingContext) {
+    expect(mockBroadcaster.on).toHaveBeenCalledWith('codebaseAdded');
+  });
+
+  it('should listen for codebaseDeleted events', function(this: TestingContext) {
+    expect(mockBroadcaster.on).toHaveBeenCalledWith('codebaseDeleted');
+  });
+
+  it('should listen for context space changes', function(this: TestingContext) {
+    expect(this.testedDirective.context).toBeUndefined();
+    expect(this.testedDirective.contextPath).toBeUndefined();
+
+    const contextA: Context = {
+      path: 'context-path',
+        space: {
+        id: 'space-id'
+      }
+    } as Context;
+    contextSubject.next(contextA);
+    expect(this.testedDirective.context).toEqual(contextA);
+    expect(this.testedDirective.contextPath).toEqual(contextA.path);
+
+    const contextB: Context = {
+      path: 'context-path-2',
+      space: {
+        id: 'space-id-2'
+      }
+    } as Context;
+    contextSubject.next(contextB);
+    expect(this.testedDirective.context).toEqual(contextB);
+    expect(this.testedDirective.contextPath).toEqual(contextB.path);
+  });
+
+  it('should add Codebase when codebaseAdded event observed', function(this: TestingContext) {
+    expect(this.testedDirective.codebases).toEqual([]);
+
+    const codebaseA: Codebase = {
+      attributes: {
+        url: 'git@github.com:fabric8-ui/fabric8-ui.git'
+      },
+      id: '1',
+      name: 'fabric8-ui/fabric8-ui'
+    } as Codebase;
+    codebaseAddedSubject.next(codebaseA);
+    expect(this.testedDirective.codebases).toEqual([codebaseA]);
+
+    const codebaseB: Codebase = {
+      attributes: {
+        url: 'git@github.com:openshiftio/openshift.io.git'
+      },
+      id: '2',
+      name: 'openshiftio/openshift.io'
+    } as Codebase;
+    codebaseAddedSubject.next(codebaseB);
+    expect(this.testedDirective.codebases).toEqual([codebaseB, codebaseA]);
+  });
+
+  it('should remove Codebase when codebaseRemoved event observed', function(this: TestingContext) {
+    expect(this.testedDirective.codebases).toEqual([]);
+
+    const codebaseA: Codebase = {
+      attributes: {
+        url: 'git@github.com:fabric8-ui/fabric8-ui.git'
+      },
+      id: '1',
+      name: 'fabric8-ui/fabric8-ui'
+    } as Codebase;
+    codebaseAddedSubject.next(codebaseA);
+    expect(this.testedDirective.codebases).toEqual([codebaseA]);
+
+    const codebaseB: Codebase = {
+      attributes: {
+        url: 'git@github.com:openshiftio/openshift.io.git'
+      },
+      id: '2',
+      name: 'openshiftio/openshift.io'
+    } as Codebase;
+    codebaseAddedSubject.next(codebaseB);
+    expect(this.testedDirective.codebases).toEqual([codebaseB, codebaseA]);
+
+    codebaseDeletedSubject.next(codebaseA);
+    expect(this.testedDirective.codebases).toEqual([codebaseB]);
+  });
+
+  it('should load Codebases from service when current context changes and contains a space', function(this: TestingContext) {
+    const context: Context = {
+      path: 'context-path',
+        space: {
+        id: 'space-id'
+      }
+    } as Context;
+    contextSubject.next(context);
+    expect(mockCodebasesService.getCodebases).toHaveBeenCalledWith('space-id');
+
+    const uiCodebase: Codebase = {
+      attributes: {
+        url: 'git@github.com:fabric8-ui/fabric8-ui.git'
+      },
+      id: '1',
+      name: 'fabric8-ui/fabric8-ui'
+    } as Codebase;
+    const osioCodebase: Codebase = {
+      attributes: {
+        url: 'git@github.com:openshiftio/openshift.io'
+      },
+      id: '2',
+      name: 'openshiftio/openshift.io'
+    } as Codebase;
+    const witCodebase: Codebase = {
+      attributes: {
+        url: 'git@github.com:fabric8-services/fabric8-wit.git'
+      },
+      id: '3',
+      name: 'fabric8-services/fabric8-wit'
+    } as Codebase;
+    expect(this.testedDirective.codebases).toEqual([]);
+    codebasesSubject.next([uiCodebase, osioCodebase, witCodebase]);
+    expect(this.testedDirective.codebases).toEqual([osioCodebase, uiCodebase, witCodebase]);
+
+    expect(mockCodebasesService.getCodebases).toHaveBeenCalledTimes(1);
+    const newContext: Context = {
+      path: 'context-path'
+    } as Context;
+    contextSubject.next(newContext);
+    expect(mockCodebasesService.getCodebases).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.ts
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.ts
@@ -26,8 +26,7 @@ import { CodebasesService } from '../../space/create/codebases/services/codebase
 })
 export class AddCodebaseWidgetComponent implements OnInit, OnDestroy {
 
-  codebases: Codebase[];
-  codebaseCount: number;
+  codebases: Codebase[] = [];
   context: Context;
   contextPath: string;
   subscriptions: Subscription[] = [];
@@ -78,7 +77,6 @@ export class AddCodebaseWidgetComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.codebaseService.getCodebases(this.context.space.id).subscribe((codebases) => {
         this.codebases = codebases;
-        this.codebaseCount = codebases.length;
         this.sortCodebases();
       })
     );

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.ts
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.ts
@@ -1,6 +1,20 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
-import { Contexts } from 'ngx-fabric8-wit';
+import {
+  Component,
+  EventEmitter,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewEncapsulation
+} from '@angular/core';
+
 import { Subscription } from 'rxjs';
+
+import { Broadcaster } from 'ngx-base';
+import {
+  Context,
+  Contexts
+} from 'ngx-fabric8-wit';
+
 import { Codebase } from '../../space/create/codebases/services/codebase';
 import { CodebasesService } from '../../space/create/codebases/services/codebases.service';
 
@@ -14,29 +28,64 @@ export class AddCodebaseWidgetComponent implements OnInit, OnDestroy {
 
   codebases: Codebase[];
   codebaseCount: number;
+  context: Context;
   contextPath: string;
-  contextSubscription: Subscription;
   subscriptions: Subscription[] = [];
   @Output() addToSpace = new EventEmitter();
 
   constructor(
-    private context: Contexts,
+    private broadcaster: Broadcaster,
+    private contexts: Contexts,
     private codebaseService: CodebasesService
-  ) {}
+  ) { }
 
   ngOnInit() {
-    this.contextSubscription = this.context.current.subscribe(context => {
+    this.subscriptions.push(this.broadcaster
+      .on('codebaseAdded')
+      .subscribe((codebase: Codebase) => {
+        this.addCodebase(codebase);
+      }));
+
+    this.subscriptions.push(this.broadcaster
+      .on('codebaseDeleted')
+      .subscribe((codebase: Codebase) => {
+        this.removeCodebase(codebase);
+      }));
+
+    this.subscriptions.push(this.contexts.current.subscribe(context => {
+      this.context = context;
       this.contextPath = context.path;
       if (context.space) {
-        this.codebaseService.getCodebases(context.space.id).subscribe((codebases) => {
-          this.codebases = codebases;
-          this.codebaseCount = codebases.length;
-        });
+        this.updateCodebases();
       }
-    });
+    }));
   }
 
   ngOnDestroy() {
-    this.contextSubscription.unsubscribe();
+    this.subscriptions.forEach((s: Subscription): void => s.unsubscribe());
   }
+
+  private addCodebase(codebase: Codebase): void {
+    this.codebases.push(codebase);
+    this.sortCodebases();
+  }
+
+  private removeCodebase(codebase: Codebase): void {
+    this.codebases = this.codebases.filter((cb: Codebase): boolean => cb.id !== codebase.id);
+  }
+
+  private updateCodebases(): void {
+    this.subscriptions.push(
+      this.codebaseService.getCodebases(this.context.space.id).subscribe((codebases) => {
+        this.codebases = codebases;
+        this.codebaseCount = codebases.length;
+        this.sortCodebases();
+      })
+    );
+  }
+
+  private sortCodebases(): void {
+    this.codebases.sort((a: Codebase, b: Codebase): number => -1 * a.name.localeCompare(b.name));
+  }
+
 }

--- a/src/app/space/forge-wizard/abstract-wizard.component.ts
+++ b/src/app/space/forge-wizard/abstract-wizard.component.ts
@@ -1,7 +1,7 @@
 import { EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { Notification, Notifications, NotificationType } from 'ngx-base';
+import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
 import { Context, Space } from 'ngx-fabric8-wit';
 import {
   ForgeService,
@@ -44,6 +44,7 @@ export abstract class AbstractWizard implements OnInit {
   validation: Promise<boolean>;
 
   constructor(public forgeService: ForgeService,
+              public broadcaster: Broadcaster,
               public codebasesService: CodebasesService,
               public context: ContextService,
               public notifications: Notifications) {
@@ -87,8 +88,12 @@ export abstract class AbstractWizard implements OnInit {
     });
     obs.subscribe(
       codebase => {
-        // todo broadcast
-        // this._broadcaster.broadcast('codebaseAdded', codebase);
+        if (codebase.attributes.type === 'git') {
+          codebase.name = codebase.attributes.url.replace('.git', '').replace('git@github.com:', '');
+        } else {
+          codebase.name = codebase.attributes.url;
+        }
+        this.broadcaster.broadcast('codebaseAdded', codebase);
         this.notifications.message(<Notification> {
           message: `Your ${codebase.attributes.url} repository has been `
           + `added to the ${this.currentSpace.attributes.name} space`,

--- a/src/app/space/forge-wizard/import-wizard.component.ts
+++ b/src/app/space/forge-wizard/import-wizard.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
-import { Notifications } from 'ngx-base';
+import { Broadcaster, Notifications } from 'ngx-base';
 import { ForgeService } from 'ngx-forge';
 import { Gui, Input } from 'ngx-forge';
 import { Observable } from 'rxjs/Rx';
@@ -22,8 +22,9 @@ export class ForgeImportWizardComponent extends AbstractWizard {
   constructor(forgeService: ForgeService,
               codebasesService: CodebasesService,
               context: ContextService,
-              notifications: Notifications) {
-    super(forgeService, codebasesService, context, notifications);
+              notifications: Notifications,
+              broadcaster: Broadcaster) {
+    super(forgeService, broadcaster, codebasesService, context, notifications);
     this.endPoint = 'fabric8-import-git';
     this.steps = configureSteps();
     this.isLoading = true;

--- a/src/app/space/forge-wizard/quickstart-wizard.component.ts
+++ b/src/app/space/forge-wizard/quickstart-wizard.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
-import { Notifications } from 'ngx-base';
+import { Broadcaster, Notifications } from 'ngx-base';
 import { ForgeService } from 'ngx-forge';
 import { Gui, Input } from 'ngx-forge';
 
@@ -20,8 +20,9 @@ export class ForgeQuickstartComponent extends AbstractWizard {
   constructor(forgeService: ForgeService,
               codebasesService: CodebasesService,
               context: ContextService,
-              notifications: Notifications) {
-    super(forgeService, codebasesService, context, notifications);
+              notifications: Notifications,
+              broadcaster: Broadcaster) {
+    super(forgeService, broadcaster, codebasesService, context, notifications);
     this.endPoint = 'fabric8-new-project';
     this.steps = configureSteps();
     this.isLoading = true;


### PR DESCRIPTION
This PR adds a feature to the Codebases widget on the space "Analyze" dashboard so that upon completing the "Add to space" wizard, a newly imported or created codebase will be automatically displayed in the widget rather than requiring the page to be reloaded. This solves the problem of the widget becoming stale whenever the wizard is used and completed by a user within the same Analyze tab, but does not solve the problem of the widget becoming stale if the wizard is completed in a different tab, by a different user, etc., or if a Codebase is added to the Space via some other manner than the wizard.

This required a TODO for adding a Broadcast in the wizard to be completed as well (first commit in the series) - this can be easily removed from this PR so that an owner of the wizard components can implement this differently if that's desired. FWIW the CodebasesComponent also had an existing expectation for the codebaseAdded broadcast to possibly be emitted, which is why I thought this would already exist.