### PR TITLE
fix(my-spaces): enable new Space overlay

### DIFF
--- a/src/app/profile/my-spaces/my-spaces.component.html
+++ b/src/app/profile/my-spaces/my-spaces.component.html
@@ -1,16 +1,10 @@
 <div class="my-spaces-page">
-  <f8-feature-toggle featureName="AppLauncher">
-    <my-spaces-toolbar default-level
-        (onCreateSpace)="openForgeWizard(createSpace)"
-        (onFilterChange)="filterChange($event)"
-        (onSortChange)="sortChange($event)"
-        [resultsCount]="resultsCount"></my-spaces-toolbar>
-    <my-spaces-toolbar user-level
-        (onCreateSpace)="showAddSpaceOverlay()"
-        (onFilterChange)="filterChange($event)"
-        (onSortChange)="sortChange($event)"
-        [resultsCount]="resultsCount"></my-spaces-toolbar>
-  </f8-feature-toggle>
+  <my-spaces-toolbar
+    (onCreateSpace)="showAddSpaceOverlay()"
+    (onFilterChange)="filterChange($event)"
+    (onSortChange)="sortChange($event)"
+    [resultsCount]="resultsCount">
+  </my-spaces-toolbar>
   <div class="container-fluid margin-bottom-20">
     <div class="row">
       <div class="col-sm-12">
@@ -21,7 +15,6 @@
             [items]="spaces"
             [itemHeadingTemplate]="itemHeadingTemplate"
             [itemTemplate]="itemTemplate"
-            (onActionSelect)="handleAction($event)"
             (onPinChange)="handlePinChange($event.item)"
             *ngIf="showSpaces">
           <ng-template #itemHeadingTemplate>
@@ -44,14 +37,6 @@
     </div>
   </div>
 </div>
