### PR TITLE
fix(space-description): fix description text not updating when using …

### DIFF
--- a/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.html
@@ -1,0 +1,22 @@
+<div class="edit-space-description-widget-old">
+  <h2 class="margin-0">
+    <b>{{space?.attributes.name | spaceName}}</b>
+  </h2>
+  <!-- There must be no spaces here, otherwise we end up with random whitespace in the editable-->
+  <div class="form-group">
+    <textarea row="2" placeholder="Description goes here" class="space-description form-control" *ngIf="isEditing && (isEditable() | async)"
+      (keyup.enter)="onUpdateDescription(description.value)" (keydown.enter)="preventDef($event)" #description>{{space?.attributes.description}}</textarea>
+    <div *ngIf="isEditing">
+      <button id="_btn_cancel" class="pull-right btn btn-default edit-space-description-btn" (click)="stopEditingDescription()">
+        <span class="fa fa-close"></span>
+      </button>
+      <!--Save icon-->
+      <button id="workItemTitle_btn_save" class="pull-right btn btn-primary edit-space-description-btn " (click)="saveDescription()">
+        <span class="fa fa-check"></span>
+      </button>
+    </div>
+    <span *ngIf="!isEditing || !(isEditable() | async)" (click)="startEditingDescription()" class="edit-space-description-span">
+      {{space?.attributes.description || "Enter a description"}}
+    </span>
+  </div>
+</div>

--- a/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.less
@@ -1,0 +1,10 @@
+@import (reference) '../../../assets/stylesheets/shared/osio.less';
+
+.edit-space-description-widget-old {
+  max-height: 245px;
+  h2 { text-transform: capitalize; }
+  .space-description {
+    margin: 5px 0;
+    resize: none;
+  }
+}

--- a/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.ts
@@ -1,0 +1,97 @@
+import { Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Broadcaster } from 'ngx-base';
+import { Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
+import { User, UserService } from 'ngx-login-client';
+import { Observable, Subject } from 'rxjs';
+import { Subscription } from 'rxjs';
+import { SpaceNamespaceService } from '../../shared/runtime-console/space-namespace.service';
+import { DummyService } from './../shared/dummy.service';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'fabric8-edit-space-description-widget-old',
+  templateUrl: './edit-space-description-widget-old.component.html',
+  styleUrls: ['./edit-space-description-widget-old.component.less']
+})
+export class EditSpaceDescriptionWidgetOldComponent implements OnInit {
+
+  space: Space;
+
+  private _descriptionUpdater: Subject<string> = new Subject();
+
+  private loggedInUser: User;
+  @ViewChild('description') description: any;
+
+  private isEditing: boolean = false;
+
+  constructor(
+    private spaces: Spaces,
+    private contexts: Contexts,
+    private userService: UserService,
+    private broadcaster: Broadcaster,
+    private spaceService: SpaceService,
+    private spaceNamespaceService: SpaceNamespaceService
+  ) {
+    spaces.current.subscribe(val => {
+      this.space = val;
+      console.log('newspace', val);
+    });
+    userService.loggedInUser.subscribe(val => this.loggedInUser = val);
+  }
+
+  ngOnInit() {
+    this._descriptionUpdater
+      .debounceTime(1000)
+      .map(description => {
+        let patch = {
+          attributes: {
+            description: description,
+            name: this.space ? this.space.attributes.name : '',
+            version: this.space ? this.space.attributes.version : ''
+          },
+          type: 'spaces',
+          id: this.space.id
+        } as Space;
+        return patch;
+      })
+      .do(val => console.log(val))
+      .switchMap(patch => this.spaceService
+        .update(patch)
+        .do(val => {
+          console.log('updatedspace', val);
+          this.isEditing = false;
+          if (this.space && val) {
+            this.space.attributes.description = val.attributes.description;
+          }
+        })
+        .do(updated => this.broadcaster.broadcast('spaceUpdated', updated))
+        .switchMap(updated => this.spaceNamespaceService.updateConfigMap(Observable.of(updated)))
+      )
+      .subscribe();
+  }
+
+  onUpdateDescription(description) {
+    this._descriptionUpdater.next(description);
+  }
+
+  preventDef(event: any) {
+    event.preventDefault();
+  }
+
+  saveDescription() {
+    this._descriptionUpdater.next(this.description.nativeElement.value);
+  }
+
+  stopEditingDescription() {
+    this.isEditing = false;
+  }
+
+  startEditingDescription() {
+    this.isEditing = true;
+  }
+
+  isEditable(): Observable<boolean> {
+    return this.contexts.current.map(val => val.user.id === this.loggedInUser.id);
+  }
+
+}

