### PR TITLE
Hide buttons from add-codebase-widget when in a foreign user space. 

### DIFF
--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
@@ -3,14 +3,18 @@
     <div class="card-pf-heading f8-card-heading">
       <f8-feature-toggle featureName="AppLauncher">
         <div class="card-pf-heading-details f8-card-heading-details" default-level>
-          <a id="spacehome-codebases-add-space-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-            <i class="pficon pficon-add-circle-o"></i>
-          </a>
-        </div>
-        <div class="card-pf-heading-details f8-card-heading-details" user-level>
+          <div *ngIf="userOwnsSpace">
             <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-                <i class="pficon pficon-add-circle-o"></i>
+              <i id="default-level-add-to-space-btn" class="pficon pficon-add-circle-o"></i>
             </a>
+          </div>
+          <div class="card-pf-heading-details f8-card-heading-details" user-level>
+            <div *ngIf="userOwnsSpace">
+              <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
+                <i id="user-level-add-to-space-btn" class="pficon pficon-add-circle-o"></i>
+              </a>
+            </div>
+          </div>
         </div>
       </f8-feature-toggle>
       <h2 class="card-pf-title">
@@ -20,16 +24,20 @@
     <div class="card-pf-body f8-card-body">
       <f8-feature-toggle featureName="AppLauncher">
         <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" default-level>
-            <h3>This Space has no Codebases</h3>
-            <div class="f8-blank-slate-main-action">
-              <button id="spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+          <h3>This Space has no Codebases</h3>
+          <div class="f8-blank-slate-main-action">
+            <div *ngIf="userOwnsSpace">
+              <button id="default-level-spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
             </div>
+          </div>
         </div>
         <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" user-level>
-            <h3>This Space has no Codebases</h3>
-            <div class="f8-blank-slate-main-action">
-              <button class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+          <h3>This Space has no Codebases</h3>
+          <div class="f8-blank-slate-main-action">
+            <div *ngIf="userOwnsSpace">
+              <button id="user-level-spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
             </div>
+          </div>
         </div>
       </f8-feature-toggle>
       <div id="spacehome-codebases-card-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
@@ -44,7 +52,8 @@
                   <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url truncate">{{codebase.name}}</a>
                 </div>
                 <div class="list-group-item-text f8-card-list-group-item-text">
-                  codebase last updated 03/12/2018 <!-- replace with real code -->
+                  codebase last updated 03/12/2018
+                  <!-- replace with real code -->
                 </div>
               </div>
             </div>
@@ -56,17 +65,22 @@
   <div id="spacehome-codebases-card" class="add-codebase-widget card-pf f8-card" default-level>
     <div class="card-pf-heading f8-card-heading">
       <f8-feature-toggle featureName="AppLauncher">
-          <div class="card-pf-heading-details f8-card-heading-details" default-level>
+        <div class="card-pf-heading-details f8-card-heading-details" default-level>
+          <div *ngIf="userOwnsSpace">
+
             <a id="spacehome-codebases-add-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
               <i class="pficon pficon-add-circle-o"></i>
             </a>
           </div>
-          <div class="card-pf-heading-details f8-card-heading-details" user-level>
-              <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-                  <i class="pficon pficon-add-circle-o"></i>
-              </a>
-            </div>
-          </f8-feature-toggle>
+        </div>
+        <div class="card-pf-heading-details f8-card-heading-details" user-level>
+          <div *ngIf="userOwnsSpace">
+            <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
+              <i class="pficon pficon-add-circle-o"></i>
+            </a>
+          </div>
+        </div>
+      </f8-feature-toggle>
       <h2 class="card-pf-title">
         <a id="spacehome-codebases-title" href="#" [routerLink]="[contextPath, 'create']">Codebases</a>
         <span id="spacehome-codebases-badge" class="badge f8-card-badge">{{codebases.length}}</span>
@@ -77,13 +91,17 @@
         <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" default-level>
           <h3>This Space has no Codebases</h3>
           <div class="f8-blank-slate-main-action">
-            <button id="spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+            <div *ngIf="userOwnsSpace">
+              <button id="default-level-spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+            </div>
           </div>
         </div>
         <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" user-level>
           <h3>This Space has no Codebases</h3>
           <div class="f8-blank-slate-main-action">
