### PR TITLE
fix(settings): do not allow deselection of feature levels

### DIFF
--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.html
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.html
@@ -22,78 +22,17 @@
         </ng-template>
 
         <ng-template #untoggledTemplate let-item="item" let-index="index">
-          <div *ngIf="item.name === 'released'">
-            <div class="col-sm-5">
-              <h1 class="feature-details-title">
-                There are currently {{item.features.length}} {{item.name}} features
-              </h1>
-              <div class="feature-details-description">
-                These features have been just been released and are part of the product release.
-              </div>
-            </div>
-            <div class="col-xs-12 col-sm-7">
-              <div class="feature-details-description">
-                <ul>
-                  <li *ngFor="let feature of item.features"><strong>{{feature?.attributes?.name}}</strong>: {{feature?.attributes?.description}}.</li>
-                </ul>
-              </div>
-            </div>
+          <div class="col-sm-5">
+            <h1 class="feature-details-title">
+              There are currently {{item.features.length}} {{item.name}} features
+            </h1>
+            <div class="feature-details-description" [innerHTML]="item.detailDescription"></div>
           </div>
-
-          <div *ngIf="item.name === 'beta'">
-            <div class="col-sm-5">
-              <h1 class="feature-details-title">
-                There are currently {{item.features.length}} {{item.name}} features
-              </h1>
-              <div class="feature-details-description">
-                These features are currently in beta testing and have no guarantee of performance or stability.<br/>
-                Use these at your own risk.
-              </div>
-            </div>
-            <div class="col-xs-12 col-sm-7">
-              <div class="feature-details-description">
-                <ul>
-                  <li *ngFor="let feature of item.features"><strong>{{feature?.attributes?.name}}</strong>: {{feature?.attributes?.description}}.</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          <div *ngIf="item.name === 'experimental'">
-            <div class="col-sm-5">
-              <h1 class="feature-details-title">
-                There are currently {{item.features.length}} {{item.name}} features
-              </h1>
-              <div class="feature-details-description">
-                These features are currently in experimental testing and have no guarantee of performance or stability.<br/>
-                Use these at your own risk.
-              </div>
-            </div>
-            <div class="col-xs-12 col-sm-7">
-              <div class="feature-details-description">
-                <ul>
-                  <li *ngFor="let feature of item.features"><strong>{{feature?.attributes?.name}}</strong>: {{feature?.attributes?.description}}.</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          <div *ngIf="item.name === 'internal'">
-            <div class="col-sm-5">
-              <h1 class="feature-details-title">
-                There are currently {{item.features.length}} {{item.name}} features
-              </h1>
-              <div class="feature-details-description">
-                These features are currently in internal testing and have no guarantee of performance or stability.<br/>
-                Use these at your own risk.
-              </div>
-            </div>
-            <div class="col-xs-12 col-sm-7">
-              <div class="feature-details-description">
-                <ul>
-                  <li *ngFor="let feature of item.features"><strong>{{feature?.attributes?.name}}</strong>: {{feature?.attributes?.description}}.</li>
-                </ul>
-              </div>
+          <div class="col-xs-12 col-sm-7">
+            <div class="feature-details-description">
+              <ul>
+                <li *ngFor="let feature of item.features"><strong>{{feature?.attributes?.name}}</strong>: {{feature?.attributes?.description}}.</li>
+              </ul>
             </div>
           </div>
         </ng-template>

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.spec.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.spec.ts
@@ -9,49 +9,16 @@ import { Observable } from 'rxjs';
 import { createMock } from 'testing/mock';
 import { initContext, TestContext } from 'testing/test-context';
 import { Feature, FeatureTogglesService } from '../../../feature-flag/service/feature-toggles.service';
-import {
-  ExtProfile,
-  GettingStartedService
-} from '../../../getting-started/services/getting-started.service';
+import { ExtProfile, GettingStartedService } from '../../../getting-started/services/getting-started.service';
 import { FeatureOptInComponent } from './feature-opt-in.component';
 
 @Component({
   template: `<alm-feature-opt-in></alm-feature-opt-in>`
 })