-
-<!-- Create Space modal -->
-<ng-template #createSpace>
-  <space-wizard (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [style.display]="selectedFlow !== 'start' ? 'none': ''"></space-wizard>
-  <flow-selector (onSelect)="selectFlow($event)" (onCancel)="closeModal()" [space]="space" [style.display]="selectedFlow !== 'selectFlow' ? 'none': ''"></flow-selector>
-  <import-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'import' ? 'none': ''"></import-wizard>
-  <quickstart-wizard (onCancel)="closeModal()" [style.display]="selectedFlow !== 'quickstart' ? 'none': ''"></quickstart-wizard>
-</ng-template>
 
 <!-- Delete Space modal -->
 <ng-template #deleteSpace title="Remove the space">

--- a/src/app/profile/my-spaces/my-spaces.component.html
+++ b/src/app/profile/my-spaces/my-spaces.component.html
@@ -1,10 +1,16 @@
 <div class="my-spaces-page">
-  <my-spaces-toolbar
-      (onCreateSpace)="openForgeWizard(createSpace)"
-      (onFilterChange)="filterChange($event)"
-      (onSortChange)="sortChange($event)"
-      [resultsCount]="resultsCount">
-  </my-spaces-toolbar>
+  <f8-feature-toggle featureName="AppLauncher">
+    <my-spaces-toolbar default-level
+        (onCreateSpace)="openForgeWizard(createSpace)"
+        (onFilterChange)="filterChange($event)"
+        (onSortChange)="sortChange($event)"
+        [resultsCount]="resultsCount"></my-spaces-toolbar>
+    <my-spaces-toolbar user-level
+        (onCreateSpace)="showAddSpaceOverlay()"
+        (onFilterChange)="filterChange($event)"
+        (onSortChange)="sortChange($event)"
+        [resultsCount]="resultsCount"></my-spaces-toolbar>
+  </f8-feature-toggle>
   <div class="container-fluid margin-bottom-20">
     <div class="row">
       <div class="col-sm-12">

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -471,6 +471,13 @@ describe('MySpacesComponent', () => {
 
   });
 
+  describe('#showAddSpaceOverlay', () => {
+    it('should broadcast an event to open the new Space overlay', () => {
+      component.showAddSpaceOverlay();
+      expect(component.broadcaster.broadcast).toHaveBeenCalledWith('showAddSpaceOverlay', true);
+    });
+  });
+
   describe('#selectFlow', () => {
     it('should set the flow and space from the passed $event', () => {
       component.selectFlow(mockEvent);

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -142,22 +142,6 @@ describe('MySpacesComponent', () => {
    * Events
    */
 
-  describe('#handleAction', () => {
-    it('should delegate to the forge wizard if the action is to create a space', () => {
-      let mockAction = { id: 'createSpace' };
-      spyOn(component, 'openForgeWizard');
-      component.handleAction(mockAction);
-      expect(component.openForgeWizard).toHaveBeenCalled();
-    });
-
-    it('should do nothing if the action is not createSpace', () => {
-      let mockAction = { id: 'not-createSpace' };
-      spyOn(component, 'openForgeWizard');
-      component.handleAction(mockAction);
-      expect(component.openForgeWizard).toHaveBeenCalledTimes(0);
-    });
-  });
-
   describe('#handlePinChange', () => {
     it('should delegate to savePins and updateSpaces if the selected space exists in the user\'s spaces', () => {
       spyOn(component, 'savePins').and.callFake(() => {});
@@ -451,24 +435,6 @@ describe('MySpacesComponent', () => {
       component.closeModal(mockEvent);
       expect(component.modalRef.hide).toHaveBeenCalled();
     });
-  });
-
-  describe('#openForgeWizard', () => {
-    it('should open a large modal and set the flow to \'start\' if there exists GitHub token', () => {
-      let mockTemplateRef = jasmine.createSpy('TemplateRef');
-      spyOn(component.authentication, 'getGitHubToken').and.returnValue('mock-token');
-      component.openForgeWizard(mockTemplateRef);
-      expect(component.selectedFlow).toBe('start');
-      expect(component.modalService.show).toHaveBeenCalledWith(mockTemplateRef, {class: 'modal-lg'});
-    });
-
-    it('should broadcast an event indicating a disconnection from GitHub if no token', () => {
-      let mockTemplateRef = jasmine.createSpy('TemplateRef');
-      spyOn(component.authentication, 'getGitHubToken').and.returnValue('');
-      component.openForgeWizard(mockTemplateRef);
-      expect(component.broadcaster.broadcast).toHaveBeenCalled();
-    });
-
   });
 
   describe('#showAddSpaceOverlay', () => {

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -3,7 +3,6 @@ import {
   OnDestroy,
   OnInit,
   TemplateRef,
-  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -30,7 +29,6 @@ import { EventService } from '../../shared/event.service';
   styleUrls: ['./my-spaces.component.less']
 })
 export class MySpacesComponent implements OnDestroy, OnInit {
-  @ViewChild('createSpace') createSpaceTemplate: TemplateRef<any>;
 
   listConfig: ListConfig;
   showSpaces: boolean = false;
@@ -116,12 +114,6 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   }
 
   // Events
-
-  handleAction($event: Action): void {
-    if ($event.id === 'createSpace') {
-      this.openForgeWizard(this.createSpaceTemplate);
-    }
-  }
 
   handlePinChange($event: any): void {
     let index: any = findIndex(this.allSpaces, (obj) => {
@@ -265,15 +257,6 @@ export class MySpacesComponent implements OnDestroy, OnInit {
 
   closeModal($event: any): void {
     this.modalRef.hide();
-  }
-
-  openForgeWizard(addSpace: TemplateRef<any>) {
-    if (this.authentication.getGitHubToken()) {
-      this.selectedFlow = 'start';
-      this.modalRef = this.modalService.show(addSpace, {class: 'modal-lg'});
-    } else {
-      this.broadcaster.broadcast('showDisconnectedFromGitHub', {'location': window.location.href });
-    }
   }
 
   showAddSpaceOverlay() {

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -276,6 +276,10 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     }
   }
 
+  showAddSpaceOverlay() {
+    this.broadcaster.broadcast('showAddSpaceOverlay', true);
+  }
+
   selectFlow($event) {
     this.selectedFlow = $event.flow;
     this.space = $event.space;

--- a/src/app/profile/my-spaces/my-spaces.module.ts
+++ b/src/app/profile/my-spaces/my-spaces.module.ts
@@ -7,6 +7,8 @@ import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { InfiniteScrollModule } from 'ngx-widgets';
 import { ListModule } from 'patternfly-ng/list';
 
+import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
+
 import { ForgeWizardModule } from '../../space/forge-wizard/forge-wizard.module';
 import { SpaceWizardModule } from '../../space/wizard/space-wizard.module';
 import { MySpacesItemActionsModule } from './my-spaces-item-actions/my-spaces-item-actions.module';
@@ -29,7 +31,8 @@ import { MySpacesComponent }     from './my-spaces.component';
     MySpacesItemHeadingModule,
     MySpacesToolbarModule,
     MySpacesRoutingModule,
-    SpaceWizardModule
+    SpaceWizardModule,
+    FeatureFlagModule
   ],
   declarations: [ MySpacesComponent ]
 })

--- a/src/app/profile/my-spaces/my-spaces.module.ts
+++ b/src/app/profile/my-spaces/my-spaces.module.ts
@@ -7,10 +7,6 @@ import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { InfiniteScrollModule } from 'ngx-widgets';
 import { ListModule } from 'patternfly-ng/list';
 
-import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
-
-import { ForgeWizardModule } from '../../space/forge-wizard/forge-wizard.module';
-import { SpaceWizardModule } from '../../space/wizard/space-wizard.module';
 import { MySpacesItemActionsModule } from './my-spaces-item-actions/my-spaces-item-actions.module';
 import { MySpacesItemHeadingModule } from './my-spaces-item-heading/my-spaces-item-heading.module';
 import { MySpacesItemModule } from './my-spaces-item/my-spaces-item.module';
@@ -22,7 +18,6 @@ import { MySpacesComponent }     from './my-spaces.component';
   imports: [
     CommonModule,
     Fabric8WitModule,
-    ForgeWizardModule,
     InfiniteScrollModule,
     ListModule,
     ModalModule.forRoot(),
@@ -30,9 +25,7 @@ import { MySpacesComponent }     from './my-spaces.component';
     MySpacesItemActionsModule,
     MySpacesItemHeadingModule,
     MySpacesToolbarModule,
-    MySpacesRoutingModule,
-    SpaceWizardModule,
-    FeatureFlagModule
+    MySpacesRoutingModule
   ],
   declarations: [ MySpacesComponent ]
 })


### PR DESCRIPTION
Enable new Space overlay with feature flag. Previously only displayed old-style Forge wizard.

fixes https://github.com/openshiftio/openshift.io/issues/3576

I wonder if the feature flag directive should be included however, or if the button should simply unconditionally open the new overlay. I believe that overlay is now enabled in production anyway. See also https://github.com/openshiftio/openshift.io/issues/3629 .
