### PR TITLE
fix(profile): fix spaces component height to show all spaces

### DIFF
--- a/src/app/profile/overview/spaces/spaces.component.less
+++ b/src/app/profile/overview/spaces/spaces.component.less
@@ -10,7 +10,7 @@
 .margin-top-25 { margin-top: 25px; }
 
 .spaces-list-scroll {
-  max-height: 625px;
+  max-height: inherit;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
This one-line fix adjusts the height of the `spaces-list-scroll` on the profile my spaces widget to match the height of the card it's placed in. Currently, if the user has a large number of spaces then some will be not visible on the widget due to overflowing off the bottom of the visible portion of the widget.

Currently, the max-height value for the `spaces-list-scroll` is 675px, but the max-height of a `f8-card` is 375px [0], and the max-height of a `f8-card-list` is 375px [1]. This fix changes the height of the `spaces-list-scroll` to inherit, so that it can properly fill the space it's put into.

Example: the widget isn't showing all of my pages, and the bottom of the scrollbar isn't visible
![before-overflow](https://user-images.githubusercontent.com/10425301/39312993-db81dcae-493e-11e8-94e7-ed5436f79cfb.png)

With this adjusted max-height value, the list now fits the height of the widget and displays all spaces.
![after-inherit](https://user-images.githubusercontent.com/10425301/39313009-ea968e92-493e-11e8-9668-2feaffe4ccab.png)

[0] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/assets/stylesheets/shared/_cards.less#L17
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/assets/stylesheets/shared/_cards.less#L47