### PR TITLE
fix(analyze-overview): prevent null space value from crashing page

### DIFF
--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -69,7 +69,7 @@
 
 <!-- Forge wizard modal -->
 <ng-template #addSpace>
-    <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
+    <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space?.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
     <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
     <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
 </ng-template>


### PR DESCRIPTION
This short PR addresses https://github.com/openshiftio/openshift.io/issues/2732.

The analyze-overview component is initialized when visiting a space's analyze page, and has a subscription to get context information. If initialized and the user navigates from an 'analyze' page to a non-analyze page (e.g., profile) while the forge-wizard modal has been opened, the subscribed context.space value will be null for a brief moment before `ngOnDestroy()` is called. This results in a typeerror "cannot read property 'attributes' of null" because the forge-wizard modal will be trying to retrieve the attributes from a null space object, and can disrupt the page layouts.

This PR simply handles null values by making the space attribute of the flow-selector template optional