--- a/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.module.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.module.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { Fabric8WitModule } from 'ngx-fabric8-wit';
+import { AlmEditableModule, AlmIconModule } from 'ngx-widgets';
+import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
+import { EditSpaceDescriptionWidgetOldComponent } from './edit-space-description-widget-old.component';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    AlmIconModule,
+    AlmEditableModule,
+    Fabric8WitModule,
+    FeatureFlagModule
+  ],
+  declarations: [EditSpaceDescriptionWidgetOldComponent],
+  exports: [EditSpaceDescriptionWidgetOldComponent]
+})
+export class EditSpaceDescriptionWidgetOldModule { }

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -1,66 +1,42 @@
-<f8-feature-toggle featureName="Analyze.newSpaceDashboard">
-  <div class="edit-space-description-widget" user-level>
-    <div class="col-sm-3 f8-space-masthead-space-info">
-      <div>
-        <span class="f8-space-masthead-name">{{space?.attributes.name | spaceName}}</span> <span class="f8-space-masthead-owner">bobross_925</span>
-      </div>
-      <div>
-        <span class="pficon pficon-users fa-lg"></span> 59
-        <span class="f8-space-masthead-vertical-divider-collab"></span>
-        <span class="pficon pficon-add-circle-o fa-lg"></span> Add Collaborator
-      </div>
+<div class="edit-space-description-widget">
+  <div class="col-sm-3 f8-space-masthead-space-info">
+    <div>
+      <span class="f8-space-masthead-name">{{space?.attributes.name | spaceName}}</span> <span class="f8-space-masthead-owner">bobross_925</span>
     </div>
-    <div class="f8-space-masthead-vertical-divider"></div>
-    <div class="col-sm-9 f8-space-masthead-description">
-      <!-- There must be no spaces here, otherwise we end up with random whitespace in the editable-->
-      <div class="form-group">
-        <div class="f8-space-masthead-description-title"></div>
-        <textarea row="3"
-                  placeholder="Description goes here"
-                  class="space-description form-control"
-                  *ngIf="isEditing && (isEditable() | async)"
-                  (keyup.enter)="onUpdateDescription(description.value)"
-                  (keydown.enter)="preventDef($event)"
-                  #description>{{space?.attributes.description}}</textarea>
-        <div class="f8-space-masthead-description-edit-buttons" *ngIf="isEditing">
-          <button id="_btn_cancel_description"
-                  class="pull-right btn btn-default edit-space-description-btn"
-                  (click)="stopEditingDescription()">
-            Cancel
-          </button>
-          <!--Save icon-->
-          <button id="workItemTitle_btn_save_description"
-                  class="pull-right btn btn-primary edit-space-description-btn "
-                  (click)="saveDescription()" >
-            Save
-          </button>
-        </div>
-        <p *ngIf="!isEditing || !(isEditable() | async)" (click)="startEditingDescription()" class="f8-space-masthead-description-body edit-space-description-pencil truncate-multiline">
-          {{space?.attributes.description || "Enter a description"}}
-        </p>
-      </div>
+    <div>
+      <span class="pficon pficon-users fa-lg"></span> 59
+      <span class="f8-space-masthead-vertical-divider-collab"></span>
+      <span class="pficon pficon-add-circle-o fa-lg"></span> Add Collaborator
     </div>
   </div>
-  <div class="old-edit-space-description-widget" default-level>
-    <h2 class="margin-0">
-      <b>{{space?.attributes.name | spaceName}}</b>
-    </h2>
+  <div class="f8-space-masthead-vertical-divider"></div>
+  <div class="col-sm-9 f8-space-masthead-description">
     <!-- There must be no spaces here, otherwise we end up with random whitespace in the editable-->
     <div class="form-group">
