### PR TITLE
Fix pipelines console link to be acquired dynamically

### DIFF
--- a/src/app/space/create/pipelines/pipelines.component.html
+++ b/src/app/space/create/pipelines/pipelines.component.html
@@ -16,12 +16,14 @@
               <li>
                 <a (click)="openForgeWizard(updateSpace)">Add to Space</a>
               </li>
-              <li class="divider"></li>
-              <li>
-                <a [href]="openshiftConsoleUrl" *ngIf="openshiftConsoleUrl"
-                   title="View in the OpenShift Console" target="_blank">Open in OpenShift Console
-                </a>
-              </li>
+              <ng-container *ngIf="consoleAvailable">
+                <li class="divider"></li>
+                <li>
+                  <a [href]="openshiftConsoleUrl"
+                     title="View in the OpenShift Console" target="_blank">Open in OpenShift Console
+                  </a>
+                </li>
+              </ng-container>
             </ul>
           </div>
         </div>

--- a/src/app/space/create/pipelines/pipelines.component.html
+++ b/src/app/space/create/pipelines/pipelines.component.html
@@ -11,19 +11,21 @@
                     aria-haspopup='true' aria-expanded='true' dropdownToggle>
               <span class='fa fa-ellipsis-v'></span>
             </button>
-
             <ul class='dropdown-menu-right dropdown-menu' aria-labelledby='dropdownKebabRight9' role="menu" *dropdownMenu>
               <li>
                 <a (click)="openForgeWizard(updateSpace)">Add to Space</a>
               </li>
-              <ng-container *ngIf="consoleAvailable">
-                <li class="divider"></li>
-                <li>
-                  <a [href]="openshiftConsoleUrl"
-                     title="View in the OpenShift Console" target="_blank">Open in OpenShift Console
+              <li class="divider"></li>
+              <li [ngClass]="{'disabled': !consoleAvailable}">
+                <a [href]="openshiftConsoleUrl" *ngIf="consoleAvailable; else consoleDisabled" target="_blank">
+                  Open in OpenShift Console
+                </a>
+                <ng-template #consoleDisabled>
+                  <a tooltip="Openshift Console unavailable" target="_blank" disabled>
+                    Open in OpenShift Console
                   </a>
-                </li>
-              </ng-container>
+                </ng-template>
+              </li>
             </ul>
           </div>
         </div>

--- a/src/app/space/create/pipelines/services/pipelines.service.spec.ts
+++ b/src/app/space/create/pipelines/services/pipelines.service.spec.ts
@@ -309,4 +309,70 @@ describe('Pipelines Service', () => {
       );
   });
 
+  describe('PipelinesService - OK calls', () => {
+    const userServiceResponse = {
+      'data': {
+        'attributes': {
+          'created-at': '2017-05-11T16:44:56.376777Z',
+          'namespaces': [{
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:44:56.561538Z',
+            'name': 'blob',
+            'state': 'created',
+            'type': 'user',
+            'updated-at': '2017-05-11T16:44:56.561538Z',
+            'version': '1.0.91'
+          }]
+        },
+        'id': 'eae1de87-f58f-4e67-977a-95024dd7c6aa',
+        'type': 'userservices'
+      }
+    };
+
+    var subscription: Subscription;
+
+    beforeEach(() => {
+      this.subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(
+          new ResponseOptions({
+            body: JSON.stringify(userServiceResponse),
+            status: 200
+          })
+        ));
+      });
+    });
+
+    it('should emit response with repeat calls', (done: DoneFn) => {
+      svc.getOpenshiftConsoleUrl()
+        .subscribe(
+          (msg: string) => {
+            expect(msg).toEqual('https://console.starter-us-east-2.openshift.com/console/project/blob/browse/pipelines');
+            done();
+          },
+          (err: string) => {
+            done.fail(err);
+          }
+        );
+
+      svc.getOpenshiftConsoleUrl()
+        .subscribe(
+          (msg: string) => {
+            expect(msg).toEqual('https://console.starter-us-east-2.openshift.com/console/project/blob/browse/pipelines');
+            done();
+          },
+          (err: string) => {
+            done.fail(err);
+          }
+        );
+    });
+
+    afterEach(() => {
+      this.subscription.unsubscribe();
+    });
+  });
+
 });