-            <button class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+            <div *ngIf="userOwnsSpace">
+              <button id="user-level-spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+            </div>
           </div>
         </div>
       </f8-feature-toggle>

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.html
@@ -1,59 +1,41 @@
 <f8-feature-toggle featureName="Analyze.newSpaceDashboard">
-  <div id="spacehome-codebases" class="add-codebase-widget card-pf f8-card" user-level>
-    <div class="card-pf-heading f8-card-heading">
-      <f8-feature-toggle featureName="AppLauncher">
-        <div class="card-pf-heading-details f8-card-heading-details" default-level>
+    <div id="spacehome-codebases" class="add-codebase-widget card-pf f8-card" user-level>
+      <div class="card-pf-heading f8-card-heading">
+        <div class="card-pf-heading-details f8-card-heading-details">
           <div *ngIf="userOwnsSpace">
             <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-              <i id="default-level-add-to-space-btn" class="pficon pficon-add-circle-o"></i>
+              <i id="test-add-codebase-circle-button" class="pficon pficon-add-circle-o"></i>
             </a>
           </div>
-          <div class="card-pf-heading-details f8-card-heading-details" user-level>
-            <div *ngIf="userOwnsSpace">
-              <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-                <i id="user-level-add-to-space-btn" class="pficon pficon-add-circle-o"></i>
-              </a>
-            </div>
-          </div>
         </div>
-      </f8-feature-toggle>
-      <h2 class="card-pf-title">
-        <span id="spacehome-codebases-card-title">Codebases</span>
-      </h2>
-    </div>
-    <div class="card-pf-body f8-card-body">
-      <f8-feature-toggle featureName="AppLauncher">
-        <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" default-level>
+        <h2 class="card-pf-title">
+          <span id="spacehome-codebases-card-title">Codebases</span>
+        </h2>
+      </div>
+      <div class="card-pf-body f8-card-body">
+        <div class="f8-blank-slate-card" *ngIf="codebases.length === 0">
           <h3>This Space has no Codebases</h3>
           <div class="f8-blank-slate-main-action">
             <div *ngIf="userOwnsSpace">
-              <button id="default-level-spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+              <button id="test-add-codebase-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
             </div>
           </div>
         </div>
-        <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" user-level>
-          <h3>This Space has no Codebases</h3>
-          <div class="f8-blank-slate-main-action">
-            <div *ngIf="userOwnsSpace">
-              <button id="user-level-spacehome-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+        <div id="spacehome-codebases-card-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
+          <div class="list-group-item list-view-pf-stacked list-view-pf-top-align" *ngFor="let codebase of codebases">
+            <div class="list-view-pf-checkbox f8-card-list-view-pf-checkbox-icon">
+              <span class="avatar fa" [ngClass]="{'fa-github fa-2x': codebase.attributes.type === 'git'}"></span>
             </div>
-          </div>
-        </div>
-      </f8-feature-toggle>
-      <div id="spacehome-codebases-card-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
-        <div class="list-group-item list-view-pf-stacked list-view-pf-top-align" *ngFor="let codebase of codebases">
-          <div class="list-view-pf-checkbox f8-card-list-view-pf-checkbox-icon">
-            <span class="avatar fa" [ngClass]="{'fa-github fa-2x': codebase.attributes.type === 'git'}"></span>
-          </div>
-          <div class="list-view-pf-main-info f8-card-list-view-pf-main-info">
-            <div class="list-view-pf-body">
-              <div class="list-view-pf-description">
-                <div class="list-group-item-heading f8-card-list-group-item-heading">
-                  <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url truncate">{{codebase.name}}</a>
-                </div>
-                <div class="list-group-item-text f8-card-list-group-item-text">
-                  codebase last updated 03/12/2018
-                  <!-- replace with real code -->
+            <div class="list-view-pf-main-info f8-card-list-view-pf-main-info">
+              <div class="list-view-pf-body">
+                <div class="list-view-pf-description">
+                  <div class="list-group-item-heading f8-card-list-group-item-heading">
+                    <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url truncate">{{codebase.name}}</a>
+                  </div>
+                  <div class="list-group-item-text f8-card-list-group-item-text">
+                    codebase last updated 03/12/2018
+                    <!-- replace with real code -->
+                  </div>
                 </div>
               </div>
             </div>
@@ -61,64 +43,43 @@
         </div>
       </div>
     </div>
