### PR TITLE
fix(version): update fabric8-planner to 0.43.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "angular2-websocket": "0.9.5",
     "chunk-manifest-webpack2-plugin": "1.0.1",
     "core-js": "2.5.1",
-    "fabric8-planner": "0.43.13",
+    "fabric8-planner": "0.43.22",
     "fabric8-stack-analysis-ui": "0.11.2",
     "http-server": "0.10.0",
     "ie-shim": "0.1.0",


### PR DESCRIPTION
There is a jump in the version number as a few PRs related to CI/CD were merged.