### PR TITLE
fix(space-creation): fixes errors after space creation and logout

### DIFF
--- a/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
@@ -123,8 +123,7 @@ describe('AddSpaceOverlayComponent', () => {
     mockSpaceService.create.and.returnValue(Observable.of(mockSpace));
     mockSpacesService.addRecent.and.returnValue(mockSubject);
     mockSpacesService.addRecent.next = {};
-    mockUserService.currentLoggedInUser = { 'id': 'mock-user' };
-    mockUserService.loggedInUser = Observable.of(mockUser);
+    mockUserService.currentLoggedInUser = mockUser;
 
     TestBed.configureTestingModule({
       imports: [FormsModule],
@@ -159,7 +158,7 @@ describe('AddSpaceOverlayComponent', () => {
     });
 
     it('should disable submit', () => {
-      mockUserService.loggedInUser = Observable.empty();
+      mockUserService.currentLoggedInUser = {};
       component.context = {
         current: Observable.of(mockSpace)
       };

--- a/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
@@ -29,7 +29,7 @@ describe('AddSpaceOverlayComponent', () => {
   };
   let mockSpaceService: any = jasmine.createSpyObj('SpaceService', ['create']);
   let mockNotifications: any = jasmine.createSpyObj('Notifications', ['message']);
-  let mockUserService: any = jasmine.createSpyObj('UserService', ['getUser']);
+  let mockUserService: any = jasmine.createSpy('UserService');
   let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
   let mockSpaceNamePipe: any = jasmine.createSpy('SpaceNamePipe');
   let mockSpacesService: any = jasmine.createSpyObj('SpacesService', ['addRecent']);
@@ -117,15 +117,15 @@ describe('AddSpaceOverlayComponent', () => {
     type: NotificationType.DANGER
   };
 
-  mockElementRef.nativeElement.value = {};
-  mockSpaceNamespaceService.updateConfigMap = {};
-  mockSpaceService.create.and.returnValue(Observable.of(mockSpace));
-  mockSpacesService.addRecent.and.returnValue(mockSubject);
-  mockSpacesService.addRecent.next = {};
-  mockUserService.currentLoggedInUser = { 'id': 'mock-user' };
-  mockUserService.getUser.and.returnValue(Observable.of(mockUser));
-
   beforeEach(() => {
+    mockElementRef.nativeElement.value = {};
+    mockSpaceNamespaceService.updateConfigMap = {};
+    mockSpaceService.create.and.returnValue(Observable.of(mockSpace));
+    mockSpacesService.addRecent.and.returnValue(mockSubject);
+    mockSpacesService.addRecent.next = {};
+    mockUserService.currentLoggedInUser = { 'id': 'mock-user' };
+    mockUserService.loggedInUser = Observable.of(mockUser);
+
     TestBed.configureTestingModule({
       imports: [FormsModule],
       declarations: [AddSpaceOverlayComponent],
@@ -159,7 +159,7 @@ describe('AddSpaceOverlayComponent', () => {
     });
 
     it('should disable submit', () => {
-      mockUserService.getUser.and.returnValue(Observable.empty());
+      mockUserService.loggedInUser = Observable.empty();
       component.context = {
         current: Observable.of(mockSpace)
       };


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3481
Fixes https://github.com/fabric8-services/fabric8-auth/issues/499

This patch fixes errors after creating a space and logging out immediately.

- createSpace() was subscribing to userService.getUser() and then calling spaceService.create() inside it which resulted in an error if user logs out.
- Added loggedInUser var for storing user context in the constructor of the component.