-  </div>
-  <div id="spacehome-codebases-card" class="add-codebase-widget card-pf f8-card" default-level>
-    <div class="card-pf-heading f8-card-heading">
-      <f8-feature-toggle featureName="AppLauncher">
+    <div id="spacehome-codebases-card" class="add-codebase-widget card-pf f8-card" default-level>
+      <div class="card-pf-heading f8-card-heading">
         <div class="card-pf-heading-details f8-card-heading-details" default-level>
           <div *ngIf="userOwnsSpace">
-
-            <a id="spacehome-codebases-add-button" class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-              <i class="pficon pficon-add-circle-o"></i>
-            </a>
-          </div>
-        </div>
-        <div class="card-pf-heading-details f8-card-heading-details" user-level>
-          <div *ngIf="userOwnsSpace">
             <a class="btn btn-link f8-card-heading-btn-link" (click)="addToSpace.emit()">
-              <i class="pficon pficon-add-circle-o"></i>
+              <i id="spacehome-codebases-add-button" class="pficon pficon-add-circle-o"></i>
             </a>
           </div>
         </div>
-      </f8-feature-toggle>
-      <h2 class="card-pf-title">
-        <a id="spacehome-codebases-title" href="#" [routerLink]="[contextPath, 'create']">Codebases</a>
-        <span id="spacehome-codebases-badge" class="badge f8-card-badge">{{codebases.length}}</span>
-      </h2>
-    </div>
-    <div class="card-pf-body f8-card-body">
-      <f8-feature-toggle featureName="AppLauncher">
-        <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" default-level>
+        <h2 class="card-pf-title">
+          <a id="spacehome-codebases-title" href="#" [routerLink]="[contextPath, 'create']">Codebases</a>
+          <span id="spacehome-codebases-badge" class="badge f8-card-badge">{{codebases.length}}</span>
+        </h2>
+      </div>
+      <div class="card-pf-body f8-card-body">
+        <div class="f8-blank-slate-card" *ngIf="codebases.length === 0">
           <h3>This Space has no Codebases</h3>
           <div class="f8-blank-slate-main-action">
             <div *ngIf="userOwnsSpace">
-              <button id="default-level-spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
+              <button id="spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
             </div>
           </div>
         </div>
-        <div class="f8-blank-slate-card" *ngIf="codebases.length === 0" user-level>
-          <h3>This Space has no Codebases</h3>
-          <div class="f8-blank-slate-main-action">
-            <div *ngIf="userOwnsSpace">
-              <button id="user-level-spacehome-my-codebases-create-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Add Codebase</button>
-            </div>
-          </div>
-        </div>
-      </f8-feature-toggle>
-      <ul id="spacehome-codebases-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
-        <li class="list-group-item" *ngFor="let codebase of codebases">
-          <div class="list-view-pf-main-info">
-            <div class="list-view-pf-body">
-              <div class="list-view-pf-description">
-                <div class="list-group-item-text">
-                  <span class="avatar fa" [ngClass]="{'fa-github': codebase.attributes.type === 'git'}"></span>
-                  <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url truncate">{{codebase.name}}</a>
+        <ul id="spacehome-codebases-list" class="list-group list-view-pf list-view-pf-view list-view-pf-striped" *ngIf="codebases.length > 0">
+          <li class="list-group-item" *ngFor="let codebase of codebases">
+            <div class="list-view-pf-main-info">
+              <div class="list-view-pf-body">
+                <div class="list-view-pf-description">
+                  <div class="list-group-item-text">
+                    <span class="avatar fa" [ngClass]="{'fa-github': codebase.attributes.type === 'git'}"></span>
+                    <a href="{{codebase.attributes.url}}" target="_blank" class="f8-card-codebase-url truncate">{{codebase.name}}</a>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </li>
-      </ul>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-</f8-feature-toggle>
+  </f8-feature-toggle>

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.spec.ts
@@ -14,6 +14,7 @@ import {
   Contexts
 } from 'ngx-fabric8-wit';
 
+import { By } from '@angular/platform-browser';
 import { Codebase } from '../../space/create/codebases/services/codebase';
 import { CodebasesService } from '../../space/create/codebases/services/codebases.service';
 import { AddCodebaseWidgetComponent } from './add-codebase-widget.component';
