### PR TITLE
fix(space): do not show errors on form touch

### DIFF
--- a/src/app/space/add-space-overlay/add-space-overlay.component.html
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.html
@@ -21,7 +21,7 @@
                 <div class="form-group">
                   <label for="name" class="control-label">Space Name</label>
                   <input id="name" name="name" type="text" class="form-control" placeholder="Enter a unique name for your space" [(ngModel)]="space.name" #name="ngModel" required uniqueSpaceName validSpaceName/>
-                  <div *ngIf="name.errors && (name.dirty || name.touched)" class="alert-danger">
+                  <div *ngIf="name.errors && name.dirty" class="alert-danger">
                     <div [hidden]="!name.errors.required">
                       Space Name is required to create a Space.
                     </div>


### PR DESCRIPTION
fixes openshiftio/openshift.io#3196

Changed the form to not show errors when simply touching the name field and moving away. This allows for clicking into the field, or tabbing in, and then moving away without causing the error to appear. Only once the user actually makes a change to the field will errors show up.

![space-name](https://user-images.githubusercontent.com/14068621/39771678-07ff99a2-52c1-11e8-880e-db828ea88cf4.gif)
