### PR TITLE
fix(launcher): updated anchor text for launcher experience

### DIFF
--- a/src/app/space/forge-wizard/components/flow-selector/flow-selector.component.html
+++ b/src/app/space/forge-wizard/components/flow-selector/flow-selector.component.html
@@ -47,7 +47,7 @@
         <button class="btn btn-link"
               type="button"
               (click)="showAddAppOverlay(); cancel();"
-              aria-label="Open New Import Experience">New Import Experience</button>
+              aria-label="Open New Launcher Experience">Try out the new Launcher experience</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Launcher 

Updates anchor text to trigger new Launcher flow.

<img width="941" alt="screen shot 2018-04-05 at 11 34 03 am" src="https://user-images.githubusercontent.com/5129024/38349568-4c91b16a-38c5-11e8-8657-34f64e2f8417.png">


Issue : https://github.com/openshiftio/openshift.io/issues/2832