### PR TITLE
fix(deployments): reappearing deployments continue updates

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -147,6 +147,8 @@ export class DeploymentDetailsComponent {
   private memChart: Subject<ChartAPI> = new ReplaySubject<ChartAPI>();
   private netChart: Subject<ChartAPI> = new ReplaySubject<ChartAPI>();
 
+  private static NO_CHART: ChartAPI = null;
+
   constructor(
     private deploymentsService: DeploymentsService,
     private deploymentStatusService: DeploymentStatusService,
@@ -163,9 +165,9 @@ export class DeploymentDetailsComponent {
     this.subscriptions.push(
       this.hasPods.subscribe((hasPods: boolean): void => {
         if (!hasPods) {
-          this.cpuChart.next(null);
-          this.memChart.next(null);
-          this.netChart.next(null);
+          this.cpuChart.next(DeploymentDetailsComponent.NO_CHART);
+          this.memChart.next(DeploymentDetailsComponent.NO_CHART);
+          this.netChart.next(DeploymentDetailsComponent.NO_CHART);
         }
       })
     );
@@ -185,10 +187,10 @@ export class DeploymentDetailsComponent {
 
     this.subscriptions.push(
       this.cpuChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, Status]> => {
-        if (chart) {
-          return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getCpuStatus(this.spaceId, this.environment, this.applicationId));
+        if (chart === DeploymentDetailsComponent.NO_CHART) {
+          return Observable.empty();
         }
-        return Observable.empty();
+        return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getCpuStatus(this.spaceId, this.environment, this.applicationId));
       })
         .subscribe((v: [ChartAPI, Status]): void => {
           const chart: ChartAPI = v[0];
@@ -214,10 +216,10 @@ export class DeploymentDetailsComponent {
 
     this.subscriptions.push(
       this.memChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, Status]> => {
-        if (chart) {
-          return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getMemoryStatus(this.spaceId, this.environment, this.applicationId));
+        if (chart === DeploymentDetailsComponent.NO_CHART) {
+          return Observable.empty();
         }
-        return Observable.empty();
+        return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getMemoryStatus(this.spaceId, this.environment, this.applicationId));
       })
         .subscribe((v: [ChartAPI, Status]): void => {
           const chart: ChartAPI = v[0];
@@ -249,13 +251,10 @@ export class DeploymentDetailsComponent {
 
     this.subscriptions.push(
       this.cpuChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, CpuStat[]]> => {
-        if (chart) {
-          return Observable.combineLatest(
-            Observable.of(chart),
-            this.cpuStat
-          );
+        if (chart === DeploymentDetailsComponent.NO_CHART) {
+          return Observable.empty();
         }
-        return Observable.empty();
+        return Observable.combineLatest(Observable.of(chart), this.cpuStat);
       })
         .subscribe((v: [ChartAPI, CpuStat[]]): void => {
           const chart: ChartAPI = v[0];
@@ -273,13 +272,10 @@ export class DeploymentDetailsComponent {
 
     this.subscriptions.push(
       this.memChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, MemoryStat[]]> => {
-        if (chart) {
-          return Observable.combineLatest(
-            Observable.of(chart),
-            this.memStat
-          );
+        if (chart === DeploymentDetailsComponent.NO_CHART) {
+          return Observable.empty();
         }
-        return Observable.empty();
+        return Observable.combineLatest(Observable.of(chart), this.memStat);
       })
         .subscribe((v: [ChartAPI, MemoryStat[]]): void => {
           const chart: ChartAPI = v[0];
@@ -298,13 +294,13 @@ export class DeploymentDetailsComponent {
 
     this.subscriptions.push(
       this.memChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, NetworkStat[]]> => {
-        if (chart) {
-          return Observable.combineLatest(
-            Observable.of(chart),
-            this.deploymentsService.getDeploymentNetworkStat(this.spaceId, this.environment, this.applicationId)
-          );
+        if (chart === DeploymentDetailsComponent.NO_CHART) {
+          return Observable.empty();
         }
-        return Observable.empty();
+        return Observable.combineLatest(
+          Observable.of(chart),
+          this.deploymentsService.getDeploymentNetworkStat(this.spaceId, this.environment, this.applicationId)
+        );
       })
         .subscribe((v: [ChartAPI, NetworkStat[]]): void => {
           const chart: ChartAPI = v[0];
@@ -331,7 +327,7 @@ export class DeploymentDetailsComponent {
       this.netChart
     ).first().subscribe((charts: ChartAPI[]): void =>
       charts.forEach((chart: ChartAPI): void => {
-        if (chart) {
+        if (chart !== DeploymentDetailsComponent.NO_CHART) {
           chart.destroy();
         }
       })

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -143,13 +143,9 @@ export class DeploymentDetailsComponent {
   cpuChartClass: string;
   memChartClass: string;
 
-  private cpuChart: ChartAPI;
-  private memChart: ChartAPI;
-  private netChart: ChartAPI;
-
-  private cpuChartLoad: Subject<void> = new ReplaySubject<void>();
-  private memChartLoad: Subject<void> = new ReplaySubject<void>();
-  private netChartLoad: Subject<void> = new ReplaySubject<void>();
+  private cpuChart: Subject<ChartAPI> = new ReplaySubject<ChartAPI>();
+  private memChart: Subject<ChartAPI> = new ReplaySubject<ChartAPI>();
+  private netChart: Subject<ChartAPI> = new ReplaySubject<ChartAPI>();
 
   constructor(
     private deploymentsService: DeploymentsService,
@@ -162,6 +158,16 @@ export class DeploymentDetailsComponent {
       this.deploymentsService.getPods(this.spaceId, this.environment, this.applicationId)
         .map((p: Pods) => p.total > 0)
         .subscribe(this.hasPods)
+    );
+
+    this.subscriptions.push(
+      this.hasPods.subscribe((hasPods: boolean): void => {
+        if (!hasPods) {
+          this.cpuChart.next(null);
+          this.memChart.next(null);
+          this.netChart.next(null);
+        }
+      })
     );
 
     this.subscriptions.push(
@@ -178,9 +184,15 @@ export class DeploymentDetailsComponent {
     );
 
     this.subscriptions.push(
-      this.deploymentStatusService.getCpuStatus(this.spaceId, this.environment, this.applicationId)
-        .skipUntil(this.cpuChartLoad)
-        .subscribe((status: Status): void => {
+      this.cpuChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, Status]> => {
+        if (chart) {
+          return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getCpuStatus(this.spaceId, this.environment, this.applicationId));
+        }
+        return Observable.empty();
+      })
+        .subscribe((v: [ChartAPI, Status]): void => {
+          const chart: ChartAPI = v[0];
+          const status: Status = v[1];
           let color: string;
           if (status.type === StatusType.OK) {
             this.cpuChartClass = '';
@@ -195,15 +207,21 @@ export class DeploymentDetailsComponent {
             this.cpuLabelClass = LabelClass.ERR;
             color = '#cc0000'; // pf-red-100
           }
-          this.cpuChart.data.colors({ CPU: color });
-          this.cpuChart.flush();
+          chart.data.colors({ CPU: color });
+          chart.flush();
         })
     );
 
     this.subscriptions.push(
-      this.deploymentStatusService.getMemoryStatus(this.spaceId, this.environment, this.applicationId)
-        .skipUntil(this.memChartLoad)
-        .subscribe((status: Status): void => {
+      this.memChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, Status]> => {
+        if (chart) {
+          return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getMemoryStatus(this.spaceId, this.environment, this.applicationId));
+        }
+        return Observable.empty();
+      })
+        .subscribe((v: [ChartAPI, Status]): void => {
+          const chart: ChartAPI = v[0];
+          const status: Status = v[1];
           let color: string;
           if (status.type === StatusType.OK) {
             this.memChartClass = '';
@@ -218,8 +236,8 @@ export class DeploymentDetailsComponent {
             this.memLabelClass = LabelClass.ERR;
             color = '#cc0000'; // pf-red-100
           }
-          this.memChart.data.colors({ Memory: color });
-          this.memChart.flush();
+          chart.data.colors({ Memory: color });
+          chart.flush();
         })
     );
 
@@ -230,24 +248,42 @@ export class DeploymentDetailsComponent {
       this.deploymentsService.getDeploymentMemoryStat(this.spaceId, this.environment, this.applicationId);
 
     this.subscriptions.push(
-      this.cpuStat
-        .skipUntil(this.cpuChartLoad)
-        .subscribe((stats: CpuStat[]) => {
+      this.cpuChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, CpuStat[]]> => {
+        if (chart) {
+          return Observable.combineLatest(
+            Observable.of(chart),
+            this.cpuStat
+          );
+        }
+        return Observable.empty();
+      })
+        .subscribe((v: [ChartAPI, CpuStat[]]): void => {
+          const chart: ChartAPI = v[0];
+          const stats: CpuStat[] = v[1];
           const last: CpuStat = stats[stats.length - 1];
           this.cpuVal = last.used;
           this.cpuMax = last.quota;
           this.cpuData.total = last.quota;
           this.cpuData.xData = [this.cpuData.xData[0], ...stats.map((stat: CpuStat) => stat.timestamp)];
           this.cpuData.yData = [this.cpuData.yData[0], ...stats.map((stat: CpuStat) => stat.used)];
-          this.cpuChart.axis.max({ y: this.getChartYAxisMax(stats) });
-          this.cpuChart.flush();
+          chart.axis.max({ y: this.getChartYAxisMax(stats) });
+          chart.flush();
         })
     );
 
     this.subscriptions.push(
-      this.memStat
-        .skipUntil(this.memChartLoad)
-        .subscribe((stats: MemoryStat[]) => {
+      this.memChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, MemoryStat[]]> => {
+        if (chart) {
+          return Observable.combineLatest(
+            Observable.of(chart),
+            this.memStat
+          );
+        }
+        return Observable.empty();
+      })
+        .subscribe((v: [ChartAPI, MemoryStat[]]): void => {
+          const chart: ChartAPI = v[0];
+          const stats: MemoryStat[] = v[1];
           const last: MemoryStat = stats[stats.length - 1];
           this.memVal = last.used;
           this.memMax = last.quota;
@@ -255,15 +291,24 @@ export class DeploymentDetailsComponent {
           this.memUnits = last.units;
           this.memData.xData = [this.memData.xData[0], ...stats.map((stat: MemoryStat) => stat.timestamp)];
           this.memData.yData = [this.memData.yData[0], ...stats.map((stat: MemoryStat) => stat.used)];
-          this.memChart.axis.max({ y: this.getChartYAxisMax(stats) });
-          this.memChart.flush();
+          chart.axis.max({ y: this.getChartYAxisMax(stats) });
+          chart.flush();
         })
     );
 
     this.subscriptions.push(
-      this.deploymentsService.getDeploymentNetworkStat(this.spaceId, this.environment, this.applicationId)
-        .skipUntil(this.netChartLoad)
-        .subscribe((stats: NetworkStat[]) => {
+      this.memChart.switchMap((chart: ChartAPI): Observable<[ChartAPI, NetworkStat[]]> => {
+        if (chart) {
+          return Observable.combineLatest(
+            Observable.of(chart),
+            this.deploymentsService.getDeploymentNetworkStat(this.spaceId, this.environment, this.applicationId)
+          );
+        }
+        return Observable.empty();
+      })
+        .subscribe((v: [ChartAPI, NetworkStat[]]): void => {
+          const chart: ChartAPI = v[0];
+          const stats: NetworkStat[] = v[1];
           const last: NetworkStat = stats[stats.length - 1];
           this.netUnits = fromOrdinal(Math.max(ordinal(last.sent.units), ordinal(last.received.units)));
           this.netConfig.units = this.netUnits;
@@ -272,41 +317,37 @@ export class DeploymentDetailsComponent {
           this.netData.xData = [this.netData.xData[0], ...stats.map((stat: NetworkStat) => stat.received.timestamp)];
           this.netData.yData[0] = [this.netData.yData[0][0], ...stats.map((stat: NetworkStat) => round(stat.sent.used, decimals))];
           this.netData.yData[1] = [this.netData.yData[1][0], ...stats.map((stat: NetworkStat) => round(stat.received.used, decimals))];
-          this.netChart.flush();
+          chart.flush();
         })
     );
   }
 
   ngOnDestroy(): void {
-    this.subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
+    this.subscriptions.forEach((sub: Subscription): void => sub.unsubscribe());
 
-    if (this.cpuChart) {
-      this.cpuChart.destroy();
-    }
-    if (this.memChart) {
-      this.memChart.destroy();
-    }
-    if (this.netChart) {
-      this.netChart.destroy();
-    }
+    Observable.combineLatest(
+      this.cpuChart,
+      this.memChart,
+      this.netChart
+    ).first().subscribe((charts: ChartAPI[]): void =>
+      charts.forEach((chart: ChartAPI): void => {
+        if (chart) {
+          chart.destroy();
+        }
+      })
+    );
   }
 
   cpuChartLoaded(cpuChart: ChartAPI): void {
-    this.cpuChart = cpuChart;
-    this.cpuChartLoad.next();
-    this.cpuChartLoad.complete();
+    this.cpuChart.next(cpuChart);
   }
 
   memChartLoaded(memChart: ChartAPI): void {
-    this.memChart = memChart;
-    this.memChartLoad.next();
-    this.memChartLoad.complete();
+    this.memChart.next(memChart);
   }
 
   netChartLoaded(netChart: ChartAPI): void {
-    this.netChart = netChart;
-    this.netChartLoad.next();
-    this.netChartLoad.complete();
+    this.netChart.next(netChart);
   }
 
   private getTooltipContents(): any {

--- a/src/app/space/create/deployments/deployments.module.ts
+++ b/src/app/space/create/deployments/deployments.module.ts
@@ -74,7 +74,7 @@ const DEPLOYMENTS_SERVICE_POLL_TIMER = Observable
     BsDropdownConfig,
     DeploymentApiService,
     { provide: TIMER_TOKEN, useValue: DEPLOYMENTS_SERVICE_POLL_TIMER },
-    { provide: TIMESERIES_SAMPLES_TOKEN, useValue: 15 }
+    { provide: TIMESERIES_SAMPLES_TOKEN, useValue: DeploymentsService.FRONT_LOAD_SAMPLES }
   ]
 })
 export class DeploymentsModule {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -36,7 +36,10 @@ import { MemoryUnit } from '../models/memory-unit';
 import { NetworkStat } from '../models/network-stat';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 import { ScaledNetStat } from '../models/scaled-net-stat';
-import { DeploymentApiService } from './deployment-api.service';
+import {
+  Application,
+  DeploymentApiService
+} from './deployment-api.service';
 import {
   DeploymentsService,
   TIMER_TOKEN,
@@ -2500,6 +2503,268 @@ describe('DeploymentsService', () => {
         expected: 'http://example.com/application',
         observable: svc.getAppUrl('foo-space', 'foo-env', 'foo-app'),
         done: done
+      });
+    });
+  });
+
+});
+
+describe('DeploymentsService with mock DeploymentApiService', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DeploymentApiService,
+          useFactory: (): jasmine.SpyObj<DeploymentApiService> => createMock(DeploymentApiService)
+        },
+        { provide: Logger, useValue: createMock(Logger) },
+        { provide: ErrorHandler, useValue: createMock(ErrorHandler) },
+        { provide: NotificationsService, useValue: jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']) },
+        { provide: TIMER_TOKEN, useValue: new Subject<void>() },
+        { provide: TIMESERIES_SAMPLES_TOKEN, useValue: 3 },
+        DeploymentsService
+      ]
+    });
+  });
+
+  describe('getDeploymentCpuStat', () => {
+    it('should return data', (done: DoneFn): void => {
+      const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
+      apiSvc.getApplications.and.returnValue(Observable.of([
+        {
+          attributes: {
+            name: 'foo-app',
+            deployments: [
+              {
+                attributes: {
+                  name: 'foo-env',
+                  pods: [['Running', '1']],
+                  pod_total: 1,
+                  pods_quota: {
+                    cpucores: 3,
+                    memory: 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]));
+      apiSvc.getTimeseriesData.and.returnValue(Observable.of({
+        cores: [
+          { value: 1, time: 1 },
+          { value: 2, time: 2 }
+        ],
+        memory: [
+          { value: 3, time: 3 },
+          { value: 4, time: 4 }
+        ],
+        net_rx: [
+          { value: 5, time: 5 },
+          { value: 6, time: 6 }
+        ],
+        net_tx: [
+          { value: 7, time: 7 },
+          { value: 8, time: 8 }
+        ],
+        start: 1,
+        end: 8
+      }));
+      apiSvc.getLatestTimeseriesData.and.returnValue(Observable.of({
+        cores: {
+          time: 9, value: 9
+        },
+        memory: {
+          time: 10, value: 10
+        },
+        net_tx: {
+          time: 11, value: 11
+        },
+        net_rx: {
+          time: 12, value: 12
+        }
+      }));
+
+      const svc: DeploymentsService = TestBed.get(DeploymentsService);
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe((stats: CpuStat[]): void => {
+        expect(stats).toEqual([
+          { used: 1, quota: 3, timestamp: 1 },
+          { used: 2, quota: 3, timestamp: 2 },
+          { used: 9, quota: 3, timestamp: 9 }
+        ]);
+        done();
+      });
+      TestBed.get(TIMER_TOKEN).next();
+      TestBed.get(TIMER_TOKEN).next();
+    });
+
+    it('should return nothing when application is not deployed in environment', (done: DoneFn): void => {
+      const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
+      apiSvc.getApplications.and.returnValue(Observable.of([
+        {
+          attributes: {
+            name: 'foo-app',
+            deployments: [
+              {
+                attributes: {
+                  name: 'bar-env',
+                  pods: [['Running', '1']],
+                  pod_total: 1,
+                  pods_quota: {
+                    cpucores: 3,
+                    memory: 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]));
+
+      const svc: DeploymentsService = TestBed.get(DeploymentsService);
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').subscribe((stats: CpuStat[]): void => {
+        done.fail('should not have emitted');
+      });
+      TestBed.get(TIMER_TOKEN).next();
+      TestBed.get(TIMER_TOKEN).next();
+
+      Observable.timer(500).first().subscribe(() => done());
+    });
+
+    it('should return nothing when application has no pods', (done: DoneFn): void => {
+      const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
+      apiSvc.getApplications.and.returnValue(Observable.of([
+        {
+          attributes: {
+            name: 'foo-app',
+            deployments: [
+              {
+                attributes: {
+                  name: 'foo-env',
+                  pods: [],
+                  pod_total: 0,
+                  pods_quota: {
+                    cpucores: 3,
+                    memory: 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]));
+
+      const svc: DeploymentsService = TestBed.get(DeploymentsService);
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').subscribe((stats: CpuStat[]): void => {
+        done.fail('should not have emitted');
+      });
+      TestBed.get(TIMER_TOKEN).next();
+      TestBed.get(TIMER_TOKEN).next();
+
+      Observable.timer(500).first().subscribe(() => done());
+    });
+
+    it('should emit updates when deployment reappears', (done: DoneFn): void => {
+      const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
+      apiSvc.getApplications.and.returnValue(Observable.of([
+        {
+          attributes: {
+            name: 'foo-app',
+            deployments: [
+              {
+                attributes: {
+                  name: 'foo-env',
+                  pods: [],
+                  pod_total: 0,
+                  pods_quota: {
+                    cpucores: 1,
+                    memory: 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]));
+      apiSvc.getLatestTimeseriesData.and.returnValue(Observable.of({
+        cores: {
+          time: 9, value: 9
+        },
+        memory: {
+          time: 10, value: 10
+        },
+        net_tx: {
+          time: 11, value: 11
+        },
+        net_rx: {
+          time: 12, value: 12
+        }
+      }));
+      apiSvc.getTimeseriesData.and.returnValue(Observable.of({
+        cores: [
+          { value: 1, time: 1 },
+          { value: 2, time: 2 }
+        ],
+        memory: [
+          { value: 3, time: 3 },
+          { value: 4, time: 4 }
+        ],
+        net_rx: [
+          { value: 5, time: 5 },
+          { value: 6, time: 6 }
+        ],
+        net_tx: [
+          { value: 7, time: 7 },
+          { value: 8, time: 8 }
+        ],
+        start: 1,
+        end: 8
+      }));
+
+      let delayPassed: boolean = false;
+
+      const svc: DeploymentsService = TestBed.get(DeploymentsService);
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe((stats: CpuStat[]): void => {
+        if (!delayPassed) {
+          done.fail('should not have emitted before delay passed');
+        }
+        expect(stats).toEqual([
+          { used: 1, quota: 2, timestamp: 1 },
+          { used: 2, quota: 2, timestamp: 2 },
+          { used: 9, quota: 2, timestamp: 9 }
+        ]);
+        done();
+      });
+      TestBed.get(TIMER_TOKEN).next();
+      TestBed.get(TIMER_TOKEN).next();
+
+      Observable.timer(500).first().subscribe(() => {
+        delayPassed = true;
+
+        apiSvc.getApplications.and.returnValue(Observable.of([
+          {
+            attributes: {
+              name: 'foo-app',
+              deployments: [
+                {
+                  attributes: {
+                    name: 'foo-env',
+                    pods: [['Running', '1']],
+                    pod_total: 1,
+                    pods_quota: {
+                      cpucores: 2,
+                      memory: 2
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]));
+
+        TestBed.get(TIMER_TOKEN).next();
+        TestBed.get(TIMER_TOKEN).next();
       });
     });
   });

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -1123,6 +1123,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 3,
                           memory: 3
@@ -1230,6 +1232,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 3,
                           memory: 3
@@ -1337,6 +1341,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env+',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 3,
                           memory: 3
@@ -1446,6 +1452,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 3,
                           memory: 3
@@ -1553,6 +1561,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 0,
                           memory: 512 * Math.pow(1024, 2)
@@ -1672,6 +1682,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env+',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 3,
                           memory: 3
@@ -1781,7 +1793,9 @@ describe('DeploymentsService', () => {
                   deployments: [
                     {
                       attributes: {
-                        name: 'foo-env'
+                        name: 'foo-env',
+                        pods: [['Running', '1']],
+                        pod_total: 1
                       }
                     }
                   ]
@@ -1884,6 +1898,8 @@ describe('DeploymentsService', () => {
                     {
                       attributes: {
                         name: 'foo-env',
+                        pods: [['Running', '1']],
+                        pod_total: 1,
                         pods_quota: {
                           cpucores: 0,
                           memory: 0
@@ -2000,7 +2016,8 @@ describe('DeploymentsService', () => {
                         name: 'foo-env',
                         pods_quota: {
                           cpucores: 3
-                        }
+                        },
+                        pods: [['Running', '1']]
                       }
                     }
                   ]

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -335,7 +335,7 @@ export class DeploymentsService implements OnDestroy {
     return Observable.combineLatest(
       this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId),
       this.getPods(spaceId, environmentName, applicationId).map((p: Pods): number => p.total),
-      this.pollTimer
+      this.pollTimer.startWith(null)
     )
       .startWith([false, 0, null])
       .pairwise()

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -97,7 +97,7 @@ export class DeploymentsService implements OnDestroy {
   }
 
   getEnvironments(spaceId: string): Observable<string[]> {
-    // Note: Sorting and filtering out test should ideally be moved to the backend
+    // Note: Sorting and filtering out "test" should ideally be moved to the backend
     return this.getEnvironmentsResponse(spaceId)
       .map((envs: EnvironmentStat[]) => envs || [])
       .map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => env.attributes))
@@ -308,100 +308,86 @@ export class DeploymentsService implements OnDestroy {
   }
 
   private getTimeseriesData(spaceId: string, environmentName: string, applicationId: string, maxSamples: number): Observable<TimeseriesData[]> {
-    return this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId)
-      .first()
-      .flatMap((deployed: boolean) => {
-        if (!deployed) {
-          return Observable.never();
+    const key = `${spaceId}:${applicationId}:${environmentName}`;
+    if (!this.timeseriesSubjects.has(key)) {
+      const subject = new ReplaySubject<TimeseriesData[]>(this.timeseriesSamples);
+
+      const now = +Date.now();
+      const seriesData = this.getStreamingTimeseriesData(spaceId, environmentName, applicationId, now - DeploymentsService.FRONT_LOAD_WINDOW_WIDTH, now)
+        .finally(() => {
+          this.timeseriesSubjects.delete(key);
+        })
+        .bufferCount(this.timeseriesSamples, 1);
+
+      this.serviceSubscriptions.push(seriesData.subscribe(subject));
+      this.timeseriesSubjects.set(key, subject);
+    }
+    return this.timeseriesSubjects.get(key)
+      .map((data: TimeseriesData[]) => {
+        if (maxSamples >= data.length) {
+          return data;
         }
-        const key = `${spaceId}:${applicationId}:${environmentName}`;
-        if (!this.timeseriesSubjects.has(key)) {
-          const subject = new ReplaySubject<TimeseriesData[]>(this.timeseriesSamples);
+        return data.slice(data.length - maxSamples);
+      });
+  }
 
-          const now = +Date.now();
-          const frontLoadedUpdates = this.getInitialTimeseriesData(spaceId, environmentName, applicationId, now - DeploymentsService.FRONT_LOAD_WINDOW_WIDTH, now);
+  private getStreamingTimeseriesData(spaceId: string, environmentName: string, applicationId: string, startTime: number, endTime: number): Observable<TimeseriesData> {
+    return Observable.combineLatest(
+      this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId),
+      this.getPods(spaceId, environmentName, applicationId).map((p: Pods): number => p.total),
+      this.pollTimer
+    )
+      .startWith([false, 0, null])
+      .pairwise()
+      .concatMap((status: [[boolean, number, void], [boolean, number, void]]): Observable<TimeseriesData> => {
+        const prev: [boolean, number, void] = status[0];
+        const curr: [boolean, number, void] = status[1];
 
-          const polledUpdates = this.getStreamingTimeseriesData(spaceId, environmentName, applicationId);
+        const isDeployed: boolean = curr[0] && curr[1] > 0;
+        const wasDeployed: boolean = prev[0] && prev[1] > 0;
 
-          const seriesData = Observable.concat(frontLoadedUpdates, polledUpdates)
-            .finally(() => {
-              this.timeseriesSubjects.delete(key);
-            })
-            .bufferCount(this.timeseriesSamples, 1);
-          this.serviceSubscriptions.push(seriesData.subscribe(subject));
-          this.timeseriesSubjects.set(key, subject);
+        if (!isDeployed) {
+          return Observable.empty();
         }
-        return this.timeseriesSubjects.get(key)
-          .map((data: TimeseriesData[]) => {
-            if (maxSamples >= data.length) {
-              return data;
-            }
-            return data.slice(data.length - maxSamples);
-          });
+
+        if (!wasDeployed) {
+          return this.getInitialTimeseriesData(spaceId, environmentName, applicationId, startTime, endTime);
+        } else {
+          return this.apiService.getLatestTimeseriesData(spaceId, environmentName, applicationId)
+            .catch((err: Response) => this.handleHttpError(err))
+            .filter((t: TimeseriesData) => !!t && !isEmpty(t));
+        }
       });
   }
 
   private getInitialTimeseriesData(spaceId: string, environmentName: string,  applicationId: string, startTime: number, endTime: number): Observable<TimeseriesData> {
-    return this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId)
-      .first()
-      .flatMap((deployed: boolean) => {
-        if (!deployed) {
-          return Observable.empty();
-        }
-        return this.apiService.getTimeseriesData(spaceId, environmentName, applicationId, startTime, endTime)
-          .catch((err: Response) => this.handleHttpError(err))
-          .filter((t: MultiTimeseriesData) => !!t && !isEmpty(t))
-          .concatMap((t: MultiTimeseriesData) => {
-            const results: TimeseriesData[] = [];
-            const numSamples = t.cores.length;
-            for (let i = 0; i < numSamples; i++) {
-              results.push({
-                cores: {
-                  time: t.cores[i].time,
-                  value: t.cores[i].value
-                },
-                memory: {
-                  time: t.memory[i].time,
-                  value: t.memory[i].value
-                },
-                net_tx: {
-                  time: t.net_tx[i].time,
-                  value: t.net_tx[i].value
-                },
-                net_rx: {
-                  time: t.net_rx[i].time,
-                  value: t.net_rx[i].value
-                }
-              });
+    return this.apiService.getTimeseriesData(spaceId, environmentName, applicationId, startTime, endTime)
+      .catch((err: Response) => this.handleHttpError(err))
+      .filter((t: MultiTimeseriesData) => !!t && !isEmpty(t))
+      .concatMap((t: MultiTimeseriesData) => {
+        const results: TimeseriesData[] = [];
+        const numSamples = t.cores.length;
+        for (let i = 0; i < numSamples; i++) {
+          results.push({
+            cores: {
+              time: t.cores[i].time,
+              value: t.cores[i].value
+            },
+            memory: {
+              time: t.memory[i].time,
+              value: t.memory[i].value
+            },
+            net_tx: {
+              time: t.net_tx[i].time,
+              value: t.net_tx[i].value
+            },
+            net_rx: {
+              time: t.net_rx[i].time,
+              value: t.net_rx[i].value
             }
-            return Observable.from(results);
           });
-      }
-      );
-  }
-
-  private getStreamingTimeseriesData(spaceId: string, environmentName: string, applicationId: string): Observable<TimeseriesData> {
-    return this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId)
-      .first()
-      .flatMap((deployed: boolean) => {
-        if (!deployed) {
-          return Observable.empty();
         }
-        /* piggyback on getApplicationsResponse rather than pollTimer directly in order to
-        * establish a happens-before relationship between applications updates and timeseries
-        * updates within each poll cycle, so that we can detect a deployment disappearing and
-        * cancel upcoming timeseries queries
-        */
-        return this.getApplicationsResponse(spaceId)
-          .takeUntil(
-            this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId)
-              .filter((deployed: boolean): boolean => !deployed)
-          )
-          .concatMap(() =>
-            this.apiService.getLatestTimeseriesData(spaceId, environmentName, applicationId)
-              .catch((err: Response) => this.handleHttpError(err))
-              .filter((t: TimeseriesData) => !!t && !isEmpty(t))
-          );
+        return Observable.from(results);
       });
   }
 


### PR DESCRIPTION
This PR modifies the DeploymentsService timeseries Observables' logic so that deployments which "reappear", ex. gaining a deployment in a new environment (promotion to "run") or scaling up from 0 pods, receive timeseries stats updates for CPU, Memory, and Network usage. Prior to these patches there is a bug where the timeseries stats will never be updated in these situations, as documented [here](https://github.com/openshiftio/openshift.io/issues/3454).

This PR also includes a patch to ensure that the correct chart component object is updated when these events occur, otherwise it is possible for the first such updated series may set appearance properties on an outdated and invalid chart object.