### PR TITLE
fix(pipelines): inject openshift urls into build configs

### DIFF
--- a/src/app/space/create/pipelines/pipelines.component.spec.ts
+++ b/src/app/space/create/pipelines/pipelines.component.spec.ts
@@ -102,13 +102,23 @@ describe('PipelinesComponent', () => {
       current: new BehaviorSubject<any[]>([
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
         },
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -116,6 +126,7 @@ describe('PipelinesComponent', () => {
         },
         {
           id: 'app3',
+          name: 'app3',
           gitUrl: 'https://example.com/app3.git',
           labels: {
             space: 'space2'
@@ -151,12 +162,45 @@ describe('PipelinesComponent', () => {
 
   describe('Pipelines component with url', () => {
     beforeAll(() => {
-      pipelinesService.getOpenshiftConsoleUrl.and.returnValue(Observable.of('http://example.com/openshift'));
+      pipelinesService.getOpenshiftConsoleUrl.and.returnValue(Observable.of('http://example.com/browse/openshift'));
     });
 
     it('should set OpenShift Console URL', function(this: TestingContext) {
       expect(this.testedDirective.consoleAvailable).toBeTruthy();
-      expect(this.testedDirective.openshiftConsoleUrl).toEqual('http://example.com/openshift');
+      expect(this.testedDirective.openshiftConsoleUrl).toEqual('http://example.com/browse/openshift');
+    });
+
+    it('should set correct urls', function(this: TestingContext) {
+      expect(this.testedDirective.pipelines as any[]).toContain({
+        id: 'app',
+        name: 'app',
+        gitUrl: 'https://example.com/app.git',
+        interestingBuilds: [
+          {
+            buildNumber: 1,
+            openShiftConsoleUrl: 'http://example.com/browse/openshift/app/app-1'
+          },
+          {
+            buildNumber: 2,
+            openShiftConsoleUrl: 'http://example.com/browse/openshift/app/app-2'
+          }
+        ],
+        labels: {
+          space: 'space'
+        },
+        openShiftConsoleUrl: 'http://example.com/browse/openshift/app',
+        editPipelineUrl: 'http://example.com/edit/openshift/app'
+      });
+      expect(this.testedDirective.pipelines as any[]).toContain({
+        id: 'app2',
+        name: 'app2',
+        gitUrl: 'https://example.com/app2.git',
+        labels: {
+          space: 'space'
+        },
+        openShiftConsoleUrl: 'http://example.com/browse/openshift/app2',
+        editPipelineUrl: 'http://example.com/edit/openshift/app2'
+      });
     });
   });
 
@@ -170,18 +214,55 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.consoleAvailable).toBeFalsy();
       expect(this.testedDirective.openshiftConsoleUrl).toEqual('');
     });
+
+    it('should not set urls', function(this: TestingContext) {
+      expect(this.testedDirective.pipelines as any[]).toContain({
+        id: 'app',
+        name: 'app',
+        gitUrl: 'https://example.com/app.git',
+        interestingBuilds: [
+          {
+            buildNumber: 1
+          },
+          {
+            buildNumber: 2
+          }
+        ],
+        labels: {
+          space: 'space'
+        }
+      });
+      expect(this.testedDirective.pipelines as any[]).toContain({
+        id: 'app2',
+        name: 'app2',
+        gitUrl: 'https://example.com/app2.git',
+        labels: {
+          space: 'space'
+        }
+      });
+    });
   });
 
   it('should only display pipelines within the current space', function(this: TestingContext) {
     expect(this.testedDirective.pipelines as any[]).toContain({
       id: 'app',
+      name: 'app',
       gitUrl: 'https://example.com/app.git',
+      interestingBuilds: [
+        {
+          buildNumber: 1
+        },
+        {
+          buildNumber: 2
+        }
+      ],
       labels: {
         space: 'space'
       }
     });
     expect(this.testedDirective.pipelines as any[]).toContain({
       id: 'app2',
+      name: 'app2',
       gitUrl: 'https://example.com/app2.git',
       labels: {
         space: 'space'
@@ -189,6 +270,7 @@ describe('PipelinesComponent', () => {
     });
     expect(this.testedDirective.pipelines as any[]).not.toContain({
       id: 'app3',
+      name: 'app3',
       gitUrl: 'https://example.com/app3.git',
       labels: {
         space: 'space2'
@@ -215,6 +297,7 @@ describe('PipelinesComponent', () => {
       );
       expect(this.testedDirective.pipelines as any[]).toEqual([{
         id: 'app2',
+        name: 'app2',
         gitUrl: 'https://example.com/app2.git',
         labels: {
           space: 'space'
@@ -241,6 +324,7 @@ describe('PipelinesComponent', () => {
       );
       expect(this.testedDirective.pipelines as any[]).toEqual([{
         id: 'app2',
+        name: 'app2',
         gitUrl: 'https://example.com/app2.git',
         labels: {
           space: 'space'
@@ -267,6 +351,7 @@ describe('PipelinesComponent', () => {
       );
       expect(this.testedDirective.pipelines as any[]).toEqual([{
         id: 'app2',
+        name: 'app2',
         gitUrl: 'https://example.com/app2.git',
         labels: {
           space: 'space'
@@ -276,6 +361,7 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -283,7 +369,16 @@ describe('PipelinesComponent', () => {
         },
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
@@ -306,6 +401,7 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -313,7 +409,16 @@ describe('PipelinesComponent', () => {
         },
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
@@ -333,13 +438,23 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
         },
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -360,6 +475,7 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -367,7 +483,16 @@ describe('PipelinesComponent', () => {
         },
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
@@ -387,13 +512,23 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
         },
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -414,13 +549,23 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
         },
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -440,6 +585,7 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -447,7 +593,16 @@ describe('PipelinesComponent', () => {
         },
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }
@@ -473,6 +628,7 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -487,6 +643,7 @@ describe('PipelinesComponent', () => {
       expect(this.testedDirective.pipelines as any[]).toEqual([
         {
           id: 'app2',
+          name: 'app2',
           gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
@@ -494,7 +651,16 @@ describe('PipelinesComponent', () => {
         },
         {
           id: 'app',
+          name: 'app',
           gitUrl: 'https://example.com/app.git',
+          interestingBuilds: [
+            {
+              buildNumber: 1
+            },
+            {
+              buildNumber: 2
+            }
+          ],
           labels: {
             space: 'space'
           }

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -118,7 +118,7 @@ export class PipelinesComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.runtimePipelinesService.current.combineLatest(
         this.pipelinesService.getOpenshiftConsoleUrl().do((url: string) => {
-          if (url !== '') {
+          if (url) {
             this.consoleAvailable = true;
           } else {
             this.consoleAvailable = false;
@@ -135,7 +135,7 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   }
 
   private setupBuildConfigLinks(buildConfigs: BuildConfig[], consoleUrl: string): BuildConfig[] {
-    if (consoleUrl && consoleUrl !== '') {
+    if (consoleUrl) {
       for (let build of buildConfigs) {
         build.openShiftConsoleUrl = consoleUrl + '/' + build.name;
         build.editPipelineUrl = build.openShiftConsoleUrl.replace('browse', 'edit');

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -117,20 +117,24 @@ export class PipelinesComponent implements OnInit, OnDestroy {
 
     this.subscriptions.push(
       this.runtimePipelinesService.current.combineLatest(
-        this.pipelinesService.getOpenshiftConsoleUrl().do((url: string) => {
-          if (url) {
-            this.consoleAvailable = true;
-          } else {
-            this.consoleAvailable = false;
-          }
-          this.openshiftConsoleUrl = url;
-        }),
+        this.pipelinesService.getOpenshiftConsoleUrl(),
         this.setupBuildConfigLinks)
         .subscribe((buildConfigs: BuildConfig[]) => {
           this._allPipelines = buildConfigs;
           this.applyFilters();
           this.applySort();
         })
+    );
+
+    this.subscriptions.push(
+      this.pipelinesService.getOpenshiftConsoleUrl().subscribe((url: string) => {
+        if (url) {
+          this.consoleAvailable = true;
+        } else {
+          this.consoleAvailable = false;
+        }
+        this.openshiftConsoleUrl = url;
+      })
     );
   }
 

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -137,11 +137,11 @@ export class PipelinesComponent implements OnInit, OnDestroy {
   private setupBuildConfigLinks(buildConfigs: BuildConfig[], consoleUrl: string): BuildConfig[] {
     if (consoleUrl) {
       for (let build of buildConfigs) {
-        build.openShiftConsoleUrl = consoleUrl + '/' + build.name;
+        build.openShiftConsoleUrl = `${consoleUrl}/${build.name}`;
         build.editPipelineUrl = build.openShiftConsoleUrl.replace('browse', 'edit');
         if (build.interestingBuilds) {
           for (let b of build.interestingBuilds) {
-            b.openShiftConsoleUrl = build.openShiftConsoleUrl + '/' + build.name + '-' + b.buildNumber;
+            b.openShiftConsoleUrl = `${build.openShiftConsoleUrl}/${build.name}-${b.buildNumber}`;
           }
         }
       }


### PR DESCRIPTION
This is a workaround to fix: https://github.com/openshiftio/openshift.io/issues/2744

The race condition affecting the build configs system is untouched and instead the URLs are injected into the objects to be used throughout the pipelines code.

After many days of investigation and attempts at solutions to the race condition affecting this pipelines component, I opted for this workaround as it fixes the issue of links being wrong while being the least intrusive as possible. This was manually tested against an intentionally delayed ngx-login-client:UserService with:

```
    this.loggedInUser = Observable.merge(
      broadcaster.on('loggedin')
        .map(val => 'loggedIn'),
      broadcaster.on('logout')
        .map(val => 'loggedOut'),
      broadcaster.on('authenticationError')
        .map(val => 'authenticationError')
    )
      .switchMap(val => {
        // If it's a login event, then we need to retreive the user's details
        if (val === 'loggedIn') {
          return this.http
            .get(this.userUrl, { headers: this.headers })
            .map(response => cloneDeep(response.json().data as User));
        } else {
          // Otherwise, we clear the user
          return Observable.of({} as User);
        }
      })
      .do(user => {
        console.log('delaying!');
      })
      .delay(5000)
      .do(user => {
        console.log('finished delay');
        this.currentLoggedInUser = user;
        // TODO remove this - ensure nobody is using userData anymore
        this.userData = user;
      })
```

and without the patch, all links are broken. With the patch, the links are correct.

This fix only applies to the pipelines component. There is a recent pipelines widget that is also affected by the same issue. If some form of this work is accepted, I will work on fixing the widget in a separate PR. In that, I will probably move some of the component logic to the service to be reused.