### PR TITLE
fix(cache): update webpack file name hashing strategy

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -398,6 +398,24 @@ module.exports = function (options) {
       new CheckerPlugin(),
 
       /*
+       * Plugin: ModuleConcatenationPlugin
+       * Description: Hoist modules into one closure for performance.
+       *
+       * See: https://webpack.js.org/plugins/module-concatenation-plugin/
+       */
+      new webpack.optimize.ModuleConcatenationPlugin(),
+
+      /*
+       * Plugin: HashedModuleIdsPlugin
+       * Description: This plugin will cause hashes to be based on the relative path of the module,
+       * generating a four character string as the module id.
+       * Prevents busting the cache prematurely due to default internal module ID generation.
+       *
+       * See: https://webpack.js.org/plugins/hashed-module-ids-plugin/
+       */
+      new webpack.HashedModuleIdsPlugin(),
+
+      /*
        * Plugin: CommonsChunkPlugin
        * Description: Shares common code between the pages.
        * It identifies common modules and put them into a commons chunk.

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -15,13 +15,11 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 // const DedupePlugin = require('webpack/lib/optimize/DedupePlugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
 const ProvidePlugin = require('webpack/lib/ProvidePlugin');
 const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
-const WebpackMd5Hash = require('webpack-md5-hash');
 const ngtools = require('@ngtools/webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const OfflinePlugin = require('offline-plugin');
@@ -159,13 +157,6 @@ module.exports = function (env) {
        // genDir: 'aot'
      }),
 */
-      /**
-       * Plugin: WebpackMd5Hash
-       * Description: Plugin to replace a standard webpack chunkhash with md5.
-       *
-       * See: https://www.npmjs.com/package/webpack-md5-hash
-       */
-      new WebpackMd5Hash(),
 
       /**
        * Webpack plugin and CLI utility that represents bundle content as convenient interactive zoomable treemap

--- a/package.json
+++ b/package.json
@@ -244,7 +244,6 @@
     "webpack-dev-server": "2.4.2",
     "webpack-dll-bundles-plugin": "1.0.0-beta.5",
     "webpack-manifest-plugin": "1.3.2",
-    "webpack-md5-hash": "0.0.5",
     "webpack-merge": "4.1.0",
     "yargs": "10.0.3"
   },


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/2915

Removed `webpack-md5-hash` from prod build as there are outstanding issues with the generated hash not changing when file contents changes.