### PR TITLE
fix(planner): board view navigation is removed temporarily

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -119,19 +119,19 @@ export const routes: Routes = [
     }
   },
 
-  // Plan board
-  {
-    path: ':entity/:space/plan/board',
-    resolve: {
-      context: ContextResolver,
-      featureFlagConfig: FeatureFlagResolver
-    },
-    loadChildren: './space/plan/board/board.module#BoardModule',
-    data: {
-      title: 'Plan: Board',
-      featureName: 'Planner'
-    }
-  },
+  // // Plan board
+  // {
+  //   path: ':entity/:space/plan/board',
+  //   resolve: {
+  //     context: ContextResolver,
+  //     featureFlagConfig: FeatureFlagResolver
+  //   },
+  //   loadChildren: './space/plan/board/board.module#BoardModule',
+  //   data: {
+  //     title: 'Plan: Board',
+  //     featureName: 'Planner'
+  //   }
+  // },
 
   // Plan details
   {

--- a/src/app/layout/header/menus.service.spec.ts
+++ b/src/app/layout/header/menus.service.spec.ts
@@ -62,12 +62,12 @@ describe('MenuService service: it', () => {
             'name':  'Backlog',
             'path':  '',
             'fullPath':  '/ckrych@redhat.com/test2/plan'
-          },
-          {
-            'name':  'Board',
-            'path':  'board',
-            'fullPath':  '/ckrych@redhat.com/test2/plan/board'
           }
+          // {
+          //   'name':  'Board',
+          //   'path':  'board',
+          //   'fullPath':  '/ckrych@redhat.com/test2/plan/board'
+          // }
         ],
         'fullPath':  '/ckrych@redhat.com/test2/plan'
       },

--- a/src/app/layout/header/menus.service.ts
+++ b/src/app/layout/header/menus.service.ts
@@ -44,10 +44,11 @@ export class MenusService {
               {
                 name: 'Backlog',
                 path: ''
-              }, {
-                name: 'Board',
-                path: 'board'
               }
+              // , {
+              //   name: 'Board',
+              //   path: 'board'
+              // }
             ]
           }, {
             name: 'Create',


### PR DESCRIPTION
Board view is removed temporarily till the summit. After that board view is likely to be refactored and added back with a new design and a number of new features. 

Related issue - https://openshift.io/openshiftio/openshiftio/plan/detail/1945