### PR TITLE
Reenable run_functional_tests in cico build script

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -59,7 +59,7 @@ if [ ! -d dist ]; then
   ./upload_to_codecov.sh
 
   ## Exec functional tests
-  #docker exec "${BUILDER_CONT}" ./run_functional_tests.sh
+  docker exec "${BUILDER_CONT}" ./run_functional_tests.sh
 
   ## Run the prod build
   docker exec "${BUILDER_CONT}" npm run build:prod


### PR DESCRIPTION
This line should be enabled, as it was in the last successful build:
- https://ci.centos.org/view/Devtools/job/devtools-fabric8-ui-npm-publish-build-master/1215/
- https://github.com/fabric8-ui/fabric8-ui/blob/a4e1e0bf091066045bb944eccf9480f4b6f9050e/cico_build_deploy.sh#L47