### PR TITLE
fix(infotip): fix text wrapping and alignment

### DIFF
--- a/src/app/layout/header/header.component.less
+++ b/src/app/layout/header/header.component.less
@@ -62,6 +62,11 @@
     &.bottom-right {
       .arrow { left: 88%; }
     }
+    .list-group {
+      &-item {
+        margin: 0 15px;
+      }
+    }
   }
   .navbar-primary {
     > .active > a {
@@ -165,7 +170,7 @@
     &:before { color: @color-pf-white; }
   }
   .infotip {
-    right: -15px;
+    right: -8px;
   }
   &-status {
     margin-right: 5px;


### PR DESCRIPTION
Fix the text wrapping of "About OpenShift.io" and adjust alignment of the infotip caret.

<img width="285" alt="screen shot 2018-04-29 at 9 53 05 pm" src="https://user-images.githubusercontent.com/4032718/39413402-c222dcb6-4bf7-11e8-9111-9f8a6cc6c080.png">
