### PR TITLE
fix(settings): Redirect user to appropriate feature opt in page

### DIFF
--- a/src/app/feature-flag/warning-page/feature-warning-page.component.html
+++ b/src/app/feature-flag/warning-page/feature-warning-page.component.html
@@ -7,7 +7,7 @@
           <h2>Internal Features Opt-in</h2>
           <p>These features are only available to Red Hat users and have no guarantee of performance or stability.
             Use these at your own risk.</p>
-          <button class="btn btn-lg btn-feature-level" [routerLink]="profileLink">Opt-in to Internal Features</button>
+          <button class="btn btn-lg btn-feature-level" [routerLink]="profileSettingsLink">Opt-in to Internal Features</button>
          </div>
       </div>
     </div>
@@ -20,7 +20,7 @@
           <h2>Experimental Features Opt-in</h2>
           <p>These features are currently in beta testing and have no guarantee of performance or stability.
             Use these at your own risk.</p>
-            <button class="btn btn-lg btn-feature-level" [routerLink]="profileLink">Opt-in to Experimental Features</button>
+            <button class="btn btn-lg btn-feature-level" [routerLink]="profileSettingsLink">Opt-in to Experimental Features</button>
         </div>
       </div>
     </div>
@@ -33,7 +33,7 @@
           <h2>Beta Features Opt-in</h2>
           <p>These features are currently in beta testing and have no guarantee of performance or stability.
             Use these at your own risk.</p>
-          <button class="btn btn-lg btn-feature-level" [routerLink]="profileLink">Opt-in to Beta Features</button>
+          <button class="btn btn-lg btn-feature-level" [routerLink]="profileSettingsLink">Opt-in to Beta Features</button>
         </div>
       </div>
     </div>

--- a/src/app/feature-flag/warning-page/feature-warning-page.component.ts
+++ b/src/app/feature-flag/warning-page/feature-warning-page.component.ts
@@ -18,7 +18,7 @@ export class FeatureWarningPageComponent implements OnInit, OnDestroy {
 
   enableFeatures: boolean;
   @Input() level: string;
-  profileLink: string;
+  profileSettingsLink: string;
   private userSubscription: Subscription;
 
   constructor(private userService: UserService,
@@ -26,11 +26,11 @@ export class FeatureWarningPageComponent implements OnInit, OnDestroy {
     if (authService.isLoggedIn()) {
       this.userSubscription = userService.loggedInUser.subscribe(val => {
         if (val.id) {
-          this.profileLink = '/' + val.attributes.username + '/_update';
+          this.profileSettingsLink = '/' + val.attributes.username + '/_settings/feature-opt-in';
         }
       });
     } else {
-      this.profileLink = '/_home';
+      this.profileSettingsLink = '/_home';
     }
   }
 


### PR DESCRIPTION
This patch changes the route used by the feature warning page to redirect users to the feature opt in page under their profile settings, instead of their profile.

Fixes: https://github.com/openshiftio/openshift.io/issues/3260 