### PR TITLE
update chat text to match landing page

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -173,7 +173,7 @@
               </li>
               <li id="header_loggedinChat">
                 <a href="https://chat.openshift.io/developers/channels/town-square" target="top" class="pointer">
-                  Chat
+                  Chat with us
                 </a>
               </li>
               <li class="divider"></li>


### PR DESCRIPTION
Update the text in the user dropdown from 'Chat' to 'Chat with us' in order to match the landing page button.

![screen shot 2018-05-14 at 3 21 15 pm](https://user-images.githubusercontent.com/4032718/40018578-a2ce18d2-578a-11e8-8741-21deab1552ac.png)

related to https://github.com/openshiftio/openshift.io/issues/3327