### PR TITLE
fix(a-runtime-console): also check for undefined user values in oauth-config-store

### DIFF
--- a/src/a-runtime-console/kubernetes/store/oauth-config-store.ts
+++ b/src/a-runtime-console/kubernetes/store/oauth-config-store.ts
@@ -141,6 +141,12 @@ export class OAuthConfigStore {
             }
           }
           _latestOAuthConfig = new OAuthConfig(data);
+          /**
+           * openshiftConsoleUrl is set late and another emission occurs
+           * so users who do not need it are not blocked from continuing.
+           * Users who do need it should subscribe and wait for the
+           * emission that contains the property.
+           */
           this.userService.loggedInUser
             .first((user: User) => user.attributes != null && user.attributes.cluster != null)
             .subscribe(

--- a/src/a-runtime-console/kubernetes/store/oauth-config-store.ts
+++ b/src/a-runtime-console/kubernetes/store/oauth-config-store.ts
@@ -142,7 +142,7 @@ export class OAuthConfigStore {
           }
           _latestOAuthConfig = new OAuthConfig(data);
           this.userService.loggedInUser
-            .first((user: User) => user.attributes !== null && user.attributes.cluster !== null)
+            .first((user: User) => user.attributes != null && user.attributes.cluster != null)
             .subscribe(
               (user: User) => {
                 let cluster = user.attributes.cluster;


### PR DESCRIPTION
This addresses the oauth-config-store error reported in https://github.com/openshiftio/openshift.io/issues/3347

The `first()` predicate check now also checks for `undefined` and `null` instead of just `null`.

A test was added, however, in test runs it strangely throws an EmptyError. In actual runs, visiting /openshiftio/openshiftio while not logged in, no error is thrown. Prior to the fix, the test run error would be the stacktrace of 'can't access undefined...' so it's still a valuable test. If anyone has ideas what could be causing the EmptyError, I'd greatly appreciate the input!