-      <textarea row="2" placeholder="Description goes here" class="space-description form-control" *ngIf="isEditing && (isEditable() | async)"
-        (keyup.enter)="onUpdateDescription(description.value)" (keydown.enter)="preventDef($event)" #description>{{space?.attributes.description}}</textarea>
-      <div *ngIf="isEditing">
-        <button id="_btn_cancel" class="pull-right btn btn-default edit-space-description-btn" (click)="stopEditingDescription()">
-          <span class="fa fa-close"></span>
+      <div class="f8-space-masthead-description-title"></div>
+      <textarea row="3"
+                placeholder="Description goes here"
+                class="space-description form-control"
+                *ngIf="isEditing && (isEditable() | async)"
+                (keyup.enter)="onUpdateDescription(description.value)"
+                (keydown.enter)="preventDef($event)"
+                #description>{{space?.attributes.description}}</textarea>
+      <div class="f8-space-masthead-description-edit-buttons" *ngIf="isEditing">
+        <button id="_btn_cancel_description"
+                class="pull-right btn btn-default edit-space-description-btn"
+                (click)="stopEditingDescription()">
+          Cancel
         </button>
         <!--Save icon-->
-        <button id="workItemTitle_btn_save" class="pull-right btn btn-primary edit-space-description-btn " (click)="saveDescription()">
-          <span class="fa fa-check"></span>
+        <button id="workItemTitle_btn_save_description"
+                class="pull-right btn btn-primary edit-space-description-btn "
+                (click)="saveDescription()" >
+          Save
         </button>
       </div>
-      <span *ngIf="!isEditing || !(isEditable() | async)" (click)="startEditingDescription()" class="edit-space-description-span">
+      <p *ngIf="!isEditing || !(isEditable() | async)" (click)="startEditingDescription()" class="f8-space-masthead-description-body edit-space-description-pencil truncate-multiline">
         {{space?.attributes.description || "Enter a description"}}
-      </span>
+      </p>
     </div>
   </div>
-</f8-feature-toggle>
+</div>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -161,33 +161,3 @@
     }
   }
 }
-
-/* remove everything below this line to complete redesign */
-.old-edit-space-description-widget {
-  max-height: 245px;
-  h2 { text-transform: capitalize; }
-  .space-description {
-    margin: 5px 0;
-    resize: none;
-  }
-}
-
-.old-edit-space-description-btn {
-  width: 42px;
-  padding: 0 !important; /* stylelint-disable-line declaration-no-important */
-  margin-bottom: 10px;
-  margin-left: 5px;
-  text-align: center;
-  .pointer;
-}
-
-.old-edit-space-description-span {
-  line-height: 1.5;
-  &:hover {
-    &:after {
-      padding-left: 20px;
-      font-family: PatternFlyIcons-webfont;
-      content: '\E60A';
-    }
-  }
-}

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -1,0 +1,75 @@
+import { DebugNode } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Broadcaster } from 'ngx-base';
+import { Contexts, SpaceNamePipe, Spaces, SpaceService } from 'ngx-fabric8-wit';
+import { UserService } from 'ngx-login-client';
+import { Observable } from 'rxjs';
+import { SpaceNamespaceService } from '../../shared/runtime-console/space-namespace.service';
+import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-widget.component';
+
+describe('EditSpaceDescriptionWidgetComponent', () => {
+  let fixture: ComponentFixture<EditSpaceDescriptionWidgetComponent>;
+  let component: DebugNode['componentInstance'];
+
+  let mockSpaces: any = jasmine.createSpy('Spaces');
+  let mockContexts: any = jasmine.createSpy('Contexts');
+  let mockUserService: any = jasmine.createSpy('UserService');
+  let mockBroadcaster: any = jasmine.createSpy('Broadcaster');
+  let mockSpaceService: any = jasmine.createSpy('SpaceService');
+  let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
+  let mockElementRef: any = jasmine.createSpyObj('ElementRef', ['nativeElement']);
+  let mockDescriptionUpdater: any = jasmine.createSpyObj('Subject', ['next']);
+  let mockSpace: any = {
+    name: 'mock-space',
+    path: 'mock-path',
+    id: 'mock-id',
+    attributes: {
+      name: 'mock-attribute',
+      description: 'mock-description',
+      'updated-at': 'mock-updated-at',
+      'created-at': 'mock-created-at',
+      version: 0
+    }
+  };
+
+  mockElementRef.nativeElement.value = {};
+  mockSpaces.current = Observable.of(mockSpace);
+  mockUserService.loggedInUser = Observable.of({});
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditSpaceDescriptionWidgetComponent, SpaceNamePipe],
+      providers: [
+        { provide: Spaces, useValue: mockSpaces },
+        { provide: Contexts, useValue: mockContexts },
+        { provide: UserService, useValue: mockUserService },
+        { provide: Broadcaster, useValue: mockBroadcaster },
+        { provide: SpaceService, useValue: mockSpaceService },
+        { provide: SpaceNamespaceService, useValue: mockSpaceNamespaceService }
+      ]
+    });
+    fixture = TestBed.createComponent(EditSpaceDescriptionWidgetComponent);
+    fixture.detectChanges();
+    component = fixture.debugElement.componentInstance;
+    component.description = mockElementRef;
+
+  });
+
+  describe('#onUpdateDescription', () => {
+    it('should delegate to _descriptionUpdater', () => {
+      component._descriptionUpdater = mockDescriptionUpdater;
+      component.onUpdateDescription('new-description');
+      expect(component._descriptionUpdater.next).toHaveBeenCalledWith('new-description');
+    });
+  });
+
+  describe('#saveDescription', () => {
+    it('should delegate to _descriptionUpdater', () => {
+      component._descriptionUpdater = mockDescriptionUpdater;
+      mockElementRef.nativeElement.value = 'new-description';
+      component.saveDescription();
+      expect(component._descriptionUpdater.next).toHaveBeenCalledWith('new-description');
+    });
+  });
+
+});

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -41,7 +41,7 @@
   <div id="analyze-overview" class="container-fluid analyze-overview-wrapper" default-level>
     <div class="row margin-top-15">
       <div class="col-xs-12 col-sm-10">
