### PR TITLE
fix(deployments): rename applications to deployments in header

### DIFF
--- a/src/app/space/create/deployments/apps/deployments-apps.component.html
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.html
@@ -6,7 +6,7 @@
     <div class="row row-cards-pf">
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h3>
-          <b>Applications</b>
+          <b>Deployments</b>
         </h3>
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">


### PR DESCRIPTION
This fixes https://github.com/openshiftio/openshift.io/issues/3460

It dawned on me in the design [1], the header is Deployments, not Applications.

[1] https://redhat.invisionapp.com/share/YSDL0KRKW#/screens/260764292