### PR TITLE
Fix TypeError warning generated by unit test

### DIFF
--- a/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.spec.ts
@@ -14,21 +14,22 @@ import { Observable } from 'rxjs';
 import { ContextService } from '../../shared/context.service';
 import { spaceMock } from '../../shared/context.service.mock';
 
-import { Codebase } from '../../space/create/codebases/services/codebase';
 import { CodebasesService } from '../../space/create/codebases/services/codebases.service';
 import { WindowService } from '../../space/create/codebases/services/window.service';
-import { Workspace } from '../../space/create/codebases/services/workspace';
+import { Workspace, WorkspaceLinks } from '../../space/create/codebases/services/workspace';
 import { WorkspacesService } from '../../space/create/codebases/services/workspaces.service';
-import { RecentWorkspacesWidgetComponent } from './recent-workspaces-widget.component';
+import { ExtCodebase, RecentWorkspacesWidgetComponent} from './recent-workspaces-widget.component';
 
-describe('Recent Workspaces Widget:', () => {
+describe('RecentWorkspacesWidgetComponent', () => {
   let comp: RecentWorkspacesWidgetComponent;
   let fixture: ComponentFixture<RecentWorkspacesWidgetComponent>;
-  let codebase: Codebase;
-  let codebases: Codebase[];
+  let codebase: ExtCodebase;
+  let codebases: ExtCodebase[];
   let component: DebugNode['componentInstance'];
   let workspace: Workspace;
   let workspaces: Workspace[];
+  let workspaceLinks: WorkspaceLinks;
+
   let mockCodebasesService: any;
   let mockContextService: any;
   let mockSpaceService: any;
@@ -44,7 +45,7 @@ describe('Recent Workspaces Widget:', () => {
     mockSpaceService.getSpaceByName.and.returnValue(Observable.of(spaceMock));
     mockNotifications = jasmine.createSpy('Notifications');
     mockWindowService = jasmine.createSpyObj('WindowService', ['open']);
-    mockWorkspacesService = jasmine.createSpyObj('WorkspacesService', ['getWorkspaces']);
+    mockWorkspacesService = jasmine.createSpyObj('WorkspacesService', ['getWorkspaces', 'openWorkspace']);
 
     TestBed.configureTestingModule({
       imports: [
@@ -76,7 +77,7 @@ describe('Recent Workspaces Widget:', () => {
         'url': 'https://github.com/fabric8-ui/fabric8-ui.git'
       },
       'type': 'codebases'
-    } as Codebase;
+    } as ExtCodebase;
     codebases = [codebase];
     mockCodebasesService.getCodebases.and.returnValue(Observable.of(codebases));
 
@@ -90,6 +91,11 @@ describe('Recent Workspaces Widget:', () => {
     };
     workspaces = [workspace];
     mockWorkspacesService.getWorkspaces.and.returnValue(Observable.of(workspaces));
+
+    workspaceLinks = {
+      links: { open: 'url' }
+    };
+    mockWorkspacesService.openWorkspace.and.returnValue(Observable.of(workspaceLinks));
 
     mockWindowService.open.and.returnValue({location: { href: 'url'}});
 

--- a/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.ts
@@ -15,7 +15,7 @@ import { WorkspacesService } from '../../space/create/codebases/services/workspa
 
 // Adds an extra workspaces property
 export class ExtCodebase extends Codebase {
-  workspaces: Workspace[];
+  workspaces?: Workspace[];
 }
 
 // Adds an extra codebases property
@@ -57,8 +57,10 @@ export class RecentWorkspacesWidgetComponent implements OnDestroy, OnInit {
       private workspacesService: WorkspacesService) {
     // Get workspaces from recent workspaces
     this.subscriptions.push(this.fetchRecentSpaces().subscribe((recent: ExtSpace[]) => {
-      this.recent = recent;
-      this.initWorkspaces();
+      if (recent !== undefined) {
+        this.recent = recent;
+        this.initWorkspaces();
+      }
     }));
   }
 


### PR DESCRIPTION
This fixes a TypeError warning generated by the RecentWorkspacesWidgetComponent unit test when the openWorkspace method of WorkspacesService is called.

