### PR TITLE
Consistently route to 404 page when visiting invalid links

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,7 @@
 import { Location } from '@angular/common';
 import {
   Component,
+  Injectable,
   NO_ERRORS_SCHEMA
 } from '@angular/core';
 import {
@@ -8,7 +9,14 @@ import {
   TestBed,
   tick
 } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  NavigationEnd,
+  NavigationError,
+  Resolve,
+  Router,
+  RouterStateSnapshot
+} from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { createMock } from 'testing/mock';
@@ -22,7 +30,10 @@ import {
   Logger
 } from 'ngx-base';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { Spaces } from 'ngx-fabric8-wit';
+import {
+  Context,
+  Spaces
+} from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import {
   Observable,
@@ -39,6 +50,7 @@ import { NotificationsService } from './shared/notifications.service';
 
 import { AppComponent } from './app.component';
 import { ErrorService } from './layout/error/error.service';
+import { ContextResolver } from './shared/context-resolver.service';
 
 @Component({
   template: '<f8-app></f8-app>'
@@ -48,28 +60,35 @@ class HostComponent { }
 @Component({
   template: ''
 })
-class MockHomeComponent { }
+class MockChildComponent { }
 
-@Component({
-  template: ''
-})
-class MockErrorComponent { }
+@Injectable()
+class MockContextResolver implements Resolve<Context> {
+  readonly subject: Subject<Context> = new Subject<Context>();
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Context> {
+    return this.subject.asObservable();
+  }
+}
 
 describe('AppComponent', () => {
-  type Context = TestContext<AppComponent, HostComponent>;
 
   initContext(AppComponent, HostComponent, {
     imports: [
       RouterTestingModule.withRoutes([
-        { path: '_home', component: MockHomeComponent },
-        { path: '_error', component: MockErrorComponent },
+        { path: '_home', component: MockChildComponent },
+        { path: '_error', component: MockChildComponent },
+        {
+          path: ':entity',
+          component: MockChildComponent,
+          resolve: {
+            context: MockContextResolver
+          }
+        },
         { path: '**', redirectTo: '/_error' }
       ])
     ],
-    declarations: [
-      MockHomeComponent,
-      MockErrorComponent
-    ],
+    declarations: [ MockChildComponent ],
     providers: [
       {
         provide: AboutService, useValue: {
@@ -107,7 +126,8 @@ describe('AppComponent', () => {
           logger.error.and.stub();
           return logger;
         }
-      }
+      },
+      MockContextResolver
     ],
     schemas: [ NO_ERRORS_SCHEMA ]
   });
@@ -115,12 +135,24 @@ describe('AppComponent', () => {
   it('should call ErrorService#updateFailedRoute on invalid URL', fakeAsync(() => {
     const testRouter: Router = TestBed.get(Router);
     const mockErrorService: jasmine.SpyObj<ErrorService> = TestBed.get(ErrorService);
-    testRouter.navigate(['/nonexistent/app/path']).then((status: boolean): void => {
+    testRouter.navigate(['/', 'nonexistent', 'app', 'path']).then((status: boolean): void => {
       expect(status).toBeTruthy();
       expect(testRouter.url).toEqual('/_error');
       tick();
       expect(mockErrorService.updateFailedRoute).toHaveBeenCalledWith('/nonexistent/app/path');
     });
-    tick();
+  }));
+
+  it ('should call ErrorService#updateFailedRoute when context resolution fails', fakeAsync(() => {
+    const testRouter: Router = TestBed.get(Router);
+    const mockErrorService: jasmine.SpyObj<ErrorService> = TestBed.get(ErrorService);
+    testRouter.navigate(['/', 'foo']).then((status: boolean): void => {
+      tick();
+      expect(testRouter.url).toEqual('/_error');
+      expect(mockErrorService.updateFailedRoute).toHaveBeenCalledWith('/foo');
+    });
+    const contextResolver: MockContextResolver = TestBed.get(MockContextResolver);
+    contextResolver.subject.error('');
+    contextResolver.subject.complete();
   }));
 });

--- a/src/app/layout/error/error.component.spec.ts
+++ b/src/app/layout/error/error.component.spec.ts
@@ -12,10 +12,6 @@ import {
 } from 'testing/test-context';
 
 import {
-  Notifications,
-  NotificationType
-} from 'ngx-base';
-import {
   AuthenticationService,
   UserService
 } from 'ngx-login-client';
@@ -45,13 +41,6 @@ describe('ErrorComponent', () => {
         }
       },
       {
-        provide: Notifications, useFactory: () => {
-          const notifications: jasmine.SpyObj<Notifications> = createMock(Notifications);
-          notifications.message.and.stub();
-          return notifications;
-        }
-      },
-      {
         provide: Location, useFactory: () => {
           const location: jasmine.SpyObj<Location> = createMock(Location);
           location.replaceState.and.stub();
@@ -60,25 +49,6 @@ describe('ErrorComponent', () => {
       }
     ],
     schemas: [ NO_ERRORS_SCHEMA ]
-  });
-
-  it('should send a notification if a failed route is available', function(this: TestContext<ErrorComponent, HostComponent>) {
-    const notifications: Notifications = TestBed.get(Notifications);
-    const errorService: ErrorService = TestBed.get(ErrorService);
-    expect(notifications.message).not.toHaveBeenCalled();
-    errorService.updateFailedRoute('/foo/path');
-    expect(notifications.message).toHaveBeenCalledWith({
-      message: '/foo/path not found',
-      type: NotificationType.WARNING
-    });
-  });
-
-  it('should not send a notification if failed route is unavailable', function(this: TestContext<ErrorComponent, HostComponent>) {
-    const notifications: Notifications = TestBed.get(Notifications);
-    const errorService: ErrorService = TestBed.get(ErrorService);
-    expect(notifications.message).not.toHaveBeenCalled();
-    errorService.updateFailedRoute('');
-    expect(notifications.message).not.toHaveBeenCalled();
   });
 
   it('should replace location state if a failed route is available', function(this: TestContext<ErrorComponent, HostComponent>) {

--- a/src/app/layout/error/error.component.spec.ts
+++ b/src/app/layout/error/error.component.spec.ts
@@ -1,0 +1,100 @@
+import { Location } from '@angular/common';
+import {
+  Component,
+  NO_ERRORS_SCHEMA
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import {
+  Notifications,
+  NotificationType
+} from 'ngx-base';
+import {
+  AuthenticationService,
+  UserService
+} from 'ngx-login-client';
+import {
+  Observable,
+  Subject
+} from 'rxjs';
+
+import { ErrorComponent } from './error.component';
+import { ErrorService } from './error.service';
+
+@Component({
+  template: '<f8-error></f8-error>'
+})
+class HostComponent { }
+
+describe('ErrorComponent', () => {
+  initContext(ErrorComponent, HostComponent, {
+    providers: [
+      ErrorService,
+      { provide: UserService, useValue: createMock(UserService) },
+      {
+        provide: AuthenticationService, useFactory: () => {
+          const authenticationService: jasmine.SpyObj<AuthenticationService> = createMock(AuthenticationService);
+          authenticationService.isLoggedIn.and.returnValue(false);
+          return authenticationService;
+        }
+      },
+      {
+        provide: Notifications, useFactory: () => {
+          const notifications: jasmine.SpyObj<Notifications> = createMock(Notifications);
+          notifications.message.and.stub();
+          return notifications;
+        }
+      },
+      {
+        provide: Location, useFactory: () => {
+          const location: jasmine.SpyObj<Location> = createMock(Location);
+          location.replaceState.and.stub();
+          return location;
+        }
+      }
+    ],
+    schemas: [ NO_ERRORS_SCHEMA ]
+  });
+
+  it('should send a notification if a failed route is available', function(this: TestContext<ErrorComponent, HostComponent>) {
+    const notifications: Notifications = TestBed.get(Notifications);
+    const errorService: ErrorService = TestBed.get(ErrorService);
+    expect(notifications.message).not.toHaveBeenCalled();
+    errorService.updateFailedRoute('/foo/path');
+    expect(notifications.message).toHaveBeenCalledWith({
+      message: '/foo/path not found',
+      type: NotificationType.WARNING
+    });
+  });
+
+  it('should not send a notification if failed route is unavailable', function(this: TestContext<ErrorComponent, HostComponent>) {
+    const notifications: Notifications = TestBed.get(Notifications);
+    const errorService: ErrorService = TestBed.get(ErrorService);
+    expect(notifications.message).not.toHaveBeenCalled();
+    errorService.updateFailedRoute('');
+    expect(notifications.message).not.toHaveBeenCalled();
+  });
+
+  it('should replace location state if a failed route is available', function(this: TestContext<ErrorComponent, HostComponent>) {
+    const location: Location = TestBed.get(Location);
+    const errorService: ErrorService = TestBed.get(ErrorService);
+    expect(location.replaceState).not.toHaveBeenCalled();
+    errorService.updateFailedRoute('/foo/path');
+    expect(location.replaceState).toHaveBeenCalledWith('/foo/path');
+  });
+
+  it('should not replace location state if failed route is unavailable', function(this: TestContext<ErrorComponent, HostComponent>) {
+    const location: Location = TestBed.get(Location);
+    const errorService: ErrorService = TestBed.get(ErrorService);
+    expect(location.replaceState).not.toHaveBeenCalled();
+    errorService.updateFailedRoute('');
+    expect(location.replaceState).not.toHaveBeenCalled();
+  });
+
+});

--- a/src/app/layout/error/error.component.ts
+++ b/src/app/layout/error/error.component.ts
@@ -1,16 +1,16 @@
+import { Location } from '@angular/common';
 import {
   Component,
   OnDestroy,
   ViewEncapsulation
 } from '@angular/core';
-import { Router } from '@angular/router';
 
-import { AuthenticationService, UserService } from 'ngx-login-client';
+import { Notification, Notifications, NotificationType } from 'ngx-base';
+import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import 'rxjs/operators/map';
 import { Subscription } from 'rxjs/Subscription';
 
 import { ErrorService } from './error.service';
-
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -20,34 +20,42 @@ import { ErrorService } from './error.service';
 })
 export class ErrorComponent implements OnDestroy {
 
-  message: string = '';
-  subscription: Subscription;
-  hideBanner: boolean;
-  spaceLink: string;
-  userSubscription: Subscription;
+  spaceLink: string = '';
 
-  constructor(private errorService: ErrorService,
-                      router: Router,
-                      userService: UserService,
-                      authService: AuthenticationService) {
-    this.subscription = this.errorService.update$.subscribe(
-      message => {
-        this.message = message;
-      });
+  private subscriptions: Subscription[] = [];
 
-    if (authService.isLoggedIn()) {
-      this.userSubscription = userService.loggedInUser.subscribe(val => {
-        if (val.id) {
-          this.spaceLink = '/' + val.attributes.username + '/_spaces';
+  constructor(
+    private errorService: ErrorService,
+    private userService: UserService,
+    private authService: AuthenticationService,
+    private notifications: Notifications,
+    private location: Location
+  ) {
+    this.subscriptions.push(
+      this.errorService.failedRoute$.subscribe((route: string): void => {
+        if (route) {
+          this.notifications.message({
+            message: `${route} not found`,
+            type: NotificationType.WARNING
+          } as Notification);
+          this.location.replaceState(route);
         }
-      });
+      })
+    );
+
+    if (this.authService.isLoggedIn()) {
+      this.subscriptions.push(this.userService.loggedInUser.subscribe((user: User): void => {
+        if (user.id) {
+          this.spaceLink = '/' + user.attributes.username + '/_spaces';
+        }
+      }));
     } else {
       this.spaceLink = '/_home';
     }
   }
-  ngOnDestroy() {
-    if (this.userSubscription) {
-      this.userSubscription.unsubscribe();
-    }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((subscription: Subscription): void => subscription.unsubscribe());
   }
+
 }

--- a/src/app/layout/error/error.component.ts
+++ b/src/app/layout/error/error.component.ts
@@ -5,7 +5,6 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { Notification, Notifications, NotificationType } from 'ngx-base';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import 'rxjs/operators/map';
 import { Subscription } from 'rxjs/Subscription';
@@ -28,16 +27,11 @@ export class ErrorComponent implements OnDestroy {
     private errorService: ErrorService,
     private userService: UserService,
     private authService: AuthenticationService,
-    private notifications: Notifications,
     private location: Location
   ) {
     this.subscriptions.push(
       this.errorService.failedRoute$.subscribe((route: string): void => {
         if (route) {
-          this.notifications.message({
-            message: `${route} not found`,
-            type: NotificationType.WARNING
-          } as Notification);
           this.location.replaceState(route);
         }
       })

--- a/src/app/layout/error/error.service.ts
+++ b/src/app/layout/error/error.service.ts
@@ -1,16 +1,22 @@
 import { Injectable } from '@angular/core';
 
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class ErrorService {
 
   private updateSubject: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private routeSubject: Subject<string> = new Subject<string>();
 
-  update$: Observable<string> = this.updateSubject.asObservable();
+  readonly update$: Observable<string> = this.updateSubject.asObservable();
+  readonly failedRoute$: Observable<string> = this.routeSubject.asObservable();
 
   updateMessage(message: string) {
     this.updateSubject.next(message);
+  }
+
+  updateFailedRoute(route: string) {
+    this.routeSubject.next(route);
   }
 }

--- a/src/app/shared/context-resolver.service.ts
+++ b/src/app/shared/context-resolver.service.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
-  NavigationEnd,
   Resolve,
-  Router,
   RouterStateSnapshot
 } from '@angular/router';
 
-import { Context, Contexts } from 'ngx-fabric8-wit';
-import { BehaviorSubject, ConnectableObservable, Observable, Subject } from 'rxjs';
+import { Context } from 'ngx-fabric8-wit';
+import { Observable } from 'rxjs';
 
 import { Navigation } from '../models/navigation';
 import { ContextService } from './context.service';
@@ -16,22 +14,7 @@ import { ContextService } from './context.service';
 @Injectable()
 export class ContextResolver implements Resolve<Context> {
 
-  private _lastRoute: string;
-
-  constructor(private contextService: ContextService, private router: Router) {
-    // The default place to navigate to if the context cannot be resolved
-    this._lastRoute = '/_error';
-    this.router.errorHandler = (err) => {
-      this.router.navigateByUrl(this._lastRoute);
-    };
-
-    // Store the last visited URL so we can navigate back if the context
-    // cannot be resolved
-    this.router.events
-      .filter(e => e instanceof NavigationEnd)
-      .map((e: NavigationEnd) => e.urlAfterRedirects)
-      .subscribe(val => this._lastRoute = val);
-  }
+  constructor(private contextService: ContextService) { }
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Context> {
     // Resolve the context

--- a/src/app/shared/context.service.spec.ts
+++ b/src/app/shared/context.service.spec.ts
@@ -193,4 +193,28 @@ describe('Context Service:', () => {
       expect((val.user as any).features).toBeNull();
     });
   });
+
+  it('emits error when requested user contains reserved characters', (done: DoneFn) => {
+    const navigation = Observable.of({
+      space: 'TEST',
+      url: '/_user/TEST',
+      user: '_user'
+    });
+    contextService.changeContext(navigation).subscribe(
+      () => done.fail('should have errored'),
+      () => done()
+    );
+  });
+
+  it('emits error when requested space contains reserved characters', (done: DoneFn) => {
+    const navigation = Observable.of({
+      space: '_TEST',
+      url: '/user/_TEST',
+      user: 'user'
+    });
+    contextService.changeContext(navigation).subscribe(
+      () => done.fail('should have errored'),
+      () => done()
+    );
+  });
 });


### PR DESCRIPTION
https://github.com/openshiftio/openshift.io/issues/2887
https://github.com/openshiftio/openshift.io/issues/2860

~~This is a work in progress for prototyping 404/_error page routing work. The homepage component gains several "error n" links in the banner under "Setup your profile", which exercise various types of failure modes with different sorts of invalid URLs. These can be clicked to manually test the behaviour of the prototype when visiting an invalid URL. Once on that page, the browser can be refreshed to also simulate the behaviour of entering that invalid URL directly into the address bar, as opposed to visiting it from within the running application.~~

This PR modifies the context resolution and routing behaviour so that the behaviour of an invalid application link, including links to invalid User or Space contexts, consistently routes the user to the 404 page (`_error` state), with the attempted URL preserved for the user in their browser's address bar. See the [demo](https://github.com/openshiftio/openshift.io/issues/2887#issuecomment-380915894) - the notification is no longer displayed, but the routing behaviour is the same as shown.