### PR TITLE
create-work-item-overlay: display work item types without errors

### DIFF
--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-overlay/create-work-item-overlay.component.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-overlay/create-work-item-overlay.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { Observable, Subscription } from 'rxjs';
@@ -19,7 +19,7 @@ import { WorkItemService } from 'fabric8-planner/app/services/work-item.service'
   selector: 'fabric8-create-work-item-overlay',
   templateUrl: './create-work-item-overlay.component.html'
 })
-export class CreateWorkItemOverlayComponent implements OnDestroy, OnInit, AfterViewInit {
+export class CreateWorkItemOverlayComponent implements OnDestroy, OnInit {
   workItemSubscription: Subscription;
   workItemTypes: Observable<any[]>;
   space: Space;
@@ -37,18 +37,13 @@ export class CreateWorkItemOverlayComponent implements OnDestroy, OnInit, AfterV
   }
 
   ngOnInit() {
+    this.overlay.panelState = 'in';
   }
 
   ngOnDestroy(): void {
     if (this.workItemSubscription !== undefined) {
       this.workItemSubscription.unsubscribe();
     }
-  }
-
-  ngAfterViewInit() {
-    setTimeout(() => {
-      this.overlay.open();
-    }, 10);
   }
 
   onClose() {


### PR DESCRIPTION
When clicking the "add work item" icon (top right) of the "My Work Item" card (in the space dashboard), two errors are generated prior to displaying the work item types overlay.

The first error is due to an “Expression has changed” error when the overlay is opened
https://github.com/fabric8-ui/fabric8-planner/issues/2571

The second error is due to an invalid API:
https://api.openshift.io/api/spaces/<id>/workitemtypes

I was able to fix the “Expression has changed” error. And use a different API so that the create-work-item-overlay displays work item types properly. Those changes get us a little further...

Unfortunately, I discovered a second invalid API during testing. When clicking on a work item type, I see a 404 for the following API:
https://api.openshift.io/api/namedspaces/dlabrecq@redhat.com/prod-5/workitems/new?type=26787039-b68f-4e28-8814-c2f93be1ef4e
