### PR TITLE
feat(deployment-api): introduce DeploymentApiService

### DIFF
--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -29,6 +29,7 @@ import { DeploymentsResourceUsageComponent } from './resource-usage/deployments-
 import { LoadingUtilizationBarComponent } from './resource-usage/loading-utilization-bar.component';
 import { ResourceCardComponent } from './resource-usage/resource-card.component';
 import { UtilizationBarComponent } from './resource-usage/utilization-bar.component';
+import { DeploymentApiService } from './services/deployment-api.service';
 import {
   DeploymentsService,
   TIMER_TOKEN,
@@ -71,6 +72,7 @@ const DEPLOYMENTS_SERVICE_POLL_TIMER = Observable
   ],
   providers: [
     BsDropdownConfig,
+    DeploymentApiService,
     { provide: TIMER_TOKEN, useValue: DEPLOYMENTS_SERVICE_POLL_TIMER },
     { provide: TIMESERIES_SAMPLES_TOKEN, useValue: 15 }
   ]

--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -1,0 +1,202 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpModule,
+  Response,
+  ResponseOptions,
+  ResponseType,
+  XHRBackend
+} from '@angular/http';
+import {
+  MockBackend,
+  MockConnection
+} from '@angular/http/testing';
+import {
+  Observable,
+  Subject,
+  Subscription
+} from 'rxjs';
+
+import { createMock } from 'testing/mock';
+
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { AuthenticationService } from 'ngx-login-client';
+
+import { DeploymentApiService } from './deployment-api.service';
+import {
+  Application,
+  EnvironmentStat,
+  MultiTimeseriesData,
+  TimeseriesData
+} from './deployments.service';
+
+describe('DeploymentApiService', () => {
+  let mockBackend: MockBackend;
+  let svc: DeploymentApiService;
+
+  beforeEach(() => {
+    const mockAuthService: jasmine.SpyObj<AuthenticationService> = createMock(AuthenticationService);
+    mockAuthService.getToken.and.returnValue('mock-auth-token');
+
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        {
+          provide: XHRBackend, useClass: MockBackend
+        },
+        {
+          provide: AuthenticationService, useValue: mockAuthService
+        },
+        {
+          provide: WIT_API_URL, useValue: 'http://example.com/'
+        },
+        DeploymentApiService
+      ]
+    });
+    mockBackend = TestBed.get(XHRBackend);
+    svc = TestBed.get(DeploymentApiService);
+  });
+
+  describe('#getEnvironments', () => {
+    it('should return result', (done: DoneFn): void => {
+      const httpResponse = {
+        data: [
+          {
+            attributes: {
+              name: 'stage'
+            },
+            id: 'fooId',
+            type: 'fooType'
+          },
+          {
+            attributes: {
+              name: 'run'
+            },
+            id: 'barId',
+            type: 'barType'
+          }
+        ]
+      };
+      mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.url).toEqual('http://example.com/deployments/spaces/foo%20spaceId/environments');
+        expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
+        connection.mockRespond(new Response(new ResponseOptions({ body: httpResponse })));
+      });
+      svc.getEnvironments('foo spaceId')
+        .subscribe((envs: EnvironmentStat[]): void => {
+          expect(envs as any[]).toEqual(httpResponse.data);
+          done();
+        });
+    });
+  });
+
+  describe('#getApplications', () => {
+    it('should return result', (done: DoneFn): void => {
+      const httpResponse = {
+        data: {
+          attributes: {
+            applications: [
+              {
+                attributes: {
+                  name: 'vertx-hello'
+                }
+              },
+              {
+                attributes: {
+                  name: 'vertx-paint'
+                }
+              },
+              {
+                attributes: {
+                  name: 'vertx-wiki'
+                }
+              }
+            ]
+          }
+        }
+      };
+      mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.url).toEqual('http://example.com/deployments/spaces/foo%20spaceId');
+        expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
+        connection.mockRespond(new Response(new ResponseOptions({ body: httpResponse })));
+      });
+      svc.getApplications('foo spaceId')
+        .subscribe((apps: Application[]): void => {
+          expect(apps as any[]).toEqual(httpResponse.data.attributes.applications);
+          done();
+        });
+    });
+  });
+
+  describe('#getTimeseriesData', () => {
+    it('should return result', (done: DoneFn): void => {
+      const httpResponse = {
+        data: {
+          cores: [
+            { value: 1, time: 1 },
+            { value: 2, time: 2 }
+          ],
+          memory: [
+            { value: 3, time: 3 },
+            { value: 4, time: 4 }
+          ],
+          net_rx: [
+            { value: 5, time: 5 },
+            { value: 6, time: 6 }
+          ],
+          net_tx: [
+            { value: 7, time: 7 },
+            { value: 8, time: 8 }
+          ],
+          start: 1,
+          end: 2
+        }
+      };
+      mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/statseries?start=1&end=2';
+        expect(connection.request.url).toEqual(expectedUrl);
+        expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
+        connection.mockRespond(new Response(new ResponseOptions({ body: httpResponse })));
+      });
+      svc.getTimeseriesData('foo spaceId', 'stage env', 'foo appId', 1, 2)
+        .subscribe((data: MultiTimeseriesData): void => {
+          expect(data).toEqual(httpResponse.data);
+          done();
+        });
+    });
+  });
+
+  describe('#getLatestTimeseriesData', () => {
+    it('should return result', (done: DoneFn): void => {
+      const httpResponse = {
+        data: {
+          attributes: {
+            cores: {
+              time: 9, value: 9
+            },
+            memory: {
+              time: 10, value: 10
+            },
+            net_tx: {
+              time: 11, value: 11
+            },
+            net_rx: {
+              time: 12, value: 12
+            }
+          }
+        }
+      };
+      mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/stats';
+        expect(connection.request.url).toEqual(expectedUrl);
+        expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
+        connection.mockRespond(new Response(new ResponseOptions({ body: httpResponse })));
+      });
+      svc.getLatestTimeseriesData('foo spaceId', 'stage env', 'foo appId')
+        .subscribe((data: TimeseriesData): void => {
+          expect(data).toEqual(httpResponse.data.attributes);
+          done();
+        });
+    });
+  });
+
+});

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -1,0 +1,77 @@
+import {
+  Inject,
+  Injectable
+} from '@angular/core';
+import {
+  Headers,
+  Http,
+  Response
+} from '@angular/http';
+import { Observable } from 'rxjs';
+
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { AuthenticationService } from 'ngx-login-client';
+
+import {
+  Application,
+  ApplicationsResponse,
+  EnvironmentsResponse,
+  EnvironmentStat,
+  MultiTimeseriesData,
+  MultiTimeseriesResponse,
+  TimeseriesData,
+  TimeseriesResponse
+} from './deployments.service';
+
+@Injectable()
+export class DeploymentApiService {
+
+  private readonly headers: Headers = new Headers();
+  private readonly apiUrl: string;
+
+  constructor(
+    private http: Http,
+    @Inject(WIT_API_URL) private witUrl: string,
+    private auth: AuthenticationService
+  ) {
+    if (this.auth.getToken() != null) {
+      this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
+    }
+    this.apiUrl = witUrl + 'deployments/spaces/';
+  }
+
+  getEnvironments(spaceId: string): Observable<EnvironmentStat[]> {
+    const encSpaceId = encodeURIComponent(spaceId);
+    return this.httpGet(`${this.apiUrl}${encSpaceId}/environments`)
+      .map((response: Response): EnvironmentStat[] => (response.json() as EnvironmentsResponse).data);
+  }
+
+  getApplications(spaceId: string): Observable<Application[]> {
+    const encSpaceId = encodeURIComponent(spaceId);
+    return this.httpGet(`${this.apiUrl}${encSpaceId}`)
+      .map((response: Response): Application[] => (response.json() as ApplicationsResponse).data.attributes.applications);
+  }
+
+  getTimeseriesData(spaceId: string, environmentName: string, applicationId: string, startTime: number, endTime: number): Observable<MultiTimeseriesData> {
+    const encSpaceId = encodeURIComponent(spaceId);
+    const encEnvironmentName = encodeURIComponent(environmentName);
+    const encApplicationId = encodeURIComponent(applicationId);
+    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/statseries?start=${startTime}&end=${endTime}`;
+    return this.httpGet(url)
+      .map((response: Response) => (response.json() as MultiTimeseriesResponse).data);
+  }
+
+  getLatestTimeseriesData(spaceId: string, environmentName: string, applicationId: string): Observable<TimeseriesData> {
+    const encSpaceId = encodeURIComponent(spaceId);
+    const encEnvironmentName = encodeURIComponent(environmentName);
+    const encApplicationId = encodeURIComponent(applicationId);
+    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/stats`;
+    return this.httpGet(url)
+      .map((response: Response) => (response.json() as TimeseriesResponse).data.attributes);
+  }
+
+  private httpGet(url: string): Observable<Response> {
+    return this.http.get(url, { headers: this.headers });
+  }
+
+}


### PR DESCRIPTION
Add a new DeploymentApiService which simply wraps Deployments WIT endpoints, for non-Deployments
page UI consumers.

fixes https://github.com/openshiftio/openshift.io/issues/2924

