### PR TITLE
fix(flow-selector): revert changes to the space attribute of flow-sel…

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -228,7 +228,7 @@
 <!-- Create Space modal -->
 <ng-template #createSpace>
   <space-wizard (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [style.display]="selectedFlow !== 'start' ? 'none': ''"></space-wizard>
-  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space?.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
+  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
   <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
   <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
 </ng-template>

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -217,7 +217,7 @@
   </nav>
   <ng-template #spaceWizard>
     <space-wizard (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [style.display]="selectedFlow !== 'start' ? 'none': ''"></space-wizard>
-    <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space?.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
+    <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
     <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
     <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
   </ng-template>

--- a/src/app/profile/my-spaces/my-spaces.component.html
+++ b/src/app/profile/my-spaces/my-spaces.component.html
@@ -42,7 +42,7 @@
 <!-- Create Space modal -->
 <ng-template #createSpace>
   <space-wizard (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [style.display]="selectedFlow !== 'start' ? 'none': ''"></space-wizard>
-  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space?.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
+  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
   <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
   <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
 </ng-template>

--- a/src/app/profile/overview/spaces/spaces.component.html
+++ b/src/app/profile/overview/spaces/spaces.component.html
@@ -52,7 +52,7 @@
 <!-- Launch Space Wizard -->
 <ng-template #spaceWizard>
   <space-wizard (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [style.display]="selectedFlow !== 'start' ? 'none': ''"></space-wizard>
-  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space?.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
+  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
   <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
   <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
 </ng-template>

--- a/src/app/profile/spaces/spaces.component.html
+++ b/src/app/profile/spaces/spaces.component.html
@@ -56,7 +56,7 @@
 <!-- Create Space modal -->
 <ng-template #createSpace>
   <space-wizard (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [style.display]="selectedFlow !== 'start' ? 'none': ''"></space-wizard>
-  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space?.attributes.name" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
+  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
   <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
   <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
 </ng-template>

--- a/src/app/space/forge-wizard/components/flow-selector/flow-selector.component.ts
+++ b/src/app/space/forge-wizard/components/flow-selector/flow-selector.component.ts
@@ -11,7 +11,7 @@ import { FeatureTogglesService } from '../../../../feature-flag/service/feature-
   styleUrls: ['./flow-selector.component.less']
 })
 export class FlowSelectorComponent implements OnDestroy {
-  @Input() space: string;
+  @Input() space: any;
   @Output('onSelect') onSelect = new EventEmitter();
   @Output('onCancel') onCancel = new EventEmitter();
 


### PR DESCRIPTION
…ector

This PR fixes https://github.com/openshiftio/openshift.io/issues/3075 [0].

It reverts the changes to 5 html components [1] where `[space]="space"` was changed to become `[space]=space?.attributes.name` when I (wrongfully) noticed that the space attribute expected a string type instead of a space type. As such, based on a recommendation the space type has been changed to `any`for the moment to remove any further confusion.

[0] https://github.com/openshiftio/openshift.io/issues/3075
[1] https://github.com/fabric8-ui/fabric8-ui/pull/2730/files

