### PR TITLE
Refactor DeploymentsService to use DeploymentApiService

### DIFF
--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import {
   HttpModule,
+  RequestMethod,
   Response,
   ResponseOptions,
   ResponseType,
@@ -77,6 +78,7 @@ describe('DeploymentApiService', () => {
         ]
       };
       mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.method).toEqual(RequestMethod.Get);
         expect(connection.request.url).toEqual('http://example.com/deployments/spaces/foo%20spaceId/environments');
         expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
         connection.mockRespond(new Response(new ResponseOptions({ body: httpResponse })));
@@ -115,6 +117,7 @@ describe('DeploymentApiService', () => {
         }
       };
       mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.method).toEqual(RequestMethod.Get);
         expect(connection.request.url).toEqual('http://example.com/deployments/spaces/foo%20spaceId');
         expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
         connection.mockRespond(new Response(new ResponseOptions({ body: httpResponse })));
@@ -152,6 +155,7 @@ describe('DeploymentApiService', () => {
         }
       };
       mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.method).toEqual(RequestMethod.Get);
         const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/statseries?start=1&end=2';
         expect(connection.request.url).toEqual(expectedUrl);
         expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
@@ -186,6 +190,7 @@ describe('DeploymentApiService', () => {
         }
       };
       mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.method).toEqual(RequestMethod.Get);
         const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/stats';
         expect(connection.request.url).toEqual(expectedUrl);
         expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