--- a/src/app/space/create/pipelines/services/pipelines.service.spec.ts
+++ b/src/app/space/create/pipelines/services/pipelines.service.spec.ts
@@ -336,7 +336,7 @@ describe('Pipelines Service', () => {
     var subscription: Subscription;
 
     beforeEach(() => {
-      this.subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+      subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(
           new ResponseOptions({
             body: JSON.stringify(userServiceResponse),
@@ -351,18 +351,16 @@ describe('Pipelines Service', () => {
         .subscribe(
           (msg: string) => {
             expect(msg).toEqual('https://console.starter-us-east-2.openshift.com/console/project/blob/browse/pipelines');
-            done();
-          },
-          (err: string) => {
-            done.fail(err);
-          }
-        );
-
-      svc.getOpenshiftConsoleUrl()
-        .subscribe(
-          (msg: string) => {
-            expect(msg).toEqual('https://console.starter-us-east-2.openshift.com/console/project/blob/browse/pipelines');
-            done();
+            svc.getOpenshiftConsoleUrl()
+            .subscribe(
+              (msg: string) => {
+                expect(msg).toEqual('https://console.starter-us-east-2.openshift.com/console/project/blob/browse/pipelines');
+                done();
+              },
+              (err: string) => {
+                done.fail(err);
+              }
+            );
           },
           (err: string) => {
             done.fail(err);
@@ -371,7 +369,7 @@ describe('Pipelines Service', () => {
     });
 
     afterEach(() => {
-      this.subscription.unsubscribe();
+      subscription.unsubscribe();
     });
   });
 

--- a/src/app/space/create/pipelines/services/pipelines.service.spec.ts
+++ b/src/app/space/create/pipelines/services/pipelines.service.spec.ts
@@ -1,0 +1,312 @@
+import { ErrorHandler } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  HttpModule,
+  Response,
+  ResponseOptions,
+  ResponseType,
+  XHRBackend
+} from '@angular/http';
+
+import {
+  MockBackend,
+  MockConnection
+} from '@angular/http/testing';
+
+import { createMock } from 'testing/mock';
+
+import {
+  Observable,
+  Subject,
+  Subscription
+} from 'rxjs';
+
+import { Logger } from 'ngx-base';
+
+import { NotificationsService } from 'app/shared/notifications.service';
+
+import { AuthenticationService } from 'ngx-login-client';
+
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+
+import { PipelinesService } from './pipelines.service';
+
+interface MockHttpParams<U> {
+  url: string;
+  response: { data: {} } | Response;
+  expected?: U;
+  expectedError?: any;
+  observable: Observable<U>;
+  done: DoneFn;
+}
+
+describe('Pipelines Service', () => {
+
+  let mockBackend: MockBackend;
+  let mockLogger: jasmine.SpyObj<Logger>;
+  let mockErrorHandler: jasmine.SpyObj<ErrorHandler>;
+  let mockNotificationsService: jasmine.SpyObj<NotificationsService>;
+  let svc: PipelinesService;
+
+  beforeEach(() => {
+    const mockAuthService: jasmine.SpyObj<AuthenticationService> = createMock(AuthenticationService);
+    mockAuthService.getToken.and.returnValue('mock-auth-token');
+
+    mockLogger = jasmine.createSpyObj<Logger>('Logger', ['error']);
+    mockErrorHandler = jasmine.createSpyObj<ErrorHandler>('ErrorHandler', ['handleError']);
+    mockNotificationsService = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
+
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        {
+          provide: XHRBackend, useClass: MockBackend
+        },
+        {
+          provide: AuthenticationService, useValue: mockAuthService
+        },
+        {
+          provide: WIT_API_URL, useValue: 'http://example.com/'
+        },
+        {
+          provide: Logger, useValue: mockLogger
+        },
+        {
+          provide: ErrorHandler, useValue: mockErrorHandler
+        },
+        {
+          provide: NotificationsService, useValue: mockNotificationsService
+        },
+        PipelinesService
+      ]
+    });
+    svc = TestBed.get(PipelinesService);
+    mockBackend = TestBed.get(XHRBackend);
+  });
+
+  it('should return openshift console url if it exists', (done: DoneFn) => {
+    const userServiceResponse = {
+      'data': {
+        'attributes': {
+          'created-at': '2017-05-11T16:44:56.376777Z',
+          'namespaces': [{
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:44:56.561538Z',
+            'name': 'blob',
+            'state': 'created',
+            'type': 'user',
+            'updated-at': '2017-05-11T16:44:56.561538Z',
+            'version': '1.0.91'
+          }, {
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:45:02.916855Z',
+            'name': 'blob-che',
+            'state': 'created',
+            'type': 'che',
+            'updated-at': '2017-05-11T16:45:02.916855Z',
+            'version': '1.0.154'
+          }, {
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:45:05.119179Z',
+            'name': 'blob-jenkins',
+            'state': 'created',
+            'type': 'jenkins',
+            'updated-at': '2017-05-11T16:45:05.119179Z',
+            'version': '1.0.154'
+          }, {
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:45:05.296929Z',
+            'name': 'blob-run',
+            'state': 'created',
+            'type': 'run',
+            'updated-at': '2017-05-11T16:45:05.296929Z',
+            'version': '1.0.154'
+          }, {
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:45:05.493244Z',
+            'name': 'blob-stage',
+            'state': 'created',
+            'type': 'stage',
+            'updated-at': '2017-05-11T16:45:05.493244Z',
+            'version': '1.0.154'
+          }]
+        },
+        'id': 'eae1de87-f58f-4e67-977a-95024dd7c6aa',
+        'type': 'userservices'
+      }
+    };
+
+    const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify(userServiceResponse),
+          status: 200
+        })
+      ));
+    });
+
+    svc.getOpenshiftConsoleUrl()
+      .subscribe(
+        (msg: string) => {
+          expect(msg).toEqual('https://console.starter-us-east-2.openshift.com/console/project/blob/browse/pipelines');
+          subscription.unsubscribe();
+          done();
+        },
+        (err: string) => {
+          done.fail(err);
+        }
+      );
+  });
+
+  it('should return empty if openshift console url does not exist', (done: DoneFn) => {
+    const userServiceResponse = {
+      'data': {
+        'attributes': {
+          'created-at': '2017-05-11T16:44:56.376777Z',
+          'namespaces': [{
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:44:56.561538Z',
+            'name': 'blob',
+            'state': 'created',
+            'type': 'user',
+            'updated-at': '2017-05-11T16:44:56.561538Z',
+            'version': '1.0.91'
+          }]
+        },
+        'id': 'eae1de87-f58f-4e67-977a-95024dd7c6aa',
+        'type': 'userservices'
+      }
+    };
+
+    const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify(userServiceResponse),
+          status: 200
+        })
+      ));
+    });
+
+    svc.getOpenshiftConsoleUrl()
+      .subscribe(
+        (msg: string) => {
+          expect(msg).toEqual('');
+          subscription.unsubscribe();
+          done();
+        },
+        (err: string) => {
+          done.fail(err);
+        }
+      );
+  });
+
+  it('should return empty if no namespace of type user exists', (done: DoneFn) => {
+    const userServiceResponse = {
+      'data': {
+        'attributes': {
+          'created-at': '2017-05-11T16:44:56.376777Z',
+          'namespaces': [{
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:44:56.561538Z',
+            'name': 'blob',
+            'state': 'created',
+            'type': 'jenkins',
+            'updated-at': '2017-05-11T16:44:56.561538Z',
+            'version': '1.0.91'
+          }, {
+            'cluster-app-domain': '8a09.starter-us-east-2.openshiftapps.com',
+            'cluster-console-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-logging-url': 'https://console.starter-us-east-2.openshift.com/console/',
+            'cluster-metrics-url': 'https://metrics.starter-us-east-2.openshift.com/',
+            'cluster-url': 'https://api.starter-us-east-2.openshift.com/',
+            'created-at': '2017-05-11T16:45:02.916855Z',
+            'name': 'blob-che',
+            'state': 'created',
+            'type': 'che',
+            'updated-at': '2017-05-11T16:45:02.916855Z',
+            'version': '1.0.154'
+          }]
+        },
+        'id': 'eae1de87-f58f-4e67-977a-95024dd7c6aa',
+        'type': 'userservices'
+      }
+    };
+
+    const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify(userServiceResponse),
+          status: 200
+        })
+      ));
+    });
+
+    svc.getOpenshiftConsoleUrl()
+      .subscribe(
+        (msg: string) => {
+          expect(msg).toEqual('');
+          subscription.unsubscribe();
+          done();
+        },
+        (err: string) => {
+          done.fail(err);
+        }
+      );
+  });
+
+  it('should notify error handler and logger if http response is not okay', (done: DoneFn) => {
+    const subscription: Subscription = mockBackend.connections.subscribe((connection: MockConnection) => {
+      connection.mockError(new Response(
+        new ResponseOptions({
+          type: ResponseType.Error,
+          status: 400
+        })
+      ) as Response & Error);
+    });
+
+    svc.getOpenshiftConsoleUrl()
+      .subscribe(
+        (msg: string) => {
+          done.fail(msg);
+        },
+        (err: string) => {
+          done.fail(err);
+        },
+        () => {
+          expect(mockErrorHandler.handleError).toHaveBeenCalled();
+          expect(mockLogger.error).toHaveBeenCalled();
+          expect(mockNotificationsService.message).toHaveBeenCalled();
+          done();
+        }
+      );
+  });
+
+});

