### PR TITLE
fix(routing): prevent side-effects of action outlet for add-work-item and add-codebases

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,7 +11,24 @@ import { SigninComponent } from './signin/signin.component';
 
 
 export function removeAction(url: string) {
-  return trimEnd(url.replace(/\(action:[a-z-]*\)/, ''), '/');
+  const nestedOutletRegex: RegExp = (/^(.*\([A-z-]*?)\/{0,2}action:[A-z-]*\)$/);
+  if (url.indexOf('action:') !== -1) {
+    if (nestedOutletRegex.test(url)) {
+      // if the action outlet contains the current page
+      // e.g., /${user}/${space}/create/(pipelines//action:add-codebase)
+      url = url.match(nestedOutletRegex)[1];
+      let i = url.lastIndexOf('(');
+      url = url.substring(0, i) + url.substring(i + 1);
+      if ((url.lastIndexOf('/') + 1) === url.length) {
+        url = url.slice(0, -1); // trim trailing '/' if applicable
+      }
+    } else {
+      // if the outlet is isolated at the end of the url
+      // e.g., /${user}/${space}/create/(action:add-codebase)
+      url = trimEnd(url.replace(/\(action:[a-z-]*\)/, ''), '/');
+    }
+  }
+  return url;
 }
 
 export const routes: Routes = [

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
@@ -2,7 +2,7 @@
   <div id="spacehome-codebases" class="add-codebase-widget card-pf f8-card" user-level>
     <div class="card-pf-heading f8-card-heading">
       <div class="card-pf-heading-details f8-card-heading-details">
-        <a id="spacehome-codebases-add-space-button" class="btn btn-link f8-card-heading-btn-link" [routerLink]="[contextPath, 'create', { outlets: { action: 'add-codebase' } }]">
+        <a id="spacehome-codebases-add-space-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
           <i class="pficon pficon-add-circle-o"></i>
         </a>
       </div>
@@ -14,10 +14,7 @@
       <div class="f8-blank-slate-card" *ngIf="codebases.length === 0">
         <h3>This Space has no Codebases</h3>
         <div class="f8-blank-slate-main-action">
-          <button id="spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
-        </div>
-        <div class="f8-blank-slate-main-action">
-          <button id="spacehome-codebases-import-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-codebase' } }]">Import Codebase</button>
+          <button id="spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add a Codebase</button>
         </div>
       </div>
       <div id="spacehome-codebases-card-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
@@ -44,7 +41,7 @@
   <div id="spacehome-codebases-card" class="add-codebase-widget card-pf f8-card" default-level>
     <div class="card-pf-heading f8-card-heading">
       <div class="card-pf-heading-details f8-card-heading-details">
-        <a id="spacehome-codebases-add-button" class="btn btn-link f8-card-heading-btn-link" [routerLink]="[contextPath, 'create', { outlets: { action: 'add-codebase' } }]">
+        <a id="spacehome-codebases-add-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
           <i class="pficon pficon-add-circle-o"></i>
         </a>
       </div>
@@ -57,10 +54,7 @@
       <div class="f8-blank-slate-card" *ngIf="codebases.length === 0">
         <h3>This Space has no Codebases</h3>
         <div class="f8-blank-slate-main-action">
-          <button id="spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
-        </div>
-        <div class="f8-blank-slate-main-action">
-          <button id="spacehome-my-codebases-import-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-codebase' } }]">Import Codebase</button>
+          <button id="spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add a Codebase</button>
         </div>
       </div>
       <ul id="spacehome-codebases-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-overlay/create-work-item-overlay.component.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-overlay/create-work-item-overlay.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { AfterViewInit, Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -30,7 +31,8 @@ export class CreateWorkItemOverlayComponent implements OnInit, AfterViewInit {
     private router: Router,
     private spaces: Spaces,
     private broadcaster: Broadcaster,
-    private workItemService: WorkItemService
+    private workItemService: WorkItemService,
+    private location: Location
   ) { }
 
   ngOnInit() {
@@ -43,7 +45,7 @@ export class CreateWorkItemOverlayComponent implements OnInit, AfterViewInit {
   }
 
   onClose() {
-    this.router.navigateByUrl(removeAction(this.router.url));
+    this.location.back();
   }
 
   onSelect(workItemType: WorkItemType) {

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget-routing.module.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget-routing.module.ts
@@ -6,8 +6,7 @@ import { CreateWorkItemOverlayComponent } from './create-work-item-overlay/creat
 const routes: Routes = [
   {
     path: 'add-work-item',
-    component: CreateWorkItemOverlayComponent,
-    outlet: 'action'
+    component: CreateWorkItemOverlayComponent
   }
 ];
 

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.html
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.html
@@ -2,7 +2,7 @@
   <div id="spacehome-my-workitems-card" class="create-work-item-widget card-pf f8-card" user-level>
     <div class="card-pf-heading f8-card-heading">
       <div class="card-pf-heading-details f8-card-heading-details">
-        <a id="spacehome-my-workitems-add-button" class="btn btn-link f8-card-heading-btn-link" [routerLink]="[{ outlets: { action: 'add-work-item' } }]">
+        <a id="spacehome-my-workitems-add-button" class="btn btn-link f8-card-heading-btn-link" [routerLink]="[contextPath | async, 'add-work-item']">
           <i class="pficon pficon-add-circle-o"></i>
         </a>
       </div>
@@ -18,7 +18,7 @@
           Planner will help you to create different types of work-items, allows you to assign team members and iterations.
         </p>
         <div class="f8-blank-slate-main-action">
-          <button id="spacehome-my-workitems-create-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-work-item' } }]">Create work item</button>
+          <button id="spacehome-my-workitems-create-button" class="btn btn-primary btn-lg" [routerLink]="[contextPath | async, 'add-work-item']">Create work item</button>
         </div>
       </div>
       <ul id="spacehome-my-workitems-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped f8-card-list"

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -1,8 +1,9 @@
 import {
   Component,
+  DebugNode,
   NO_ERRORS_SCHEMA
 } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -61,6 +62,8 @@ describe('HeaderComponent', () => {
   mockBroadcaster.broadcast.and.stub();
 
   let testRouter: Router;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let component: DebugNode['componentInstance'];
 
   initContext(HeaderComponent, HostComponent, {
     imports: [
@@ -94,6 +97,8 @@ describe('HeaderComponent', () => {
 
   beforeEach(() => {
     testRouter = TestBed.get(Router);
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.debugElement.componentInstance;
   });
 
   it('should return default context when in _home state', function(this: TestingContext, done: DoneFn) {
@@ -137,4 +142,25 @@ describe('HeaderComponent', () => {
       });
     });
   });
+
+  describe('#formatUrl', () => {
+    it('should remove an action outlet from the end of the url', () => {
+      let url: string = 'create/(action:add-codebase)';
+      let result = component.formatUrl(url);
+      expect(result).toEqual('create');
+    });
+
+    it('should remove an action outlet that contains a nested route', () => {
+      let url: string = 'create/(pipelines//action:add-codebase)';
+      let result = component.formatUrl(url);
+      expect(result).toEqual('create/pipelines');
+    });
+
+    it('should remove a query from the url', () => {
+      let url: string = 'space/plan?q=(space:1234567890)&showTree=true';
+      let result = component.formatUrl(url);
+      expect(result).toEqual('space/plan');
+    });
+  });
+
 });

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -8,8 +8,8 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { Context, Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 
+import { removeAction } from '../../app-routing.module';
 import { FeatureTogglesService } from '../../feature-flag/service/feature-toggles.service';
-
 import { Navigation } from '../../models/navigation';
 import { LoginService } from '../../shared/login.service';
 import { MenuedContextType } from './menued-context-type';
@@ -196,6 +196,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return (this.router.url.indexOf('applauncher') !== -1);
   }
 
+  formatUrl(url: string) {
+    url = this.stripQueryFromUrl(url);
+    url = removeAction(url);
+    return url;
+  }
+
   private stripQueryFromUrl(url: string) {
     if (url.indexOf('?q=') !== -1) {
       url = url.substring(0, url.indexOf('?q='));
@@ -206,6 +212,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private updateMenus() {
     if (this.context && this.context.type && this.context.type.hasOwnProperty('menus')) {
       let foundPath = false;
+      let url = this.formatUrl(this.router.url);
       let menus = (this.context.type as MenuedContextType).menus;
       for (let n of menus) {
         // Clear the menu's active state
@@ -221,7 +228,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
           for (let o of subMenus) {
             // Clear the menu's active state
             o.active = false;
-            if (!foundPath && o.fullPath === decodeURIComponent(this.router.url)) {
+            if (!foundPath && o.fullPath === decodeURIComponent(url)) {
               foundPath = true;
               o.active = true;
               n.active = true;
@@ -233,7 +240,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
           if (!foundPath) {
             // lets check if the URL matches part of the path
             for (let o of subMenus) {
-              if (!foundPath && decodeURIComponent(this.router.url).startsWith(o.fullPath + '/')) {
+              if (!foundPath && decodeURIComponent(url).startsWith(o.fullPath + '/')) {
                 foundPath = true;
                 o.active = true;
                 n.active = true;
@@ -257,7 +264,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
               }
             }
           }
-        } else if (!foundPath && n.fullPath === this.stripQueryFromUrl(this.router.url)) {
+        } else if (!foundPath && n.fullPath === url) {
           n.active = true;
           foundPath = true;
         }


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/3021 [0]

By fixing up the side-effects that named router outlets are currently causing, this PR accomplishes two things:

1. Makes the add-work-item action into a separate page

Previously, the add-work-item action would display an "overlay", and cause a 404 when trying to go to the planner, settings, or create page while active [0]. Now, the overlay can be treated as it's own page, which maintains the routing we would expect. 

**Note, at the time of writing this something is wrong in the f8-planner side of the add-work-item [1], specifically trying to retrieve the work item types is returning a 404; it looks like it may get amended by [2] . There is an issue logged for it here: [3].

2. Removes the add-codebases action from the dashboard, and modifies the header component so that switching between the codebases/pipelines/deployments pages with the outlet active will update the header accordingly.

The add-codebases action, similar to the add-work-items action, has routing problems when used in the dashboard. To patch this as discussed in [0] the add-codebases action has been replaced with the code wizard. On the create/ pages however, I patched up the url verification for determining active menu items, so the add-codebases action can still work in codebases and update the header accordingly. 

[0] https://github.com/openshiftio/openshift.io/issues/3021
[1] https://github.com/fabric8-ui/fabric8-planner/blob/fa4c909b8297f60e29b5d67dfd43db0e8f0850e4/src/app/components/work-item-create/work-item-create-selector/work-item-create-selector.component.html
[2] https://github.com/fabric8-ui/fabric8-planner/pull/2574
[3] https://github.com/openshiftio/openshift.io/issues/3300
