### PR TITLE
fix(pipeline): Promote pipeline button calls jenkins proxy

### DIFF
--- a/src/a-runtime-console/kubernetes/ui/pipeline/input-action-dialog/input-action-dialog.component.ts
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/input-action-dialog/input-action-dialog.component.ts
@@ -1,13 +1,10 @@
-import { Component, Inject, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { Headers, Http, RequestOptions } from '@angular/http';
 import { AuthenticationService } from 'ngx-login-client';
-
-import { FABRIC8_FORGE_API_URL } from 'app/shared/runtime-console/fabric8-ui-forge-api';
-
-import { OnLogin } from '../../../../shared/onlogin.service';
 import { Build, PendingInputAction } from '../../../model/build.model';
 import { PipelineStage } from '../../../model/pipelinestage.model';
 import { pathJoin } from '../../../model/utils';
+
 
 @Component({
   selector: 'input-action-dialog',
@@ -22,8 +19,7 @@ export class InputActionDialog {
   @ViewChild('inputModal') modal: any;
 
   constructor(private http: Http,
-              private authService: AuthenticationService,
-              @Inject(FABRIC8_FORGE_API_URL) private forgeApiUrl: string
+              private authService: AuthenticationService
   ) {
   }
 
@@ -52,31 +48,29 @@ export class InputActionDialog {
       if (url.startsWith('//')) {
         url = url.substring(1);
       }
+      let jenkinsUrl = this.build.jenkinsBuildURL;
+      // Remove /job from jenkinsBuildURL if exists
+      let idx = jenkinsUrl.indexOf("/job/");
+      if (idx > -1) {
+        jenkinsUrl = jenkinsUrl.substring(0, idx);
+      }
       // lets replace URL which doesn't seem to work right ;)
       const postfix = '/wfapi/inputSubmit?inputId=Proceed';
       if (url.endsWith(postfix)) {
         url = url.substring(0, url.length - postfix.length) + '/input/Proceed/proceedEmpty';
       }
-
-      let jenkinsNamespace = this.build.jenkinsNamespace;
-      let forgeUrl = this.forgeApiUrl;
-      if (!forgeUrl) {
-        console.log('Warning no $FABRIC8_FORGE_API_URL environment variable!');
-      } else if (!jenkinsNamespace) {
-        console.log('Warning no jenkinsNamespace on the Build!');
-      } else {
-        url = pathJoin(forgeUrl, '/api/openshift/services/jenkins/', jenkinsNamespace, url);
-        let token = this.authService.getToken();
-        console.log('about to invoke ' + url);
+      url = pathJoin(jenkinsUrl, url);
+      this.authService.getOpenShiftToken().subscribe(token => {
         let options = new RequestOptions();
         let headers = new Headers();
         headers.set('Authorization', 'Bearer ' + token);
+        headers.set('Content-Type', 'text/plain');
         options.headers = headers;
         let body = null;
         this.http.post(url, body, options).subscribe(res => {
           console.log('posting to url: ' + url + ' and returned response ' + res.status);
         });
-      }
+      });
     }
     this.close();
   }


### PR DESCRIPTION
The pipeline button no longer calls the launcher-backend directly.

Fixes https://github.com/openshiftio/openshift.io/issues/2093

Signed-off-by: George Gastaldi <gegastaldi@gmail.com>