--- a/src/app/space/create/pipelines/services/pipelines.service.ts
+++ b/src/app/space/create/pipelines/services/pipelines.service.ts
@@ -1,0 +1,97 @@
+import {
+  ErrorHandler,
+  Inject,
+  Injectable
+} from '@angular/core';
+import {
+  Headers,
+  Http,
+  Response
+} from '@angular/http';
+
+import {
+  Observable,
+  Subscription
+} from 'rxjs';
+
+import {
+  Logger,
+  Notification,
+  NotificationType
+} from 'ngx-base';
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { AuthenticationService } from 'ngx-login-client';
+
+import { NotificationsService } from 'app/shared/notifications.service';
+
+export interface UserServiceResponse {
+  data: UserServiceData;
+}
+
+export interface UserServiceData {
+  attributes: UserServiceAttributes;
+}
+
+export interface UserServiceAttributes {
+  namespaces: UserServiceNamespace[];
+}
+
+export interface UserServiceNamespace {
+  name: string;
+  type: string;
+  'cluster-console-url': string;
+}
+
+@Injectable()
+export class PipelinesService {
+
+  private readonly headers: Headers = new Headers({ 'Content-Type': 'application/json' });
+  private readonly apiUrl: string;
+
+  private consoleObservable: Observable<string>;
+
+  constructor(
+    private readonly http: Http,
+    private readonly auth: AuthenticationService,
+    private readonly logger: Logger,
+    private readonly errorHandler: ErrorHandler,
+    private readonly notifications: NotificationsService,
+    @Inject(WIT_API_URL) private readonly witUrl: string
+  ) {
+    if (this.auth.getToken() != null) {
+      this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
+    }
+    this.apiUrl = witUrl + 'user/services';
+  }
+
+  getOpenshiftConsoleUrl(): Observable<string> {
+    if (!this.consoleObservable) {
+      this.consoleObservable = this.http.get(this.apiUrl, { headers: this.headers })
+        .map((resp: Response) => resp.json() as UserServiceResponse)
+        .catch((err: Response) => this.handleHttpError(err))
+        .map((resp: UserServiceResponse) => resp.data.attributes.namespaces)
+        .map((namespaces: UserServiceNamespace[]) => {
+          for (let namespace of namespaces) {
+            if (namespace.name && namespace.type && namespace.type === 'user' && namespace['cluster-console-url']) {
+              return namespace['cluster-console-url'] + 'project/' + namespace.name + '/browse/pipelines';
+            }
+          }
+
+          return '';
+        });
+    }
+
+    return this.consoleObservable;
+  }
+
+  private handleHttpError(response: Response): Observable<any> {
+    this.errorHandler.handleError(response);
+    this.logger.error(response);
+    this.notifications.message({
+      type: NotificationType.DANGER,
+      header: `Request failed: ${response.status} (${response.statusText})`,
+      message: response.text()
+    } as Notification);
+    return Observable.empty();
+  }
+}

