### PR TITLE
fix(add-space-overlay): fix option font colour

### DIFF
--- a/src/app/space/add-space-overlay/add-space-overlay.component.less
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.less
@@ -45,6 +45,9 @@
         border-radius: 0;
         font-size: 1.2em;
         color: @color-pf-white;
+        option {
+          color: @color-pf-black;
+        }
         &:focus {
           border-bottom-color: @color-pf-blue;
           box-shadow: none;


### PR DESCRIPTION
addresses https://github.com/openshiftio/openshift.io/issues/3341

This small stylesheet fix changes the font colour of the option dropdown in the add-space-overlay. 

Currently in Chrome (on Windows & Fedora) the select dropdown displays white text on a white background, which makes it impossible to read the non-highlighted options.

Here, the option text will be coloured black, and will show up on the white background.

Before:
![chrome-before](https://user-images.githubusercontent.com/10425301/39721483-b34b338e-520d-11e8-8809-1a37a35a035f.png)

After:
![chrome-after](https://user-images.githubusercontent.com/10425301/39721426-8f0422c4-520d-11e8-9611-1c438b25f7e7.png)
