### PR TITLE
Preserve visited URL when routing to _error (404) state

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,108 @@
+import { Location } from '@angular/common';
+import {
+  Component,
+  NO_ERRORS_SCHEMA
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { Broadcaster } from 'ngx-base';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { Spaces } from 'ngx-fabric8-wit';
+import { AuthenticationService } from 'ngx-login-client';
+import {
+  Observable,
+  Subject
+} from 'rxjs';
+
+import { OnLogin } from 'a-runtime-console';
+import { AboutService } from './shared/about.service';
+import { ProviderService } from './shared/account/provider.service';
+import { AnalyticService } from './shared/analytics.service';
+import { BrandingService } from './shared/branding.service';
+import { LoginService } from './shared/login.service';
+import { NotificationsService } from './shared/notifications.service';
+
+import { AppComponent } from './app.component';
+
+@Component({
+  template: '<f8-app></f8-app>'
+})
+class HostComponent { }
+
+@Component({
+  template: ''
+})
+class MockHomeComponent { }
+
+@Component({
+  template: ''
+})
+class MockErrorComponent { }
+
+describe('AppComponent', () => {
+  type Context = TestContext<AppComponent, HostComponent>;
+
+  const mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
+  mockBroadcaster.on.and.returnValue(Observable.never());
+
+  let testRouter: Router;
+  let testLocation: Location;
+
+  initContext(AppComponent, HostComponent, {
+    imports: [
+      RouterTestingModule.withRoutes([
+        { path: '_home', component: MockHomeComponent },
+        { path: '_error', component: MockErrorComponent },
+        { path: '**', redirectTo: '/_error' }
+      ])
+    ],
+    declarations: [
+      MockHomeComponent,
+      MockErrorComponent
+    ],
+    providers: [
+      {
+        provide: AboutService, useValue: {
+          buildVersion: '1.2.3',
+          buildNumber: '123',
+          buildTimestamp: '02468'
+        }
+      },
+      { provide: LoginService, useValue: jasmine.createSpyObj('LoginService', ['login']) },
+      { provide: NotificationsService, useValue: { actionSubject: new Subject<any>() } },
+      { provide: Spaces, useValue: null },
+      { provide: AnalyticService, useValue: null },
+      { provide: OnLogin, useValue: null },
+      { provide: AuthenticationService, useValue: null },
+      { provide: Broadcaster, useValue: mockBroadcaster },
+      { provide: BrandingService, useValue: createMock(BrandingService) },
+      { provide: BsModalService, useValue: createMock(BsModalService) },
+      { provide: ProviderService, useValue: createMock(ProviderService) }
+    ],
+    schemas: [ NO_ERRORS_SCHEMA ]
+  });
+
+  beforeEach(() => {
+    testRouter = TestBed.get(Router);
+    testLocation = TestBed.get(Location);
+  });
+
+  it('should preserve URL on error state redirect', function(this: Context, done: DoneFn) {
+    spyOn(testLocation, 'replaceState').and.callThrough();
+    testRouter.navigate(['/nonexistent/app/path']).then((status: boolean): void => {
+      expect(status).toBeTruthy();
+      expect(testRouter.url).toEqual('/_error');
+      expect(testLocation.replaceState).toHaveBeenCalledWith('/nonexistent/app/path');
+      expect(testLocation.path()).toEqual('/nonexistent/app/path');
+      done();
+    });
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Component, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
@@ -49,6 +50,7 @@ export class AppComponent {
     private authService: AuthenticationService,
     private broadcaster: Broadcaster,
     private router: Router,
+    private location: Location,
     private titleService: Title,
     private brandingService: BrandingService,
     private modalService: BsModalService,
@@ -63,6 +65,11 @@ export class AppComponent {
     this.activatedRoute.params.subscribe(() => {
       this.loginService.login();
     });
+
+    // preserve an invalid URL in the browser's history while routing to the 404 page
+    this.router.events
+      .filter(event => event instanceof NavigationEnd && event.urlAfterRedirects === '/_error')
+      .subscribe((event: NavigationEnd) => this.location.replaceState(event.url));
 
     this.router.events
       .filter(event => event instanceof NavigationEnd)

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -1,0 +1,127 @@
+import {
+  Component,
+  NO_ERRORS_SCHEMA
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+  ConnectableObservable,
+  Observable
+} from 'rxjs';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import {
+  Broadcaster,
+  Logger
+} from 'ngx-base';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { Contexts } from 'ngx-fabric8-wit';
+import {
+  AuthenticationService,
+  UserService
+} from 'ngx-login-client';
+
+import { LoginService } from '../../shared/login.service';
+
+import { HeaderComponent } from './header.component';
+
+@Component({
+  template: '<alm-app-header></alm-app-header>'
+})
+class HostComponent { }
+
+@Component({
+  template: ''
+})
+class MockRoutedComponent { }
+
+describe('HeaderComponent', () => {
+  type TestingContext = TestContext<HeaderComponent, HostComponent>;
+
+  const mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
+  mockBroadcaster.broadcast.and.stub();
+
+  let testRouter: Router;
+
+  initContext(HeaderComponent, HostComponent, {
+    imports: [
+      RouterTestingModule.withRoutes([
+        { path: '_home', component: MockRoutedComponent },
+        { path: '_featureflag', component: MockRoutedComponent },
+        { path: '_error', component: MockRoutedComponent },
+        { path: '_other', component: MockRoutedComponent },
+        { path: '**', redirectTo: '/_error' }
+      ])
+    ],
+    declarations: [ MockRoutedComponent ],
+    providers: [
+      { provide: UserService, useValue: { loggedInUser: Observable.never() } },
+      { provide: Logger, useValue: createMock(Logger) },
+      { provide: LoginService, useValue: jasmine.createSpyObj('LoginService', ['login']) },
+      { provide: Broadcaster, useValue: mockBroadcaster },
+      {
+        provide: Contexts, useValue: {
+          default: Observable.of({ name: 'default' }),
+          current: Observable.of({ name: 'current' }),
+          recent: Observable.never()
+        }
+      },
+      { provide: BsModalService, useValue: createMock(BsModalService) },
+      { provide: AuthenticationService, useValue: createMock(AuthenticationService) }
+    ],
+    schemas: [ NO_ERRORS_SCHEMA ]
+  });
+
+  beforeEach(() => {
+    testRouter = TestBed.get(Router);
+  });
+
+  it('should return default context when in _home state', function(this: TestingContext, done: DoneFn) {
+    testRouter.navigate(['_home']).then((status: boolean): void => {
+      expect(status).toBeTruthy();
+      expect(this.testedDirective.context.name).toEqual('default');
+      done();
+    });
+  });
+
+  it('should return default context when in _featureflag state', function(this: TestingContext, done: DoneFn) {
+    testRouter.navigate(['_featureflag']).then((status: boolean): void => {
+      expect(status).toBeTruthy();
+      expect(this.testedDirective.context.name).toEqual('default');
+      done();
+    });
+  });
+
+  it('should return current context when in non-home valid state', function(this: TestingContext, done: DoneFn) {
+    testRouter.navigate(['_other']).then((status: boolean): void => {
+      expect(status).toBeTruthy();
+      expect(this.testedDirective.context.name).toEqual('current');
+      done();
+    });
+  });
+
+  describe('_error state handling', () => {
+    it('should return no context when directly visiting _error', function(this: TestingContext, done: DoneFn) {
+      testRouter.navigate(['_error']).then((status: boolean): void => {
+        expect(status).toBeTruthy();
+        expect(this.testedDirective.context).toBeFalsy();
+        done();
+      });
+    });
+
+    it('should return no context when redirected to _error', function(this: TestingContext, done: DoneFn) {
+      testRouter.navigateByUrl('/nonexistent/app/path').then((status: boolean): void => {
+        expect(status).toBeTruthy();
+        expect(this.testedDirective.context).toBeFalsy();
+        done();
+      });
+    });
+  });
+});

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -175,6 +175,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
   get context(): Context {
     if (this.router.url.startsWith('/_home') || this.router.url.startsWith('/_featureflag')) {
       return this._defaultContext;
+    } else if (this.router.url.startsWith('/_error')) {
+      return null;
     } else {
       return this._context;
     }


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/2731

This patch adds a small handler to replace the browser's location/state with the attempted URL rather than the path to the _error state, so that the user can more easily see or report what URL they tried to visit and which failed. The approach taken is to replace the browser's location state using the Angular Location service since all other approaches tried using various router functions still resulted in the browser location state being updated for the routed _error state, or resulted in the URL remaining what it was before an invalid link was clicked. Additionally the HeaderComponent is modified to check if the current router state is _error, and if so, to return a falsy (in this case, null) Context, so that the header component template is not displayed while in the error state.