--- a/src/app/space/create/pipelines/services/pipelines.service.ts
+++ b/src/app/space/create/pipelines/services/pipelines.service.ts
@@ -48,8 +48,6 @@ export class PipelinesService {
   private readonly headers: Headers = new Headers({ 'Content-Type': 'application/json' });
   private readonly apiUrl: string;
 
-  private consoleObservable: Observable<string>;
-
   constructor(
     private readonly http: Http,
     private readonly auth: AuthenticationService,
@@ -65,23 +63,19 @@ export class PipelinesService {
   }
 
   getOpenshiftConsoleUrl(): Observable<string> {
-    if (!this.consoleObservable) {
-      this.consoleObservable = this.http.get(this.apiUrl, { headers: this.headers })
-        .map((resp: Response) => resp.json() as UserServiceResponse)
-        .catch((err: Response) => this.handleHttpError(err))
-        .map((resp: UserServiceResponse) => resp.data.attributes.namespaces)
-        .map((namespaces: UserServiceNamespace[]) => {
-          for (let namespace of namespaces) {
-            if (namespace.name && namespace.type && namespace.type === 'user' && namespace['cluster-console-url']) {
-              return namespace['cluster-console-url'] + 'project/' + namespace.name + '/browse/pipelines';
-            }
+    return this.http.get(this.apiUrl, { headers: this.headers })
+      .map((resp: Response) => resp.json() as UserServiceResponse)
+      .catch((err: Response) => this.handleHttpError(err))
+      .map((resp: UserServiceResponse) => resp.data.attributes.namespaces)
+      .map((namespaces: UserServiceNamespace[]) => {
+        for (let namespace of namespaces) {
+          if (namespace.name && namespace.type && namespace.type === 'user' && namespace['cluster-console-url']) {
+            return namespace['cluster-console-url'] + 'project/' + namespace.name + '/browse/pipelines';
           }
+        }
 
-          return '';
-        });
-    }
-
-    return this.consoleObservable;
+        return '';
+      });
   }
 
   private handleHttpError(response: Response): Observable<any> {


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/2229

Adds a service to acquire openshift console url from WIT /api/user/services and uses it. Tested with account in 2 and account in 2a.
