### PR TITLE
fix(launcher): disable submit while processing request

### DIFF
--- a/src/app/space/add-space-overlay/add-space-overlay.component.html
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.html
@@ -70,7 +70,7 @@
       <footer class="container-fluid padding-top-standard-offset padding-bottom-standard-offset">
         <div class="row">
           <div class="col-sm-12 create-launcher-step-tool-bar button-right">
-            <button id="createSpaceButton" class="btn btn-primary" [disabled]="!spaceForm.form.valid" type="submit">Ok</button>
+            <button id="createSpaceButton" class="btn btn-primary" [disabled]="!spaceForm.form.valid || !canSubmit" type="submit">Ok</button>
             <button id="cancelSpaceButton" class="btn btn-link" aria-label="Cancel"
                     (click)="hideAddSpaceOverlay()">Cancel</button>
           </div>

--- a/src/app/space/add-space-overlay/add-space-overlay.component.less
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.less
@@ -8,6 +8,7 @@
   bottom: 0;
   left: 0;
   background-color: rgba(0, 0, 0, .8);
+  overflow-y: auto;
   .create-launcher {
     color: @color-pf-white;
     .alert-danger {

--- a/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
@@ -1,6 +1,7 @@
 import { DebugNode, ErrorHandler } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 
 import { Broadcaster, Logger, Notification, Notifications, NotificationType } from 'ngx-base';
@@ -153,6 +154,25 @@ describe('AddSpaceOverlayComponent', () => {
         .toBeTruthy();
       expect(component.space.relationships['space-template'].data.id)
         .toBe('template-02');
+    });
+
+    it('should disable submit', () => {
+      mockUserService.getUser.and.returnValue(Observable.empty());
+      component.context = {
+        current: Observable.of(mockSpace)
+      };
+      component.ngOnInit();
+
+      const submitBtnEl = fixture.debugElement.query(By.css('button[type=submit]'));
+
+      expect(submitBtnEl.nativeElement.disabled).toBeFalsy();
+      expect(component.canSubmit).toBe(true);
+
+      component.createSpace();
+
+      expect(component.canSubmit).toBe(false);
+      fixture.detectChanges();
+      expect(submitBtnEl.nativeElement.disabled).toBeTruthy();
     });
   });
 

--- a/src/app/space/add-space-overlay/add-space-overlay.component.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.ts
@@ -28,6 +28,7 @@ export class AddSpaceOverlayComponent implements OnInit {
   selectedTemplate: ProcessTemplate = null;
   spaceTemplates: ProcessTemplate[];
   space: Space;
+  canSubmit: Boolean = true;
 
   constructor(private router: Router,
               private spaceService: SpaceService,
@@ -83,6 +84,7 @@ export class AddSpaceOverlayComponent implements OnInit {
         }
       };
     }
+    this.canSubmit = false;
     this.userService.getUser()
       .switchMap(user => {
         this.space.relationships['owned-by'].data.id = user.id;
@@ -105,6 +107,7 @@ export class AddSpaceOverlayComponent implements OnInit {
           this.hideAddSpaceOverlay();
         },
         err => {
+          this.canSubmit = true;
           this.notifications.message(<Notification> {
             message: `Failed to create "${this.space.name}"`,
             type: NotificationType.DANGER


### PR DESCRIPTION
When the user clicks the OK button, a request to save the space is made which is async and therefore allows the user to continuously press the OK button while the request is being processed. Simply disabled the button until the request completes.

Also added `overflow-y: auto` to the dialog as I was unable to scroll vertically in a smaller window while testing.

fixes openshiftio/openshift.io#3198