-        <fabric8-edit-space-description-widget></fabric8-edit-space-description-widget>
+        <fabric8-edit-space-description-widget-old></fabric8-edit-space-description-widget-old>
       </div>
       <div class="col-xs-4 col-xs-offset-4 col-sm-2 col-sm-offset-0">
         <f8-feature-toggle featureName="AppLauncher">

--- a/src/app/space/analyze/analyze-overview/analyze-overview.module.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.module.ts
@@ -10,6 +10,7 @@ import { AddCodebaseWidgetModule } from '../../../dashboard-widgets/add-codebase
 import { AnalyticalReportWidgetModule } from '../../../dashboard-widgets/analytical-report-widget/analytical-report-widget.module';
 import { ApplicationsWidgetModule } from '../../../dashboard-widgets/applications-widget/applications-widget.module';
 import { CreateWorkItemWidgetModule } from '../../../dashboard-widgets/create-work-item-widget/create-work-item-widget.module';
+import { EditSpaceDescriptionWidgetOldModule } from '../../../dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.module';
 import { EditSpaceDescriptionWidgetModule } from '../../../dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module';
 import { EnvironmentWidgetComponent } from '../../../dashboard-widgets/environment-widget/environment-widget.component';
 import { EnvironmentWidgetModule } from '../../../dashboard-widgets/environment-widget/environment-widget.module';
@@ -26,6 +27,7 @@ import { AnalyzeOverviewComponent } from './analyze-overview.component';
     ApplicationsWidgetModule,
     FeatureFlagModule,
     FormsModule,
+    EditSpaceDescriptionWidgetOldModule,
     EditSpaceDescriptionWidgetModule,
     AnalyticalReportWidgetModule,
     CreateWorkItemWidgetModule,


### PR DESCRIPTION
…save button

fixes https://github.com/openshiftio/openshift.io/issues/2879 [0]

This PR fixes an issue where trying to update the descriptor text of a Space using the buttons would not work. However, pressing the enter button would properly update the description, (it's just the button that's not working). The result of this was trying to grab the textarea contents outside of the textarea tag would return an undefined value, so `saveDescription()` would be trying to update an undefined value [1]; the enter-keyclick was inside of the textarea tag [2], which is why `onUpdateDescription` would be passed the correct value. 

To amend this, the textarea now binds to a variable in the component which is able to be retrieved by the button. There are also two methods (`onUpdateDescription`[3] and `saveDescription()[1]` which do the same thing, so they have been combined into the later. Additionally, the placeholder text has been moved to a variable as well to reduce duplication. 

[0] https://github.com/openshiftio/openshift.io/issues/2879
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts#L82
[2] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html#L51
[3] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts#L74