@@ -202,6 +207,7 @@ describe('DeploymentApiService', () => {
   describe('#deleteDeployment', () => {
     it('should return response', (done: DoneFn): void => {
       mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.method).toEqual(RequestMethod.Delete);
         const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env';
         expect(connection.request.url).toEqual(expectedUrl);
         expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
@@ -218,6 +224,7 @@ describe('DeploymentApiService', () => {
   describe('#scalePods', () => {
     it('should return response', (done: DoneFn): void => {
       mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        expect(connection.request.method).toEqual(RequestMethod.Put);
         const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env?podCount=5';
         expect(connection.request.url).toEqual(expectedUrl);
         expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');

--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -199,4 +199,36 @@ describe('DeploymentApiService', () => {
     });
   });
 
+  describe('#deleteDeployment', () => {
+    it('should return response', (done: DoneFn): void => {
+      mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env';
+        expect(connection.request.url).toEqual(expectedUrl);
+        expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
+        connection.mockRespond(new Response(new ResponseOptions({ status: 200 })));
+      });
+      svc.deleteDeployment('foo spaceId', 'stage env', 'foo appId')
+        .subscribe((resp: Response): void => {
+          expect(resp.status).toEqual(200);
+          done();
+        });
+    });
+  });
+
+  describe('#scalePods', () => {
+    it('should return response', (done: DoneFn): void => {
+      mockBackend.connections.first().subscribe((connection: MockConnection): void => {
+        const expectedUrl: string = 'http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env?podCount=5';
+        expect(connection.request.url).toEqual(expectedUrl);
+        expect(connection.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
+        connection.mockRespond(new Response(new ResponseOptions({ status: 200 })));
+      });
+      svc.scalePods('foo spaceId', 'stage env', 'foo appId', 5)
+        .subscribe((resp: Response): void => {
+          expect(resp.status).toEqual(200);
+          done();
+        });
+    });
+  });
+
 });

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -70,6 +70,22 @@ export class DeploymentApiService {
       .map((response: Response) => (response.json() as TimeseriesResponse).data.attributes);
   }
 
+  deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<Response> {
+    const encSpaceId = encodeURIComponent(spaceId);
+    const encEnvironmentName = encodeURIComponent(environmentName);
+    const encApplicationId = encodeURIComponent(applicationId);
+    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
+    return this.http.delete(url, { headers: this.headers });
+  }
+
+  scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<Response> {
+    const encSpaceId = encodeURIComponent(spaceId);
+    const encEnvironmentName = encodeURIComponent(environmentName);
+    const encApplicationId = encodeURIComponent(applicationId);
+    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}?podCount=${desiredReplicas}`;
+    return this.http.put(url, '', { headers: this.headers });
+  }
+
   private httpGet(url: string): Observable<Response> {
     return this.http.get(url, { headers: this.headers });
   }

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -34,6 +34,7 @@ import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 import { ScaledNetworkStat } from '../models/scaled-network-stat';
+import { DeploymentApiService } from './deployment-api.service';
 import {
   DeploymentsService,
   NetworkStat,
@@ -96,6 +97,7 @@ describe('DeploymentsService', () => {
         {
           provide: TIMESERIES_SAMPLES_TOKEN, useValue: 3
         },
+        DeploymentApiService,
         DeploymentsService
       ]
     });

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -297,17 +297,8 @@ export class DeploymentsService implements OnDestroy {
       .distinctUntilChanged();
   }
 
-  scalePods(
-    spaceId: string,
-    environmentName: string,
-    applicationId: string,
-    desiredReplicas: number
-  ): Observable<string> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    const encEnvironmentName = encodeURIComponent(environmentName);
-    const encApplicationId = encodeURIComponent(applicationId);
-    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}?podCount=${desiredReplicas}`;
-    return this.http.put(url, '', { headers: this.headers })
+  scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<string> {
+    return this.apiService.scalePods(spaceId, environmentName, applicationId, desiredReplicas)
       .map((r: Response) => `Successfully scaled ${applicationId}`)
       .catch(err => Observable.throw(`Failed to scale ${applicationId}`));
   }
@@ -404,11 +395,7 @@ export class DeploymentsService implements OnDestroy {
   }
 
   deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    const encEnvironmentName = encodeURIComponent(environmentName);
-    const encApplicationId = encodeURIComponent(applicationId);
-    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
-    return this.http.delete(url, { headers: this.headers })
+    return this.apiService.deleteDeployment(spaceId, environmentName, applicationId)
       .map((r: Response) => `Deployment has successfully deleted`)
       .catch(err => Observable.throw(`Failed to delete ${applicationId} in ${spaceId} (${environmentName})`));
   }

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -6,11 +6,7 @@ import {
   OnDestroy
 } from '@angular/core';
 
-import {
-  Headers,
-  Http,
-  Response
-} from '@angular/http';
+import { Response } from '@angular/http';
 
 import {
   Observable,
@@ -18,10 +14,6 @@ import {
   Subject,
   Subscription
 } from 'rxjs';
-
-import { AuthenticationService } from 'ngx-login-client';
-
-import { WIT_API_URL } from 'ngx-fabric8-wit';
 
 import { NotificationsService } from 'app/shared/notifications.service';
 import {
@@ -201,9 +193,6 @@ export class DeploymentsService implements OnDestroy {
   static readonly FRONT_LOAD_SAMPLES: number = 15;
   static readonly FRONT_LOAD_WINDOW_WIDTH: number = DeploymentsService.FRONT_LOAD_SAMPLES * DeploymentsService.POLL_RATE_MS;
 
-  private readonly headers: Headers = new Headers({ 'Content-Type': 'application/json' });
-  private readonly apiUrl: string;
-
   private readonly appsObservables: Map<string, Observable<Application[]>> = new Map<string, Observable<Application[]>>();
   private readonly envsObservables: Map<string, Observable<EnvironmentStat[]>> = new Map<string, Observable<EnvironmentStat[]>>();
   private readonly timeseriesSubjects: Map<string, Subject<TimeseriesData[]>> = new Map<string, Subject<TimeseriesData[]>>();
@@ -211,21 +200,13 @@ export class DeploymentsService implements OnDestroy {
   private readonly serviceSubscriptions: Subscription[] = [];
 
   constructor(
-    private readonly http: Http,
     private readonly apiService: DeploymentApiService,
-    private readonly auth: AuthenticationService,
     private readonly logger: Logger,
     private readonly errorHandler: ErrorHandler,
     private readonly notifications: NotificationsService,
-    @Inject(WIT_API_URL) private readonly witUrl: string,
     @Inject(TIMER_TOKEN) private readonly pollTimer: Observable<void>,
     @Inject(TIMESERIES_SAMPLES_TOKEN) private readonly timeseriesSamples: number
-  ) {
-    if (this.auth.getToken() != null) {
-      this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
-    }
-    this.apiUrl = witUrl + 'deployments/spaces/';
-  }
+  ) { }
 
   ngOnDestroy(): void {
     this.serviceSubscriptions.forEach((sub: Subscription) => {


### PR DESCRIPTION
https://github.com/openshiftio/openshift.io/issues/2925

This PR refactors the DeploymentsService to move the scalePods and deleteDeployments functions into DeploymentApiService, removing all direct HTTP knowledge from DeploymentsService so that it is entirely built on top of the generalized and simplified DeploymentApiService and only implements functionality to enable the Deployments page components to be as simple and dumb as possible.