### PR TITLE
fix(version): Update planner version to 0.48.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4912,9 +4912,9 @@
       "dev": true
     },
     "fabric8-planner": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/fabric8-planner/-/fabric8-planner-0.48.0.tgz",
-      "integrity": "sha512-EGNutdh5xv1AtmePyHGaPtJpJ890O+9MfB+i80TekJQdKpanOHE6zazTeBn2ulv0/EtGSSTLN1x9P4OEscOWyw==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/fabric8-planner/-/fabric8-planner-0.48.1.tgz",
+      "integrity": "sha512-9LFBRSknibG+TGeASonCC1laYBZ8AZqrvRo06Om8G4z5HOeaZqny6a/MM1WwQk+01oG6UnIWxzOJ5gcBd6LjAw==",
       "requires": {
         "@angular/animations": "4.4.6",
         "@angular/common": "4.4.6",
@@ -4944,7 +4944,7 @@
         "ngx-widgets": "2.4.1",
         "patternfly-ng": "3.1.5",
         "reflect-metadata": "0.1.10",
-        "rh-ngx-datatable": "12.0.11",
+        "rh-ngx-datatable": "12.0.16",
         "rxjs": "5.5.2",
         "zone.js": "0.8.18"
       },
@@ -9960,6 +9960,237 @@
             "patternfly-bootstrap-treeview": "2.1.5"
           },
           "dependencies": {
+            "@types/c3": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/@types/c3/-/c3-0.6.0.tgz",
+              "integrity": "sha512-49E+Oh7KDKd8Dg4WjYh8NvFSZlmPUYuNquJzTvhk+CaBhsN7z+m1U/jmGS4V2QWHxBwj1HT7Hdz2mWbRXEmjQA==",
+              "requires": {
+                "@types/d3": "4.13.0"
+              }
+            },
+            "@types/d3": {
+              "version": "4.13.0",
+              "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.0.tgz",
+              "integrity": "sha512-L7C+aOIl+z/e7pPBvRXxA9EZ8a5RIZSq4UnTgdjCnypYV3bPI1wpx81snC8pE1zB4SZQC/WK4noZUHzWAABfBA==",
+              "requires": {
+                "@types/d3-array": "1.2.1",
+                "@types/d3-axis": "1.0.10",
+                "@types/d3-brush": "1.0.7",
+                "@types/d3-chord": "1.0.6",
+                "@types/d3-collection": "1.0.6",
+                "@types/d3-color": "1.2.1",
+                "@types/d3-dispatch": "1.0.6",
+                "@types/d3-drag": "1.2.0",
+                "@types/d3-dsv": "1.0.31",
+                "@types/d3-ease": "1.0.7",
+                "@types/d3-force": "1.1.0",
+                "@types/d3-format": "1.3.0",
+                "@types/d3-geo": "1.10.2",
+                "@types/d3-hierarchy": "1.1.1",
+                "@types/d3-interpolate": "1.1.6",
+                "@types/d3-path": "1.0.6",
+                "@types/d3-polygon": "1.0.6",
+                "@types/d3-quadtree": "1.0.5",
+                "@types/d3-queue": "3.0.5",
+                "@types/d3-random": "1.1.0",
+                "@types/d3-request": "1.0.2",
+                "@types/d3-scale": "1.0.12",
+                "@types/d3-selection": "1.3.0",
+                "@types/d3-shape": "1.2.2",
+                "@types/d3-time": "1.0.7",
+                "@types/d3-time-format": "2.1.0",
+                "@types/d3-timer": "1.0.6",
+                "@types/d3-transition": "1.1.1",
+                "@types/d3-voronoi": "1.1.7",
+                "@types/d3-zoom": "1.7.0"
+              }
+            },
+            "@types/d3-array": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.1.tgz",
+              "integrity": "sha512-YBaAfimGdWE4nDuoGVKsH89/dkz2hWZ0i8qC+xxqmqi+XJ/aXiRF0jPtzXmN7VdkpVjy1xuDmM5/m1FNuB6VWA=="
+            },
+            "@types/d3-axis": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.10.tgz",
+              "integrity": "sha512-5YF0wfdQMPKw01VAAupLIlg/T4pn5M3/vL9u0KZjiemnVnnKBEWE24na4X1iW+TfZiYJ8j+BgK2KFYnAAT54Ug==",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-brush": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.7.tgz",
+              "integrity": "sha1-BcMEQPTVN/0j+Xaw5sS6IjAB70U=",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-chord": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.6.tgz",
+              "integrity": "sha1-BYnrl6MZH07a8Xt73kmEYokM4ew="
+            },
+            "@types/d3-collection": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.6.tgz",
+              "integrity": "sha512-UHBvaU2wT5GlJN6rRVQm42211uAyZtp7m0jpQFuMuX7hTuivc0tcF0cjx5Ny5eQkhIolEyKwWgvJexw4e8g4+A=="
+            },
+            "@types/d3-color": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.1.tgz",
+              "integrity": "sha512-xwb1tqvYNWllbHuhMFhiXk63Imf+QNq/dJdmbXmr2wQVnwGenCuj3/0IWJ9hdIFQIqzvhT7T37cvx93jtAsDbQ=="
+            },
+            "@types/d3-dispatch": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+              "integrity": "sha512-xyWJQMr832vqhu6fD/YqX+MSFBWnkxasNhcStvlhqygXxj0cKqPft0wuGoH5TIq5ADXgP83qeNVa4R7bEYN3uA=="
+            },
+            "@types/d3-drag": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.0.tgz",
+              "integrity": "sha512-AePmm0sXj0Tpl0uQWvwmbAf1QR3yCy9aRhjJ9mRDDSZlHBdY0SCpUtdZC9uG9Q+pyHT/dEt1R2FT/sj+5k/bVA==",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-dsv": {
+              "version": "1.0.31",
+              "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.31.tgz",
+              "integrity": "sha512-UCAVZdwd2NkrbkF1lZu9vzTlmUENRRrPCubyhDPlG8Ye1B8Xr2PNvk/Tp8tMm6sPoWZWagri6/P9H+t7WqkGDg=="
+            },
+            "@types/d3-ease": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.7.tgz",
+              "integrity": "sha1-k6MBhovp4VBh89RDQ7GrP4rLbwk="
+            },
+            "@types/d3-force": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.1.0.tgz",
+              "integrity": "sha512-a39Uu/ltLaMpj6K0elEB1oAqhx9rlTB5X/O75uTUqyTW2CfjhPXg6hFsX1lF8oeMc29kqGJZ4g9Pf6mET25bVw=="
+            },
+            "@types/d3-format": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.0.tgz",
+              "integrity": "sha512-ZiY4j3iJvAdOwzwW24WjlZbUNvqOsnPAMfPBmdXqxj3uKJbrzBlRrdGl5uC89pZpFs9Dc92E81KcwG2uEgkIZA=="
+            },
+            "@types/d3-geo": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.10.2.tgz",
+              "integrity": "sha512-3VvrHG5e9PNWyusAsqHtHWzAYHcOxOrpacA/p527KUpSZKJybKeF9wqSyQgIeV0qZuh/FYMv4vlwQzeXgPQYlg==",
+              "requires": {
+                "@types/geojson": "7946.0.3"
+              }
+            },
+            "@types/d3-hierarchy": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.1.tgz",
+              "integrity": "sha512-2JYl75eoSdtqfmwIqf9TN7kWmT+/PBfz7Qejdn77gAu/k5HSqBINYVnciLRcjWzKq+lAujGypFuAAQ4zaGKxxg=="
+            },
+            "@types/d3-interpolate": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+              "integrity": "sha1-ZAQbFcnAMsNI2hsiuqvFn6TRYTY=",
+              "requires": {
+                "@types/d3-color": "1.2.1"
+              }
+            },
+            "@types/d3-path": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.6.tgz",
+              "integrity": "sha512-YHW4cs+wOU9gFUzudjJs9TkrB/8GOgKhq32ZyNaZ2rzZjOhkqG486sGr9XSh4C91CcgIg1FRGoDaN29Ropx9nw=="
+            },
+            "@types/d3-polygon": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.6.tgz",
+              "integrity": "sha512-E6Kyodn9JThgLq20nxSbEce9ow5/ePgm9PX2EO6W1INIL4DayM7cFaiG10DStuamjYAd0X4rntW2q+GRjiIktw=="
+            },
+            "@types/d3-quadtree": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
+              "integrity": "sha1-HOHmWerkUw3wyxJ/KX8XQaNnqC4="
+            },
+            "@types/d3-queue": {
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.5.tgz",
+              "integrity": "sha1-Pky+Kv9h22oLK4xIACmeTsasyFA="
+            },
+            "@types/d3-random": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.0.tgz",
+              "integrity": "sha1-LdCPEVnHBxknDkp8g0r4XIuI0sM="
+            },
+            "@types/d3-request": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.2.tgz",
+              "integrity": "sha1-2524FU9HgWWEcGxub3Ar5m8i9L4=",
+              "requires": {
+                "@types/d3-dsv": "1.0.31"
+              }
+            },
+            "@types/d3-scale": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.12.tgz",
+              "integrity": "sha512-2Z3YsHdWRBuUiqKHcnWVF1ffuALFn+k74QEECUCpzabD/5Olxvs/aJM4eG3QTe5n9yiWK432kOEpinGvO1wDfA==",
+              "requires": {
+                "@types/d3-time": "1.0.7"
+              }
+            },
+            "@types/d3-selection": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.3.0.tgz",
+              "integrity": "sha512-1SJhi3kTk/SHHIE6XkHuHU2REYkbSOjkQuo3HT71FOTs8/tjeGcvtXMsX4N3kU1UE1nVG+A5pg7TSjuJ4zUN3A=="
+            },
+            "@types/d3-shape": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.2.tgz",
+              "integrity": "sha512-Ydksrces8J5WP/NXhZ/CcDx/XZZ8b7MDX+u6WGQXwEWfmimJn9eYHiD7QR4BLe3zBiAOQmmiGAwRBKUDp5zb1g==",
+              "requires": {
+                "@types/d3-path": "1.0.6"
+              }
+            },
+            "@types/d3-time": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.7.tgz",
+              "integrity": "sha512-X5ZQYiJIM38XygNwld4gZ++Vtw2ftgo3KOfZOY4n/sCudUxclxf/3THBvuG8UqSV+EQ0ezYjT5eyvcrrmixOWA=="
+            },
+            "@types/d3-time-format": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+              "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA=="
+            },
+            "@types/d3-timer": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.6.tgz",
+              "integrity": "sha1-eG1OIHMa3wOvLF32yG/ilmf+Qps="
+            },
+            "@types/d3-transition": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.1.tgz",
+              "integrity": "sha512-GHTghl0YYB8gGgbyKxVLHyAp9Na0HqsX2U7M0u0lGw4IdfEaslooykweZ8fDHW13T+KZeZAuzhbmqBZVFO+6kg==",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-voronoi": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.7.tgz",
+              "integrity": "sha512-/dHFLK5jhXTb/W4XEQcFydVk8qlIAo85G3r7+N2fkBFw190l0R1GQ8C1VPeXBb2GfSU5GbT2hjlnE7i7UY5Gvg=="
+            },
+            "@types/d3-zoom": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.0.tgz",
+              "integrity": "sha512-eIivt2ehMUXqS0guuVzRSMr5RGhO958g9EKxIJv3Z23suPnX4VQI9k1TC/bLuwKq0IWp9a1bEEcIy+PNJv9BtA==",
+              "requires": {
+                "@types/d3-interpolate": "1.1.6",
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/geojson": {
+              "version": "7946.0.3",
+              "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.3.tgz",
+              "integrity": "sha512-BYHiG1vQJ7T93uswzuXZ0OBPWqj5tsAPtaMDQADV8sn2InllXarwg9llr6uaW22q1QCwBZ81gVajOpYWzjesug=="
+            },
             "bootstrap": {
               "version": "3.3.7",
               "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
@@ -11498,6 +11729,237 @@
             "patternfly-bootstrap-treeview": "2.1.5"
           },
           "dependencies": {
+            "@types/c3": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/@types/c3/-/c3-0.6.0.tgz",
+              "integrity": "sha512-49E+Oh7KDKd8Dg4WjYh8NvFSZlmPUYuNquJzTvhk+CaBhsN7z+m1U/jmGS4V2QWHxBwj1HT7Hdz2mWbRXEmjQA==",
+              "requires": {
+                "@types/d3": "4.13.0"
+              }
+            },
+            "@types/d3": {
+              "version": "4.13.0",
+              "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.0.tgz",
+              "integrity": "sha512-L7C+aOIl+z/e7pPBvRXxA9EZ8a5RIZSq4UnTgdjCnypYV3bPI1wpx81snC8pE1zB4SZQC/WK4noZUHzWAABfBA==",
+              "requires": {
+                "@types/d3-array": "1.2.1",
+                "@types/d3-axis": "1.0.10",
+                "@types/d3-brush": "1.0.7",
+                "@types/d3-chord": "1.0.6",
+                "@types/d3-collection": "1.0.6",
+                "@types/d3-color": "1.2.1",
+                "@types/d3-dispatch": "1.0.6",
+                "@types/d3-drag": "1.2.0",
+                "@types/d3-dsv": "1.0.31",
+                "@types/d3-ease": "1.0.7",
+                "@types/d3-force": "1.1.0",
+                "@types/d3-format": "1.3.0",
+                "@types/d3-geo": "1.10.2",
+                "@types/d3-hierarchy": "1.1.1",
+                "@types/d3-interpolate": "1.1.6",
+                "@types/d3-path": "1.0.6",
+                "@types/d3-polygon": "1.0.6",
+                "@types/d3-quadtree": "1.0.5",
+                "@types/d3-queue": "3.0.5",
+                "@types/d3-random": "1.1.0",
+                "@types/d3-request": "1.0.2",
+                "@types/d3-scale": "1.0.12",
+                "@types/d3-selection": "1.3.0",
+                "@types/d3-shape": "1.2.2",
+                "@types/d3-time": "1.0.7",
+                "@types/d3-time-format": "2.1.0",
+                "@types/d3-timer": "1.0.6",
+                "@types/d3-transition": "1.1.1",
+                "@types/d3-voronoi": "1.1.7",
+                "@types/d3-zoom": "1.7.0"
+              }
+            },
+            "@types/d3-array": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.1.tgz",
+              "integrity": "sha512-YBaAfimGdWE4nDuoGVKsH89/dkz2hWZ0i8qC+xxqmqi+XJ/aXiRF0jPtzXmN7VdkpVjy1xuDmM5/m1FNuB6VWA=="
+            },
+            "@types/d3-axis": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.10.tgz",
+              "integrity": "sha512-5YF0wfdQMPKw01VAAupLIlg/T4pn5M3/vL9u0KZjiemnVnnKBEWE24na4X1iW+TfZiYJ8j+BgK2KFYnAAT54Ug==",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-brush": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.7.tgz",
+              "integrity": "sha1-BcMEQPTVN/0j+Xaw5sS6IjAB70U=",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-chord": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.6.tgz",
+              "integrity": "sha1-BYnrl6MZH07a8Xt73kmEYokM4ew="
+            },
+            "@types/d3-collection": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.6.tgz",
+              "integrity": "sha512-UHBvaU2wT5GlJN6rRVQm42211uAyZtp7m0jpQFuMuX7hTuivc0tcF0cjx5Ny5eQkhIolEyKwWgvJexw4e8g4+A=="
+            },
+            "@types/d3-color": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.1.tgz",
+              "integrity": "sha512-xwb1tqvYNWllbHuhMFhiXk63Imf+QNq/dJdmbXmr2wQVnwGenCuj3/0IWJ9hdIFQIqzvhT7T37cvx93jtAsDbQ=="
+            },
+            "@types/d3-dispatch": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+              "integrity": "sha512-xyWJQMr832vqhu6fD/YqX+MSFBWnkxasNhcStvlhqygXxj0cKqPft0wuGoH5TIq5ADXgP83qeNVa4R7bEYN3uA=="
+            },
+            "@types/d3-drag": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.0.tgz",
+              "integrity": "sha512-AePmm0sXj0Tpl0uQWvwmbAf1QR3yCy9aRhjJ9mRDDSZlHBdY0SCpUtdZC9uG9Q+pyHT/dEt1R2FT/sj+5k/bVA==",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-dsv": {
+              "version": "1.0.31",
+              "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.31.tgz",
+              "integrity": "sha512-UCAVZdwd2NkrbkF1lZu9vzTlmUENRRrPCubyhDPlG8Ye1B8Xr2PNvk/Tp8tMm6sPoWZWagri6/P9H+t7WqkGDg=="
+            },
+            "@types/d3-ease": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.7.tgz",
+              "integrity": "sha1-k6MBhovp4VBh89RDQ7GrP4rLbwk="
+            },
+            "@types/d3-force": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.1.0.tgz",
+              "integrity": "sha512-a39Uu/ltLaMpj6K0elEB1oAqhx9rlTB5X/O75uTUqyTW2CfjhPXg6hFsX1lF8oeMc29kqGJZ4g9Pf6mET25bVw=="
+            },
+            "@types/d3-format": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.0.tgz",
+              "integrity": "sha512-ZiY4j3iJvAdOwzwW24WjlZbUNvqOsnPAMfPBmdXqxj3uKJbrzBlRrdGl5uC89pZpFs9Dc92E81KcwG2uEgkIZA=="
+            },
+            "@types/d3-geo": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.10.2.tgz",
+              "integrity": "sha512-3VvrHG5e9PNWyusAsqHtHWzAYHcOxOrpacA/p527KUpSZKJybKeF9wqSyQgIeV0qZuh/FYMv4vlwQzeXgPQYlg==",
+              "requires": {
+                "@types/geojson": "7946.0.3"
+              }
+            },
+            "@types/d3-hierarchy": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.1.tgz",
+              "integrity": "sha512-2JYl75eoSdtqfmwIqf9TN7kWmT+/PBfz7Qejdn77gAu/k5HSqBINYVnciLRcjWzKq+lAujGypFuAAQ4zaGKxxg=="
+            },
+            "@types/d3-interpolate": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+              "integrity": "sha1-ZAQbFcnAMsNI2hsiuqvFn6TRYTY=",
+              "requires": {
+                "@types/d3-color": "1.2.1"
+              }
+            },
+            "@types/d3-path": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.6.tgz",
+              "integrity": "sha512-YHW4cs+wOU9gFUzudjJs9TkrB/8GOgKhq32ZyNaZ2rzZjOhkqG486sGr9XSh4C91CcgIg1FRGoDaN29Ropx9nw=="
+            },
+            "@types/d3-polygon": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.6.tgz",
+              "integrity": "sha512-E6Kyodn9JThgLq20nxSbEce9ow5/ePgm9PX2EO6W1INIL4DayM7cFaiG10DStuamjYAd0X4rntW2q+GRjiIktw=="
+            },
+            "@types/d3-quadtree": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
+              "integrity": "sha1-HOHmWerkUw3wyxJ/KX8XQaNnqC4="
+            },
+            "@types/d3-queue": {
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.5.tgz",
+              "integrity": "sha1-Pky+Kv9h22oLK4xIACmeTsasyFA="
+            },
+            "@types/d3-random": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.0.tgz",
+              "integrity": "sha1-LdCPEVnHBxknDkp8g0r4XIuI0sM="
+            },
+            "@types/d3-request": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.2.tgz",
+              "integrity": "sha1-2524FU9HgWWEcGxub3Ar5m8i9L4=",
+              "requires": {
+                "@types/d3-dsv": "1.0.31"
+              }
+            },
+            "@types/d3-scale": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.12.tgz",
+              "integrity": "sha512-2Z3YsHdWRBuUiqKHcnWVF1ffuALFn+k74QEECUCpzabD/5Olxvs/aJM4eG3QTe5n9yiWK432kOEpinGvO1wDfA==",
+              "requires": {
+                "@types/d3-time": "1.0.7"
+              }
+            },
+            "@types/d3-selection": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.3.0.tgz",
+              "integrity": "sha512-1SJhi3kTk/SHHIE6XkHuHU2REYkbSOjkQuo3HT71FOTs8/tjeGcvtXMsX4N3kU1UE1nVG+A5pg7TSjuJ4zUN3A=="
+            },
+            "@types/d3-shape": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.2.tgz",
+              "integrity": "sha512-Ydksrces8J5WP/NXhZ/CcDx/XZZ8b7MDX+u6WGQXwEWfmimJn9eYHiD7QR4BLe3zBiAOQmmiGAwRBKUDp5zb1g==",
+              "requires": {
+                "@types/d3-path": "1.0.6"
+              }
+            },
+            "@types/d3-time": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.7.tgz",
+              "integrity": "sha512-X5ZQYiJIM38XygNwld4gZ++Vtw2ftgo3KOfZOY4n/sCudUxclxf/3THBvuG8UqSV+EQ0ezYjT5eyvcrrmixOWA=="
+            },
+            "@types/d3-time-format": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+              "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA=="
+            },
+            "@types/d3-timer": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.6.tgz",
+              "integrity": "sha1-eG1OIHMa3wOvLF32yG/ilmf+Qps="
+            },
+            "@types/d3-transition": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.1.tgz",
+              "integrity": "sha512-GHTghl0YYB8gGgbyKxVLHyAp9Na0HqsX2U7M0u0lGw4IdfEaslooykweZ8fDHW13T+KZeZAuzhbmqBZVFO+6kg==",
+              "requires": {
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/d3-voronoi": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.7.tgz",
+              "integrity": "sha512-/dHFLK5jhXTb/W4XEQcFydVk8qlIAo85G3r7+N2fkBFw190l0R1GQ8C1VPeXBb2GfSU5GbT2hjlnE7i7UY5Gvg=="
+            },
+            "@types/d3-zoom": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.0.tgz",
+              "integrity": "sha512-eIivt2ehMUXqS0guuVzRSMr5RGhO958g9EKxIJv3Z23suPnX4VQI9k1TC/bLuwKq0IWp9a1bEEcIy+PNJv9BtA==",
+              "requires": {
+                "@types/d3-interpolate": "1.1.6",
+                "@types/d3-selection": "1.3.0"
+              }
+            },
+            "@types/geojson": {
+              "version": "7946.0.3",
+              "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.3.tgz",
+              "integrity": "sha512-BYHiG1vQJ7T93uswzuXZ0OBPWqj5tsAPtaMDQADV8sn2InllXarwg9llr6uaW22q1QCwBZ81gVajOpYWzjesug=="
+            },
             "bootstrap": {
               "version": "3.3.7",
               "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
@@ -13955,9 +14417,9 @@
       "dev": true
     },
     "rh-ngx-datatable": {
-      "version": "12.0.11",
-      "resolved": "https://registry.npmjs.org/rh-ngx-datatable/-/rh-ngx-datatable-12.0.11.tgz",
-      "integrity": "sha1-sIEJNWz3ZDzFpZveucDXfMT+f+s=",
+      "version": "12.0.16",
+      "resolved": "https://registry.npmjs.org/rh-ngx-datatable/-/rh-ngx-datatable-12.0.16.tgz",
+      "integrity": "sha512-ntwkJOtqyNmT/PQLwlZrJj0mQoPD1CrXRjzRXzl783+JXYnJFqosVUlFvai0KJBtHGtj/Ez+YcUYqP83aIVzbg==",
       "requires": {
         "ng-drag-drop": "4.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "angular2-websocket": "0.9.5",
     "chunk-manifest-webpack2-plugin": "1.0.1",
     "core-js": "2.5.1",
-    "fabric8-planner": "0.48.0",
+    "fabric8-planner": "0.48.1",
     "fabric8-stack-analysis-ui": "0.12.5",
     "http-server": "0.10.0",
     "ie-shim": "0.1.0",


### PR DESCRIPTION
NOTE - The changes to package-lock.json are a result of `npm install`. The transitive dependencies have been updated because `rh-ngx-datatable` version is updated in planner.