### PR TITLE
fix(launcher): updates text to trigger getting started experience

### DIFF
--- a/src/app/space/forge-wizard/components/flow-selector/flow-selector.component.html
+++ b/src/app/space/forge-wizard/components/flow-selector/flow-selector.component.html
@@ -47,7 +47,7 @@
         <button class="btn btn-link"
               type="button"
               (click)="showAddAppOverlay(); cancel();"
-              aria-label="Open New Launcher Experience">Try out the new Launcher experience</button>
+              aria-label="Open New Getting Started Experience">Try our new Getting Started experience</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Launcher 

- updates text to trigger getting started experience as internal feature

Issue link : https://github.com/openshiftio/openshift.io/issues/2832