### PR TITLE
Refactor EnvironmentWidget to remove DeploymentsService dependency

### DIFF
--- a/src/app/dashboard-widgets/environment-widget/application-overview.service.spec.ts
+++ b/src/app/dashboard-widgets/environment-widget/application-overview.service.spec.ts
@@ -1,0 +1,122 @@
+import {
+  fakeAsync,
+  TestBed,
+  tick
+} from '@angular/core/testing';
+
+import { createMock } from 'testing/mock';
+
+import { Observable } from 'rxjs';
+
+import { DeploymentApiService } from '../../space/create/deployments/services/deployment-api.service';
+import {
+  ApplicationAttributesOverview,
+  ApplicationOverviewService
+} from './application-overview.service';
+
+describe('ApplicationOverviewService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DeploymentApiService, useValue: createMock(DeploymentApiService) },
+        ApplicationOverviewService
+      ]
+    });
+  });
+
+  it('should return data from backend', (done: DoneFn): void => {
+    const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
+    apiSvc.getApplications.and.returnValue(Observable.of([
+      {
+        attributes: {
+          name: 'foo-app',
+          deployments: [
+            {
+              attributes: {
+                name: 'stage',
+                version: '1'
+              },
+              links: {
+                application: 'foo-app-stage-url'
+              }
+            }
+          ]
+        }
+      },
+      {
+        attributes: {
+          name: 'bar-app',
+          deployments: [
+            {
+              attributes: {
+                name: 'run',
+                version: '2'
+              },
+              links: {
+                application: 'bar-app-run-url'
+              }
+            }
+          ]
+        }
+      }
+    ]));
+
+    const svc: ApplicationOverviewService = TestBed.get(ApplicationOverviewService);
+    svc.getAppsAndEnvironments('foo-spaceId')
+      .subscribe(
+        (overviews: ApplicationAttributesOverview[]): void => {
+          expect(apiSvc.getApplications).toHaveBeenCalledWith('foo-spaceId');
+          expect(overviews).toEqual([
+            {
+              appName: 'bar-app',
+              deploymentsInfo: [
+                {
+                  name: 'run',
+                  version: '2',
+                  url: 'bar-app-run-url'
+                }
+              ]
+            },
+            {
+              appName: 'foo-app',
+              deploymentsInfo: [
+                {
+                  name: 'stage',
+                  version: '1',
+                  url: 'foo-app-stage-url'
+                }
+              ]
+            }
+          ] as any[]);
+          done();
+        },
+        done.fail
+      );
+  });
+
+  it('should start immediately and then poll on a 10-second interval', fakeAsync(() => {
+    const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
+    apiSvc.getApplications.and.returnValue(Observable.of([]));
+
+    let emissions: number = 0;
+    const svc: ApplicationOverviewService = TestBed.get(ApplicationOverviewService);
+    svc.getAppsAndEnvironments('foo')
+      .subscribe((overviews: ApplicationAttributesOverview[]): void => {
+        expect(overviews).toEqual([]);
+        emissions++;
+        expect(apiSvc.getApplications.calls.count()).toEqual(emissions);
+      });
+
+    expect(emissions).toBe(0);
+    tick();
+    expect(emissions).toBe(1);
+    tick(10000);
+    expect(emissions).toBe(2);
+    tick(10000);
+    expect(emissions).toBe(3);
+    tick(10000);
+    expect(emissions).toBe(4);
+
+    svc.ngOnDestroy();
+  }));
+});

--- a/src/app/dashboard-widgets/environment-widget/application-overview.service.ts
+++ b/src/app/dashboard-widgets/environment-widget/application-overview.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
+
+import {
+  Application,
+  Deployment,
+  DeploymentApiService
+} from '../../../app/space/create/deployments/services/deployment-api.service';
+
+export interface ApplicationAttributesOverview {
+  appName: string;
+  deploymentsInfo: DeploymentPreviewInfo[];
+}
+
+export interface DeploymentPreviewInfo {
+  name: string;
+  version: string;
+  url: string;
+}
+
+@Injectable()
+export class ApplicationOverviewService {
+
+  constructor(
+    private deploymentApiService: DeploymentApiService
+  ) { }
+
+  getAppsAndEnvironments(spaceId: string): Observable<ApplicationAttributesOverview[]> {
+    return this.deploymentApiService.getApplications(spaceId)
+      .map((apps: Application[]): Application[] => apps || [])
+      .map((apps: Application[]): ApplicationAttributesOverview[] =>
+        apps.map((app: Application): ApplicationAttributesOverview => {
+          const appName: string = app.attributes.name;
+          const deploymentsInfo: DeploymentPreviewInfo[] = app.attributes.deployments.map(
+            (dep: Deployment): DeploymentPreviewInfo => ({
+              name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
+            })
+          );
+          return { appName, deploymentsInfo };
+        })
+      );
+  }
+
+}

