### PR TITLE
Move interfaces out of deployments.service.ts

### DIFF
--- a/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
+++ b/src/app/dashboard-widgets/environment-widget/environment-widget.component.ts
@@ -5,10 +5,10 @@ import { BehaviorSubject, ConnectableObservable, Observable, Subject, Subscripti
 
 import { Context, Contexts, Spaces } from 'ngx-fabric8-wit';
 
+import { Space } from '../../../app/space/create/deployments/services/deployment-api.service';
 import {
   ApplicationAttributesOverview,
-  DeploymentsService,
-  Space
+  DeploymentsService
 } from '../../../app/space/create/deployments/services/deployments.service';
 
 @Component({

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -20,17 +20,15 @@ import {
 
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
+import { NetworkStat } from '../models/network-stat';
 import { Pods } from '../models/pods';
-import { ScaledNetworkStat } from '../models/scaled-network-stat';
+import { ScaledNetStat } from '../models/scaled-net-stat';
 import {
   DeploymentStatusService,
   Status,
   StatusType
 } from '../services/deployment-status.service';
-import {
-  DeploymentsService,
-  NetworkStat
-} from '../services/deployments.service';
+import { DeploymentsService } from '../services/deployments.service';
 import { DeploymentDetailsComponent } from './deployment-details.component';
 
 // Makes patternfly charts available
@@ -114,8 +112,8 @@ describe('DeploymentDetailsComponent', () => {
 
     const mb = Math.pow(1024, 2);
     netStatObservable = new BehaviorSubject([{
-      sent: new ScaledNetworkStat(1 * mb, 1),
-      received: new ScaledNetworkStat(2 * mb, 1)
+      sent: new ScaledNetStat(1 * mb, 1),
+      received: new ScaledNetStat(2 * mb, 1)
     }] as NetworkStat[]);
 
     podsObservable = new BehaviorSubject(
@@ -354,12 +352,12 @@ describe('DeploymentDetailsComponent', () => {
       const mb = Math.pow(1024, 2);
       netStatObservable.next([
         {
-          sent: new ScaledNetworkStat(1 * mb, 1),
-          received: new ScaledNetworkStat(2 * mb, 1)
+          sent: new ScaledNetStat(1 * mb, 1),
+          received: new ScaledNetStat(2 * mb, 1)
         },
         {
-          sent: new ScaledNetworkStat(100.567, 2),
-          received: new ScaledNetworkStat(200.234, 2)
+          sent: new ScaledNetStat(100.567, 2),
+          received: new ScaledNetStat(200.234, 2)
         }
       ] as NetworkStat[]);
       this.detectChanges();
@@ -375,12 +373,12 @@ describe('DeploymentDetailsComponent', () => {
       const mb = Math.pow(1024, 2);
       netStatObservable.next([
         {
-          sent: new ScaledNetworkStat(1 * mb, 1),
-          received: new ScaledNetworkStat(2 * mb, 1)
+          sent: new ScaledNetStat(1 * mb, 1),
+          received: new ScaledNetStat(2 * mb, 1)
         },
         {
-          sent: new ScaledNetworkStat(12.34 * 1024, 2),
-          received: new ScaledNetworkStat(45.67 * 1024, 2)
+          sent: new ScaledNetStat(12.34 * 1024, 2),
+          received: new ScaledNetStat(45.67 * 1024, 2)
         }
       ] as NetworkStat[]);
       this.detectChanges();

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -25,6 +25,10 @@ import { MemoryStat } from '../models/memory-stat';
 import { NetworkStat } from '../models/network-stat';
 import { Pods } from '../models/pods';
 import { ScaledNetStat } from '../models/scaled-net-stat';
+import {
+  instanceOfScaledStat,
+  ScaledStat
+} from '../models/scaled-stat';
 import { Stat } from '../models/stat';
 import {
   DeploymentStatusService,
@@ -321,7 +325,7 @@ export class DeploymentDetailsComponent {
   private getNetStatValue(stat: NetworkStat): { sent: number, received: number } {
     let sent: number = stat.sent.used;
     let received: number = stat.received.used;
-    if ((stat.received instanceof ScaledNetStat) && (stat.sent instanceof ScaledNetStat)) {
+    if (instanceOfScaledStat(stat.sent) && instanceOfScaledStat(stat.received)) {
       sent = stat.sent.raw;
       received = stat.received.raw;
     }

--- a/src/app/space/create/deployments/models/cpu-stat.ts
+++ b/src/app/space/create/deployments/models/cpu-stat.ts
@@ -1,3 +1,3 @@
 import { Stat } from './stat';
 
-export declare interface CpuStat extends Stat {}
+export interface CpuStat extends Stat {}

--- a/src/app/space/create/deployments/models/memory-stat.ts
+++ b/src/app/space/create/deployments/models/memory-stat.ts
@@ -2,6 +2,6 @@ import { Stat } from './stat';
 
 export type MemoryUnit = 'bytes' | 'KB' | 'MB' | 'GB';
 
-export declare interface MemoryStat extends Stat {
+export interface MemoryStat extends Stat {
   readonly units: MemoryUnit;
 }

--- a/src/app/space/create/deployments/models/network-stat.ts
+++ b/src/app/space/create/deployments/models/network-stat.ts
@@ -1,0 +1,9 @@
+export interface NetworkStat {
+  readonly sent: NetStat;
+  readonly received: NetStat;
+}
+
+export interface NetStat {
+  readonly used: number;
+  readonly timestamp?: number;
+}

--- a/src/app/space/create/deployments/models/pods.ts
+++ b/src/app/space/create/deployments/models/pods.ts
@@ -2,7 +2,7 @@ import { PodPhase } from './pod-phase';
 
 export type PodsData = [PodPhase, number];
 
-export declare interface Pods {
+export interface Pods {
   readonly pods: PodsData[];
   readonly total: number;
 }

--- a/src/app/space/create/deployments/models/scaled-memory-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-memory-stat.ts
@@ -2,13 +2,15 @@ import {
   MemoryStat,
   MemoryUnit
 } from './memory-stat';
+import { ScaledStat } from './scaled-stat';
 
 import { round } from 'lodash';
 
-export class ScaledMemoryStat implements MemoryStat {
+export class ScaledMemoryStat implements MemoryStat, ScaledStat {
 
   private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
 
+  public readonly raw: number;
   public readonly units: MemoryUnit;
 
   constructor(
@@ -16,6 +18,7 @@ export class ScaledMemoryStat implements MemoryStat {
     public readonly quota: number,
     public readonly timestamp?: number
   ) {
+    this.raw = used;
     let scale = 0;
     if (this.used !== 0) {
       while (this.used > 1024 && scale < ScaledMemoryStat.UNITS.length) {

--- a/src/app/space/create/deployments/models/scaled-net-stat.spec.ts
+++ b/src/app/space/create/deployments/models/scaled-net-stat.spec.ts
@@ -1,16 +1,16 @@
-import { ScaledNetworkStat } from './scaled-network-stat';
+import { ScaledNetStat } from './scaled-net-stat';
 
-describe('ScaledNetworkStat', () => {
+describe('ScaledNetStat', () => {
 
   it('should not scale 500 bytes', () => {
-    let stat = new ScaledNetworkStat(500);
+    let stat = new ScaledNetStat(500);
     expect(stat.raw).toEqual(500);
     expect(stat.used).toEqual(500);
     expect(stat.units).toEqual('bytes');
   });
 
   it('should scale 2048 bytes', () => {
-    let stat = new ScaledNetworkStat(2048);
+    let stat = new ScaledNetStat(2048);
     expect(stat.raw).toEqual(2048);
     expect(stat.used).toEqual(2);
     expect(stat.units).toEqual('KB');
@@ -18,7 +18,7 @@ describe('ScaledNetworkStat', () => {
 
   it('should scale 5.5GB', () => {
     let gb = Math.pow(1024, 3);
-    let stat = new ScaledNetworkStat(5.5 * gb);
+    let stat = new ScaledNetStat(5.5 * gb);
     expect(stat.raw).toEqual(5.5 * gb);
     expect(stat.used).toEqual(5.5);
     expect(stat.units).toEqual('GB');

--- a/src/app/space/create/deployments/models/scaled-net-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-net-stat.ts
@@ -1,9 +1,10 @@
 import { MemoryUnit } from './memory-stat';
 import { NetStat } from './network-stat';
+import { ScaledStat } from './scaled-stat';
 
 import { round } from 'lodash';
 
-export class ScaledNetStat implements NetStat {
+export class ScaledNetStat implements NetStat, ScaledStat {
 
   private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
 

--- a/src/app/space/create/deployments/models/scaled-net-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-net-stat.ts
@@ -1,8 +1,9 @@
 import { MemoryUnit } from './memory-stat';
+import { NetStat } from './network-stat';
 
 import { round } from 'lodash';
 
-export class ScaledNetworkStat {
+export class ScaledNetStat implements NetStat {
 
   private static readonly UNITS = ['bytes', 'KB', 'MB', 'GB'];
 
@@ -15,11 +16,11 @@ export class ScaledNetworkStat {
   ) {
     this.raw = used;
     let scale = 0;
-    while (this.used > 1024 && scale < ScaledNetworkStat.UNITS.length) {
+    while (this.used > 1024 && scale < ScaledNetStat.UNITS.length) {
       this.used /= 1024;
       scale++;
     }
     this.used = round(this.used, 1);
-    this.units = ScaledNetworkStat.UNITS[scale] as MemoryUnit;
+    this.units = ScaledNetStat.UNITS[scale] as MemoryUnit;
   }
 }

--- a/src/app/space/create/deployments/models/scaled-stat.ts
+++ b/src/app/space/create/deployments/models/scaled-stat.ts
@@ -1,0 +1,7 @@
+export interface ScaledStat {
+  readonly raw: number;
+}
+
+export function instanceOfScaledStat(object: any): object is ScaledStat {
+  return 'raw' in object;
+}

--- a/src/app/space/create/deployments/models/stat.ts
+++ b/src/app/space/create/deployments/models/stat.ts
@@ -1,4 +1,4 @@
-export declare interface Stat {
+export interface Stat {
   readonly used: number;
   readonly quota: number;
   readonly timestamp?: number;

--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -22,13 +22,13 @@ import { createMock } from 'testing/mock';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 
-import { DeploymentApiService } from './deployment-api.service';
 import {
   Application,
+  DeploymentApiService,
   EnvironmentStat,
   MultiTimeseriesData,
   TimeseriesData
-} from './deployments.service';
+} from './deployment-api.service';
 
 describe('DeploymentApiService', () => {
   let mockBackend: MockBackend;

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -12,16 +12,122 @@ import { Observable } from 'rxjs';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 
-import {
-  Application,
-  ApplicationsResponse,
-  EnvironmentsResponse,
-  EnvironmentStat,
-  MultiTimeseriesData,
-  MultiTimeseriesResponse,
-  TimeseriesData,
-  TimeseriesResponse
-} from './deployments.service';
+import { CpuStat } from '../models/cpu-stat';
+import { MemoryStat } from '../models/memory-stat';
+
+export interface ApplicationsResponse {
+  data: Space;
+}
+
+export interface Space {
+  attributes: SpaceAttributes;
+  id: string;
+  type: string;
+}
+
+export interface SpaceAttributes {
+  applications: Application[];
+}
+
+export interface Application {
+  attributes: ApplicationAttributes;
+  id: string;
+  type: string;
+}
+
+export interface ApplicationAttributes {
+  name: string;
+  deployments: Deployment[];
+}
+
+export interface Deployment {
+  attributes: DeploymentAttributes;
+  links: Links;
+  id: string;
+  type: string;
+}
+
+export interface DeploymentAttributes {
+  name: string;
+  pod_total: number;
+  pods: [[string, string]];
+  pods_quota: PodsQuota;
+  version: string;
+}
+
+export interface Links {
+  application: string;
+  console: string;
+  logs: string;
+}
+
+export interface PodsQuota {
+  cpucores: number;
+  memory: number;
+}
+
+export interface EnvironmentsResponse {
+  data: EnvironmentStat[];
+}
+
+export interface EnvironmentStat {
+  attributes: EnvironmentAttributes;
+  id: string;
+  type: string;
+}
+
+export interface EnvironmentAttributes {
+  name: string;
+  quota: Quota;
+}
+
+export interface Quota {
+  cpucores: CpuStat;
+  memory: MemoryStat;
+}
+
+export interface TimeseriesResponse {
+  data: DeploymentStats;
+}
+
+export interface MultiTimeseriesResponse {
+  data: MultiTimeseriesData;
+}
+
+export interface DeploymentStats {
+  attributes: TimeseriesData;
+  id: string;
+  type: string;
+}
+
+export interface TimeseriesData {
+  cores: CoresSeries;
+  memory: MemorySeries;
+  net_tx: NetworkSentSeries;
+  net_rx: NetworkReceivedSeries;
+}
+
+export interface MultiTimeseriesData {
+  cores: CoresSeries[];
+  memory: MemorySeries[];
+  net_tx: NetworkSentSeries[];
+  net_rx: NetworkReceivedSeries[];
+  start: number;
+  end: number;
+}
+
+export interface CoresSeries extends SeriesData { }
+
+export interface MemorySeries extends SeriesData { }
+
+export interface NetworkSentSeries extends SeriesData { }
+
+export interface NetworkReceivedSeries extends SeriesData { }
+
+export interface SeriesData {
+  time: number;
+  value: number;
+}
 
 @Injectable()
 export class DeploymentApiService {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -32,12 +32,12 @@ import { WIT_API_URL } from 'ngx-fabric8-wit';
 
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
+import { NetworkStat } from '../models/network-stat';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
-import { ScaledNetworkStat } from '../models/scaled-network-stat';
+import { ScaledNetStat } from '../models/scaled-net-stat';
 import { DeploymentApiService } from './deployment-api.service';
 import {
   DeploymentsService,
-  NetworkStat,
   TIMER_TOKEN,
   TIMESERIES_SAMPLES_TOKEN
 } from './deployments.service';
@@ -1590,9 +1590,9 @@ describe('DeploymentsService', () => {
         .first()
         .subscribe((stats: NetworkStat[]) => {
           expect(stats).toEqual([
-            { sent: new ScaledNetworkStat(7, 7), received: new ScaledNetworkStat(5, 5) },
-            { sent: new ScaledNetworkStat(8, 8), received: new ScaledNetworkStat(6, 6) },
-            { sent: new ScaledNetworkStat(11, 11), received: new ScaledNetworkStat(12, 12) }
+            { sent: new ScaledNetStat(7, 7), received: new ScaledNetStat(5, 5) },
+            { sent: new ScaledNetStat(8, 8), received: new ScaledNetStat(6, 6) },
+            { sent: new ScaledNetStat(11, 11), received: new ScaledNetStat(12, 12) }
           ]);
           subscription.unsubscribe();
           done();


### PR DESCRIPTION
See initial commit message or linked issue for more detail, but the gist is that these interfaces should be moved closer to the functions that produce them as return types, for general cleanliness but also to create a clearer separation for "internal to Deployments" (DeploymentsService) and "external for Deployments consumers" (DeploymentApiService and these interfaces).