-class HostComponent {
-  collapsed: boolean = false;
-  applicationId: string = 'mockAppId';
-  environment: string = 'mockEnvironment';
-  spaceId: string = 'mockSpaceId';
-  detailsActive: boolean = true;
-}
+class HostComponent {}
 
 describe('FeatureOptInComponent', () => {
   type Context = TestContext<FeatureOptInComponent, HostComponent>;
-
-  let featureOptInComponent: FeatureOptInComponent;
-  let gettingStartedServiceMock: jasmine.SpyObj<GettingStartedService>;
-  let notificationsMock: jasmine.SpyObj<Notifications>;
-  let userServiceMock: jasmine.SpyObj<UserService>;
-  let toggleServiceMock: jasmine.SpyObj<FeatureTogglesService>;
-
-  beforeEach(() => {
-    gettingStartedServiceMock = createMock(GettingStartedService);
-    toggleServiceMock = createMock(FeatureTogglesService);
-    notificationsMock = createMock(Notifications);
-    userServiceMock = createMock(UserService);
-    (userServiceMock as any).currentLoggedInUser = {
-      attributes: {
-        featureLevel: 'beta',
-        email: 'somebody@email.com',
-        emailVerified: true
-      }
-    };
-    toggleServiceMock.getAllFeaturesEnabledByLevel.and.returnValue(Observable.of([]));
-    gettingStartedServiceMock.createTransientProfile.and.returnValue({ featureLevel: 'beta' } as ExtProfile);
-    gettingStartedServiceMock.update.and.returnValue(Observable.of({}));
-    notificationsMock.message.and.returnValue(Observable.of({}));
-  });
 
   initContext(FeatureOptInComponent, HostComponent, {
     imports: [
@@ -60,14 +27,37 @@ describe('FeatureOptInComponent', () => {
       ListModule
     ],
     providers: [
-      { provide: GettingStartedService, useFactory: () => gettingStartedServiceMock },
-      { provide: Notifications, useFactory: () => notificationsMock },
-      { provide: UserService, useFactory: () => userServiceMock },
-      { provide: FeatureTogglesService, useFactory: () => toggleServiceMock }
+      { provide: GettingStartedService, useFactory: (): jasmine.SpyObj<GettingStartedService> => {
+        const mock: jasmine.SpyObj<GettingStartedService> = createMock(GettingStartedService);
+        mock.createTransientProfile.and.returnValue({ featureLevel: 'beta' } as ExtProfile);
+        mock.update.and.returnValue(Observable.of({}));
+        return mock;
+      }},
+      { provide: Notifications, useFactory: (): jasmine.SpyObj<Notifications> => {
+        const mock: jasmine.SpyObj<Notifications> = createMock(Notifications);
+        mock.message.and.returnValue(Observable.of({}));
+        return mock;
+      }},
+      { provide: UserService, useFactory: (): jasmine.SpyObj<UserService> => {
+        const mock: jasmine.SpyObj<UserService> = createMock(UserService);
+        (mock as any).currentLoggedInUser = {
+          attributes: {
+            featureLevel: 'beta',
+            email: 'somebody@email.com',
+            emailVerified: true
+          }
+        };
+        return mock;
+      }},
+      { provide: FeatureTogglesService, useFactory: (): jasmine.SpyObj<FeatureTogglesService> => {
+        const mock: jasmine.SpyObj<FeatureTogglesService> = createMock(FeatureTogglesService);
+        mock.getAllFeaturesEnabledByLevel.and.returnValue(Observable.of([]));
+        return mock;
+      }}
     ]
   });
 
-  it('should sort feature per level', function(this: TestContext<FeatureOptInComponent, HostComponent>) {
+  it('should sort feature per level', function(this: Context) {
     const features = [   {
       'attributes': {
         'description': 'main dashboard view',
@@ -105,7 +95,7 @@ describe('FeatureOptInComponent', () => {
   });
 
   describe('updateProfile', () => {
-    it('should call GettingStartedService#update and send a notification', function(this: TestContext<FeatureOptInComponent, HostComponent>) {
+    it('should call GettingStartedService#update and send a notification', function(this: Context) {
       const gettingStartedService: jasmine.SpyObj<GettingStartedService> = TestBed.get(GettingStartedService);
       const notifications: jasmine.SpyObj<Notifications> = TestBed.get(Notifications);
 
@@ -117,7 +107,7 @@ describe('FeatureOptInComponent', () => {
       expect(notifications.message).toHaveBeenCalled();
     });
 
-    it('should update the feature level', function(this: TestContext<FeatureOptInComponent, HostComponent>) {
+    it('should update the feature level', function(this: Context) {
       const gettingStartedService: jasmine.SpyObj<GettingStartedService> = TestBed.get(GettingStartedService);
       const notifications: jasmine.SpyObj<Notifications> = TestBed.get(Notifications);
 
@@ -135,7 +125,7 @@ describe('FeatureOptInComponent', () => {
       }));
     });
 
-    it('should cancel events deselecting a feature level', function(this: TestContext<FeatureOptInComponent, HostComponent>) {
+    it('should cancel events deselecting a feature level', function(this: Context) {
       const gettingStartedService: jasmine.SpyObj<GettingStartedService> = TestBed.get(GettingStartedService);
       const notifications: jasmine.SpyObj<Notifications> = TestBed.get(Notifications);
 

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { Notification, Notifications, NotificationType } from 'ngx-base';
 import { UserService } from 'ngx-login-client';
-import { ListConfig } from 'patternfly-ng';
+import { ListComponent, ListConfig } from 'patternfly-ng';
 import { Subscription } from 'rxjs';
 import { Feature, FeatureTogglesService } from '../../../feature-flag/service/feature-toggles.service';
 import { ExtProfile, GettingStartedService } from '../../../getting-started/services/getting-started.service';
@@ -15,11 +15,12 @@ import { Fabric8UIConfig } from '../shared/config/fabric8-ui-config';
 })
 export class FeatureOptInComponent implements OnInit, OnDestroy {
 
+  @ViewChild(ListComponent) listComponent: ListComponent;
+
   public featureLevel: string;
   private subscriptions: Subscription[] = [];
   listConfig: ListConfig;
   private items;
-
 
   constructor(
     private gettingStartedService: GettingStartedService,
@@ -39,6 +40,12 @@ export class FeatureOptInComponent implements OnInit, OnDestroy {
   }
 
   updateProfile(event): void {
+    if (event.selectedItems.length === 0) {
+      // Do not allow item deselection events - one item should always be selected. If a
+      // deselection occurs, re-select the item and ignore the event.
+      this.listComponent.selectItem(event.item, true);
+      return;
+    }
     this.featureLevel = event.item.name;
     let profile = this.getTransientProfile();
     this.subscriptions.push(this.gettingStartedService.update(profile).subscribe(user => {


### PR DESCRIPTION
The first commit in this PR addresses https://github.com/openshiftio/openshift.io/issues/3590 , blocking events that deselect feature levels from the Settings > Feature Opt-In component, adds a test for this behaviour, and does some slight test restructuring. The second commit cleans up the spec file further. The third cleans up a bunch of boilerplate from the template.