@@ -89,6 +90,30 @@ describe('AddCodebaseWidgetComponent', () => {
 
   it('should listen for codebaseDeleted events', function(this: TestingContext) {
     expect(mockBroadcaster.on).toHaveBeenCalledWith('codebaseDeleted');
+  });
+
+  it('should enable buttons if the user owns the space', function(this: TestingContext) {
+    this.testedDirective.userOwnsSpace = true;
+    this.detectChanges();
+
+    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-my-codebases-create-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-my-codebases-create-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-codebases-create-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-codebases-create-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#default-level-add-to-space-btn'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#user-level-add-to-space-btn'))).not.toBeNull();
+  });
+
+  it('should disable buttons if the user does not own the space', function(this: TestingContext) {
+    this.testedDirective.userOwnsSpace = false;
+    this.detectChanges();
+
+    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-my-codebases-create-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-my-codebases-create-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-codebases-create-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-codebases-create-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#default-level-add-to-space-btn'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#user-level-add-to-space-btn'))).toBeNull();
   });
 
   it('should listen for context space changes', function(this: TestingContext) {

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.spec.ts
@@ -1,3 +1,5 @@
+
+
 import {
   Component,
   NO_ERRORS_SCHEMA
@@ -96,24 +98,20 @@ describe('AddCodebaseWidgetComponent', () => {
     this.testedDirective.userOwnsSpace = true;
     this.detectChanges();
 
-    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-my-codebases-create-button'))).not.toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-my-codebases-create-button'))).not.toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-codebases-create-button'))).not.toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-codebases-create-button'))).not.toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#default-level-add-to-space-btn'))).not.toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#user-level-add-to-space-btn'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#test-add-codebase-circle-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#test-add-codebase-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#spacehome-codebases-add-button'))).not.toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#spacehome-my-codebases-create-button'))).not.toBeNull();
   });
 
   it('should disable buttons if the user does not own the space', function(this: TestingContext) {
     this.testedDirective.userOwnsSpace = false;
     this.detectChanges();
 
-    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-my-codebases-create-button'))).toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-my-codebases-create-button'))).toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#default-level-spacehome-codebases-create-button'))).toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#user-level-spacehome-codebases-create-button'))).toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#default-level-add-to-space-btn'))).toBeNull();
-    expect(this.fixture.debugElement.query(By.css('#user-level-add-to-space-btn'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#test-add-codebase-circle-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#test-add-codebase-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#spacehome-codebases-add-button'))).toBeNull();
+    expect(this.fixture.debugElement.query(By.css('#spacehome-my-codebases-create-button'))).toBeNull();
   });
 
   it('should listen for context space changes', function(this: TestingContext) {

--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.ts
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   EventEmitter,
+  Input,
   OnDestroy,
   OnInit,
   Output,
@@ -30,6 +31,8 @@ export class AddCodebaseWidgetComponent implements OnInit, OnDestroy {
   context: Context;
   contextPath: string;
   subscriptions: Subscription[] = [];
+
+  @Input() userOwnsSpace: boolean;
   @Output() addToSpace = new EventEmitter();
 
   constructor(

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -62,8 +62,8 @@
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-md-4">
           <f8-feature-toggle featureName="AppLauncher">
-            <fabric8-add-codebase-widget (addToSpace)="openForgeWizard(addSpace)" default-level></fabric8-add-codebase-widget>
-            <fabric8-add-codebase-widget (addToSpace)="showAddAppOverlay()" user-level></fabric8-add-codebase-widget>
+            <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace()" (addToSpace)="openForgeWizard(addSpace)" default-level></fabric8-add-codebase-widget>
+            <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace()"  (addToSpace)="showAddAppOverlay()" user-level></fabric8-add-codebase-widget>
           </f8-feature-toggle>
         </div>
         <div class="col-xs-12 col-md-8">


### PR DESCRIPTION
As a follow up to #2898, this patch both hides undesirable functionality from the add-codebase-widget and removes the now outdated app launcher feature flag from its HTML structure. 

Here's a screenshot : 
_In my space_
![2018-05-22-113717_1918x951_scrot](https://user-images.githubusercontent.com/17230733/40373362-bdb1990a-5db4-11e8-9193-005b66023c09.png)

_In a foreign user space_
![2018-05-22-113812_1919x991_scrot](https://user-images.githubusercontent.com/17230733/40373373-c14ad9d2-5db4-11e8-878a-0df8a54d6d4f.png)
