### PR TITLE
fix(feature-footer): reset boolean values in ngOnChanges to fix updat…

### DIFF
--- a/src/app/feature-flag/notification-footer/feature-footer.component.ts
+++ b/src/app/feature-flag/notification-footer/feature-footer.component.ts
@@ -32,6 +32,10 @@ export class FeatureFooterComponent implements OnInit, OnDestroy, OnChanges {
   ngOnChanges() {
     if (this.featurePageConfig) {
       this.userLevel = this.featurePageConfig['user-level'] || 'released';
+      // re-init the boolean values
+      this.noFeaturesInInternal = true;
+      this.noFeaturesInBeta = true;
+      this.noFeaturesInExperimental = true;
       if (this.isNotEmpty('beta')) {
         this.noFeaturesInBeta = false;
       }


### PR DESCRIPTION
…ing of feature-footer

This PR fixes https://github.com/openshiftio/openshift.io/issues/3078.

When visiting a page without experimental features (e.g., analyze) from a page with features (e.g., deployments), the booleans are not reset and retain the previous values. As a result, the feature footer may not correctly display experimental-feature information for the page. This PR adds a couple of lines to the `ngOnChanges()` that re-inits the boolean values to true so they can be properly adjusted by the following if-statements.

