### PR TITLE
fix(linting): fix pipelines component less indentation

### DIFF
--- a/src/app/space/create/pipelines/pipelines.component.less
+++ b/src/app/space/create/pipelines/pipelines.component.less
@@ -19,18 +19,18 @@
 }
 
 .feature-anchor {
-    border-color: transparent;
-    border-style: solid;
-    border-width: 1px 0;
-    color: #363636;
-    display: block;
-    padding: 1px 10px;
-    white-space: nowrap;
-    &:hover,
-    &:focus {
-      background-color: #def3ff;
-      border-color: #bee1f4;
-      color: #4d5258;
-      text-decoration: none;
-    }
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px 0;
+  color: #363636;
+  display: block;
+  padding: 1px 10px;
+  white-space: nowrap;
+  &:hover,
+  &:focus {
+    background-color: #def3ff;
+    border-color: #bee1f4;
+    color: #4d5258;
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
This short PR addresses some warnings from the linter that were a result of using 4 spaces instead of 2 spaces in `pipelines.component.less` during a recent commit [0].

![linting warnings](https://user-images.githubusercontent.com/10425301/40126464-64609ce2-58fb-11e8-8ed4-7703669019b8.png)

[0] https://github.com/fabric8-ui/fabric8-ui/commit/8d84c75ff96ead2d5f544887ef7164c02a0ff66c#diff-69a04fcac923bf32cf38f013802660fe