### PR TITLE
WIP: Build on RHEL

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,11 @@
+FROM FROM registry.devshift.net/osio-prod/base/nginx:latest
+MAINTAINER "Devtools <devtools@redhat.com>"
+
+USER root
+
+RUN rm -rf /usr/share/nginx/html/
+COPY dist /usr/share/nginx/html
+RUN chmod -R 777 /usr/share/nginx/html/
+
+
+USER ${FABRIC8_USER_NAME}


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

This PR will remain as a WIP until a successful end to end run is achieved. This involves:

- Succesfully building and pushing the CentOS and RHEL based containers
- Succesful deployment of the RHEL container in prod-preview and prod

The project that has been selected to do the end to end test run is fabric8-auth.