--- a/src/app/dashboard-widgets/environment-widget/application-overview.service.ts
+++ b/src/app/dashboard-widgets/environment-widget/application-overview.service.ts
@@ -1,6 +1,12 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  OnDestroy
+} from '@angular/core';
 
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  Subject
+} from 'rxjs';
 
 import {
   Application,
@@ -20,26 +26,42 @@ export interface DeploymentPreviewInfo {
 }
 
 @Injectable()
-export class ApplicationOverviewService {
+export class ApplicationOverviewService implements OnDestroy {
+
+  private readonly destroyed: Subject<void> = new Subject<void>();
+
+  private readonly pollTimer: Observable<void> = Observable.timer(0, 10000)
+    .map(() => null)
+    .takeUntil(this.destroyed);
 
   constructor(
     private deploymentApiService: DeploymentApiService
   ) { }
 
+  ngOnDestroy(): void {
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+
   getAppsAndEnvironments(spaceId: string): Observable<ApplicationAttributesOverview[]> {
-    return this.deploymentApiService.getApplications(spaceId)
-      .map((apps: Application[]): Application[] => apps || [])
-      .map((apps: Application[]): ApplicationAttributesOverview[] =>
-        apps.map((app: Application): ApplicationAttributesOverview => {
-          const appName: string = app.attributes.name;
-          const deploymentsInfo: DeploymentPreviewInfo[] = app.attributes.deployments.map(
-            (dep: Deployment): DeploymentPreviewInfo => ({
-              name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
-            })
-          );
-          return { appName, deploymentsInfo };
-        })
-      );
+    return this.pollTimer.mergeMap(() =>
+      this.deploymentApiService.getApplications(spaceId)
+        .map((apps: Application[]): Application[] => apps || [])
+        .map((apps: Application[]): Application[] => apps.sort((a: Application, b: Application): number => a.attributes.name.localeCompare(b.attributes.name)))
+        .map((apps: Application[]): ApplicationAttributesOverview[] =>
+          apps.map((app: Application): ApplicationAttributesOverview => {
+            const appName: string = app.attributes.name;
+            const deploymentsInfo: DeploymentPreviewInfo[] = app.attributes.deployments.map(
+              (dep: Deployment): DeploymentPreviewInfo => ({
+                name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
+              })
+            ).sort((a: DeploymentPreviewInfo, b: DeploymentPreviewInfo): number => a.name.localeCompare(b.name));
+            return { appName, deploymentsInfo };
+          })
+        )
+    )
+      .distinctUntilChanged()
+      .shareReplay();
   }
 
 }

--- a/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
+++ b/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
@@ -8,15 +8,15 @@ import { Context, Contexts, Spaces } from 'ngx-fabric8-wit';
 import { Space } from '../../../app/space/create/deployments/services/deployment-api.service';
 import {
   ApplicationAttributesOverview,
-  DeploymentsService
-} from '../../../app/space/create/deployments/services/deployments.service';
+  ApplicationOverviewService
+} from './application-overview.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'fabric8-environment-widget',
   templateUrl: './environment-widget.component.html',
   styleUrls: ['./environment-widget.component.less'],
-  providers: [DeploymentsService]
+  providers: [ApplicationOverviewService]
 })
 export class EnvironmentWidgetComponent implements OnInit {
 
@@ -26,13 +26,13 @@ export class EnvironmentWidgetComponent implements OnInit {
 
   constructor(private context: Contexts,
               private spaces: Spaces,
-              private deploymentsService: DeploymentsService) {
+              private applicationOverviewService: ApplicationOverviewService) {
     this.spaceId = this.spaces.current.first().map(space => space.id);
   }
 
   ngOnInit() {
     this.spaceId.subscribe((spaceId: string) => {
-      this.appInfos = this.deploymentsService.getAppsAndEnvironments(spaceId);
+      this.appInfos = this.applicationOverviewService.getAppsAndEnvironments(spaceId);
     });
 
     this.contextPath = this.context.current.map(context => context.path);

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -51,17 +51,6 @@ import {
   TimeseriesData
 } from './deployment-api.service';
 
-export interface ApplicationAttributesOverview {
-  appName: string;
-  deploymentsInfo: DeploymentPreviewInfo[];
-}
-
-export interface DeploymentPreviewInfo {
-  name: string;
-  version: string;
-  url: string;
-}
-
 export const TIMER_TOKEN: InjectionToken<Observable<void>> = new InjectionToken<Observable<void>>('DeploymentsServiceTimer');
 export const TIMESERIES_SAMPLES_TOKEN: InjectionToken<number> = new InjectionToken<number>('DeploymentsServiceTimeseriesSamples');
 
@@ -113,24 +102,6 @@ export class DeploymentsService implements OnDestroy {
         .map((env: EnvironmentAttributes) => env.name)
       )
       .distinctUntilChanged((p: string[], q: string[]) => deepEqual(new Set<string>(p), new Set<string>(q)));
-  }
-
-  getAppsAndEnvironments(spaceId: string): Observable<ApplicationAttributesOverview[]> {
-    return this.getApplicationsResponse(spaceId)
-      .map((apps: Application[]) => apps || [])
-      .map((apps: Application[]) => apps.map((app: Application) => {
-        const appName = app.attributes.name;
-        const deploymentNamesAndVersions = app.attributes.deployments.map(
-          (dep: Deployment) => ({
-            name: dep.attributes.name, version: dep.attributes.version, url: dep.links.application
-          })
-        );
-
-        return {
-          appName: appName,
-          deploymentsInfo: deploymentNamesAndVersions as DeploymentPreviewInfo[]
-        } as ApplicationAttributesOverview;
-      }));
   }
 
   isApplicationDeployedInEnvironment(spaceId: string, environmentName: string, applicationId: string):


### PR DESCRIPTION
This refactors the EnvironmentWidget found on the current Analyze dashboard to remove its dependency on the DeploymentsService, which is intended to be consumed only by Deployments-area components. The function and structures that were previously added to the DeploymentsService to support this widget have been moved into a new, very small service, which is specific to the EnvironmentWidget, and which uses the new DeploymentApiService to handle HTTP requests to the backend Deployments API.