### PR TITLE
fix(version): update fabric8-planner to 0.43.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "angular2-websocket": "0.9.5",
     "chunk-manifest-webpack2-plugin": "1.0.1",
     "core-js": "2.5.1",
-    "fabric8-planner": "0.42.31",
+    "fabric8-planner": "0.43.5",
     "fabric8-stack-analysis-ui": "0.11.2",
     "http-server": "0.10.0",
     "ie-shim": "0.1.0",


### PR DESCRIPTION
Introduces ngrx planner. Overall the planner will work much faster.
The board view has **not** been moved to ngrx.