### PR TITLE
feat(deployments): disable "Scale Up" when environment quotas are rea…

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -2,16 +2,16 @@
 </deployments-donut-chart>
 <div column class="deployments-donut-scale-controls fade-inline" *ngIf="!isIdled && !mini">
   <div>
-    <a id="scaleUp" (click)="$event.preventDefault(); scaleUp()" [ngClass]="{ disabled: !scalable }" [attr.title]="!scalable ? undefined : 'Scale up'"
-      [attr.aria-disabled]="!scalable ? 'true' : undefined" role="button">
+    <a id="scaleUp" (click)="$event.preventDefault(); scaleUp()" [ngClass]="{ disabled: atQuota }" [attr.title]="atQuota ? 'You don\'t have enough resources. Scale down the number of pods on another deployment to make resources available.' : 'Scale up'"
+      [attr.aria-disabled]="atQuota ? 'true' : undefined" role="button">
       <i class="fa fa-chevron-up"></i>
       <span class="sr-only">Scale up</span>
     </a>
   </div>
   <div>
     <!-- Remove the title when disabled because the not-allowed styled cursor overlaps the tooltip on some browsers. -->
-    <a id="scaleDown" (click)="$event.preventDefault(); scaleDown()" [ngClass]="{ disabled: !scalable || desiredReplicas === 0 }" [attr.title]="!scalable || desiredReplicas === 0 ? undefined : 'Scale down'"
-      [attr.aria-disabled]="!scalable || desiredReplicas === 0 ? 'true' : undefined" role="button">
+    <a id="scaleDown" (click)="$event.preventDefault(); scaleDown()" [ngClass]="{ disabled: desiredReplicas === 0 }" [attr.title]="desiredReplicas === 0 ? undefined : 'Scale down'"
+      [attr.aria-disabled]="desiredReplicas === 0 ? 'true' : undefined" role="button">
       <i class="fa fa-chevron-down"></i>
       <span class="sr-only">Scale down</span>
     </a>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -2,11 +2,16 @@
 </deployments-donut-chart>
 <div column class="deployments-donut-scale-controls fade-inline" *ngIf="!isIdled && !mini">
   <div>
-    <a id="scaleUp" (click)="$event.preventDefault(); scaleUp()" [ngClass]="{ disabled: atQuota }" [attr.title]="atQuota ? 'You don\'t have enough resources. Scale down the number of pods on another deployment to make resources available.' : 'Scale up'"
-      [attr.aria-disabled]="atQuota ? 'true' : undefined" role="button">
+    <a id="scaleUp" title="Scale up" role="button" (click)="$event.preventDefault(); scaleUp()" *ngIf="!atQuota; else scaleUpDisabled">
       <i class="fa fa-chevron-up"></i>
       <span class="sr-only">Scale up</span>
     </a>
+    <ng-template #scaleUpDisabled>
+      <a class="disabled" title="You don't have enough resources. Scale down the number of pods on another deployment to make resources available." aria-disabled="true" role="button">
+        <i class="fa fa-chevron-up"></i>
+        <span class="sr-only">Scale up</span>
+      </a>
+    </ng-template>
   </div>
   <div>
     <!-- Remove the title when disabled because the not-allowed styled cursor overlaps the tooltip on some browsers. -->


### PR DESCRIPTION
…ched

fixes https://github.com/openshiftio/openshift.io/issues/3345

![screenshot from 2018-04-27 18-15-43](https://user-images.githubusercontent.com/3787464/39387335-077a234e-4a47-11e8-9d0d-37faa93e55cd.png)

This PR also does some cleanup of the component, removing an unused variable (`scalable`) and tracking/unsubscribing Subscriptions. The feature is in the new `atQuota` property and the `combineLatest` Observable in ngOnInit that sets it, along with the template changes to disable the button and change the tooltip text based on `atQuota`.