### PR TITLE
fix master build

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -27,7 +27,8 @@ RUN yum -y update && \
       python-setuptools xorg-x11-xauth wget unzip which \
       xorg-x11-server-Xvfb xfonts-100dpi libXfont GConf2 \
       xorg-x11-fonts-75dpi xfonts-scalable xfonts-cyrillic \
-      ipa-gothic-fonts xorg-x11-utils xorg-x11-fonts-Type1 xorg-x11-fonts-misc && \
+      ipa-gothic-fonts xorg-x11-utils xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
+      epel-release libappindicator && \
       yum -y clean all
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \


### PR DESCRIPTION
The master build is failing at chrome installation with "Requires: libappindicator3.so.1()(64bit)"
This PR installs epel-release and libappindicator to the builder container.

