### PR TITLE
fix(add-codebase): fix header highlighting when navigating pages with action, and remove add-codebase button from codebases widget

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,7 +11,24 @@ import { SigninComponent } from './signin/signin.component';
 
 
 export function removeAction(url: string) {
-  return trimEnd(url.replace(/\(action:[a-z-]*\)/, ''), '/');
+  const nestedOutletRegex: RegExp = (/^(.*\([A-z-]*?)\/{0,2}action:[A-z-]*\)$/);
+  if (url.indexOf('action:') !== -1) {
+    if (nestedOutletRegex.test(url)) {
+      // if the action outlet contains the current page
+      // e.g., /${user}/${space}/create/(pipelines//action:add-codebase)
+      url = url.match(nestedOutletRegex)[1];
+      let i = url.lastIndexOf('(');
+      url = url.substring(0, i) + url.substring(i + 1);
+      if ((url.lastIndexOf('/') + 1) === url.length) {
+       url = url.slice(0, -1); // trim trailing '/' if applicable
+      }
+    } else {
+      // if the outlet is isolated at the end of the url
+      // e.g., /${user}/${space}/create/(action:add-codebase)
+      url = trimEnd(url.replace(/\(action:[a-z-]*\)/, ''), '/');
+    }
+  }
+  return url;
 }
 
 export const routes: Routes = [

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
@@ -3,7 +3,7 @@
     <div class="card-pf-heading f8-card-heading">
       <f8-feature-toggle featureName="AppLauncher">
         <div class="card-pf-heading-details f8-card-heading-details" default-level>
-          <a id="spacehome-codebases-add-space-button" class="btn btn-link f8-card-heading-btn-link" [routerLink]="[contextPath, 'create', { outlets: { action: 'add-codebase' } }]">
+          <a id="spacehome-codebases-add-space-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
             <i class="pficon pficon-add-circle-o"></i>
           </a>
         </div>
@@ -23,9 +23,6 @@
             <h3>This Space has no Codebases</h3>
             <div class="f8-blank-slate-main-action">
               <button id="spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
-            </div>
-            <div class="f8-blank-slate-main-action">
-              <button id="spacehome-codebases-import-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-codebase' } }]">Import Codebase</button>
             </div>
         </div>
         <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" user-level>
@@ -60,7 +57,7 @@
     <div class="card-pf-heading f8-card-heading">
       <f8-feature-toggle featureName="AppLauncher">
           <div class="card-pf-heading-details f8-card-heading-details" default-level>
-            <a id="spacehome-codebases-add-button" class="btn btn-link f8-card-heading-btn-link" [routerLink]="[contextPath, 'create', { outlets: { action: 'add-codebase' } }]">
+            <a id="spacehome-codebases-add-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
               <i class="pficon pficon-add-circle-o"></i>
             </a>
           </div>
@@ -81,9 +78,6 @@
           <h3>This Space has no Codebases</h3>
           <div class="f8-blank-slate-main-action">
             <button id="spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
-          </div>
-          <div class="f8-blank-slate-main-action">
-            <button id="spacehome-my-codebases-import-button" class="btn btn-primary btn-lg" [routerLink]="[{ outlets: { action: 'add-codebase' } }]">Import Codebase</button>
           </div>
         </div>
         <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" user-level>

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -1,8 +1,9 @@
 import {
   Component,
+  DebugNode,
   NO_ERRORS_SCHEMA
 } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -61,6 +62,8 @@ describe('HeaderComponent', () => {
   mockBroadcaster.broadcast.and.stub();
 
   let testRouter: Router;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let component: DebugNode['componentInstance'];
 
   initContext(HeaderComponent, HostComponent, {
     imports: [
@@ -94,6 +97,8 @@ describe('HeaderComponent', () => {
 
   beforeEach(() => {
     testRouter = TestBed.get(Router);
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.debugElement.componentInstance;
   });
 
   it('should return default context when in _home state', function(this: TestingContext, done: DoneFn) {
@@ -137,4 +142,25 @@ describe('HeaderComponent', () => {
       });
     });
   });
+
+  describe('#formatUrl', () => {
+    it('should remove an action outlet from the end of the url', () => {
+      let url: string = 'create/(action:add-codebase)';
+      let result = component.formatUrl(url);
+      expect(result).toEqual('create');
+    });
+
+    it('should remove an action outlet that contains a nested route', () => {
+      let url: string = 'create/(pipelines//action:add-codebase)';
+      let result = component.formatUrl(url);
+      expect(result).toEqual('create/pipelines');
+    });
+
+    it('should remove a query from the url', () => {
+      let url: string = 'space/plan?q=(space:1234567890)&showTree=true';
+      let result = component.formatUrl(url);
+      expect(result).toEqual('space/plan');
+    });
+  });
+
 });

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -8,6 +8,7 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { Context, Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 
+import { removeAction } from '../../app-routing.module';
 import { FeatureTogglesService } from '../../feature-flag/service/feature-toggles.service';
 
 import { Navigation } from '../../models/navigation';
@@ -196,6 +197,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return (this.router.url.indexOf('applauncher') !== -1);
   }
 
+  formatUrl(url: string) {
+    url = this.stripQueryFromUrl(url);
+    url = removeAction(url);
+    return url;
+  }
+
   private stripQueryFromUrl(url: string) {
     if (url.indexOf('?q=') !== -1) {
       url = url.substring(0, url.indexOf('?q='));
@@ -206,6 +213,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private updateMenus() {
     if (this.context && this.context.type && this.context.type.hasOwnProperty('menus')) {
       let foundPath = false;
+      let url = this.formatUrl(this.router.url);
       let menus = (this.context.type as MenuedContextType).menus;
       for (let n of menus) {
         // Clear the menu's active state
@@ -221,7 +229,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
           for (let o of subMenus) {
             // Clear the menu's active state
             o.active = false;
-            if (!foundPath && o.fullPath === decodeURIComponent(this.router.url)) {
+            if (!foundPath && o.fullPath === decodeURIComponent(url)) {
               foundPath = true;
               o.active = true;
               n.active = true;
@@ -233,7 +241,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
           if (!foundPath) {
             // lets check if the URL matches part of the path
             for (let o of subMenus) {
-              if (!foundPath && decodeURIComponent(this.router.url).startsWith(o.fullPath + '/')) {
+              if (!foundPath && decodeURIComponent(url).startsWith(o.fullPath + '/')) {
                 foundPath = true;
                 o.active = true;
                 n.active = true;
@@ -257,7 +265,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
               }
             }
           }
-        } else if (!foundPath && n.fullPath === this.stripQueryFromUrl(this.router.url)) {
+        } else if (!foundPath && n.fullPath === url) {
           n.active = true;
           foundPath = true;
         }


### PR DESCRIPTION
This PR stems from the discussion of a previous PR regarding the [add-work-items and add-codebases router outlets](https://github.com/fabric8-ui/fabric8-ui/pull/2794) [0].

This PR accomplishes two things:
1. Fixes the header highlighting when navigating between pages with an active 'add-codebase' router action [1]
    - This can currently only occur in feature-level == production because any feature-level above and the slider is replaced with the newer overlay
    - If the slider is open on the codebases page and the user switches to the pipelines page, the header doesn't update to display the pipelines page as the active page
![header-highlight-bug](https://user-images.githubusercontent.com/10425301/39592291-531b45ee-4ed4-11e8-9b6c-9e94656049ea.gif)

2. Removes the Import Codebases button from the codebases widget [2][3]
    - The import codebases button is displayed only in feature-level == production, and can cause a 404 if navigating to a different page while the action is active
![404](https://user-images.githubusercontent.com/10425301/39592303-5bd97bba-4ed4-11e8-8abf-0d812263b811.gif)
    - The import codebases button is hidden in feature-levels > production .. but has a noticeable delay when doing so; so it looks cleaner if the button is removed outright
![button-disappears](https://user-images.githubusercontent.com/10425301/39597003-14b42f74-4ee2-11e8-8e4f-8b9a84c8709e.gif)


[0] https://github.com/fabric8-ui/fabric8-ui/pull/2794
[1] https://github.com/fabric8-ui/fabric8-ui/pull/2794#issuecomment-386005710
[2] https://github.com/openshiftio/openshift.io/issues/3021#issuecomment-383697074
[3] https://github.com/openshiftio/openshift.io/issues/3021#issuecomment-383741730