### PR TITLE
Continue execution if semantic-release fails

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -65,7 +65,7 @@ if [ ! -d dist ]; then
   docker exec "${BUILDER_CONT}" npm run build:prod
 
   echo 'CICO: functional tests OK'
-  #docker exec "${BUILDER_CONT}" npm run semantic-release
+  docker exec "${BUILDER_CONT}" npm run semantic-release || :
   docker exec -u root "${BUILDER_CONT}" cp -r /home/fabric8/fabric8-ui/dist /
 fi
 


### PR DESCRIPTION
Reenables semantic-release, but it doesn't stop execution if it fails.

This request is explained in this commit:
9d371c96675a61e8bb7feee9557aee969c1caf83