### PR TITLE
fix(webpack): fix webpack config which prevented updating ngx-bootstrap

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -474,7 +474,7 @@ module.exports = function (options) {
 
       extractCSS,
 
-      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new webpack.IgnorePlugin(/^\.\/locale$/, /[^-]moment$/),
 
       /*
        * StyleLintPlugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -734,6 +734,16 @@
         "@types/uglify-js": "3.0.2"
       }
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -2911,8 +2921,8 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "4.0.1",
         "split2": "2.2.0",
@@ -4967,7 +4977,7 @@
         "@angular/http": "4.4.6",
         "c3": "0.4.18",
         "ngx-base": "2.3.1",
-        "ngx-bootstrap": "1.8.0",
+        "ngx-bootstrap": "1.9.3",
         "ngx-fabric8-wit": "6.20.3",
         "ngx-login-client": "1.4.1",
         "ngx-modal": "0.0.29",
@@ -7971,16 +7981,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsontoxml": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz",
@@ -9802,19 +9802,9 @@
       }
     },
     "ngx-bootstrap": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.8.0.tgz",
-      "integrity": "sha512-y4+9cQkCAZ8C2iHfGC9PMu6tqHqDPyZN0ejz4fDwWljAUtxqXqwUgPKAnebkckdLw/EFmozgvf27ouVqhDA+CA==",
-      "requires": {
-        "moment": "2.18.1"
-      },
-      "dependencies": {
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-        }
-      }
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.3.tgz",
+      "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
     },
     "ngx-fabric8-wit": {
       "version": "6.20.3",
@@ -10403,7 +10393,6 @@
             "c3": "0.4.22",
             "core-js": "2.4.1",
             "moment": "2.17.1",
-            "ngx-bootstrap": "1.8.0",
             "patternfly": "3.46.1",
             "rxjs": "5.5.2",
             "zone.js": "0.8.4"
@@ -11669,7 +11658,7 @@
         "c3": "0.4.22",
         "lodash": "4.17.4",
         "ng2-dragula": "1.5.0",
-        "ngx-bootstrap": "1.8.0",
+        "ngx-bootstrap": "1.9.3",
         "patternfly": "3.46.1"
       },
       "dependencies": {
@@ -15500,15 +15489,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -15536,6 +15516,15 @@
       "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
       "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "stringify-entities": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "ng2-restangular": "0.1.30",
     "ng2-truncate": "1.3.11",
     "ngx-base": "2.3.1",
-    "ngx-bootstrap": "1.8.0",
+    "ngx-bootstrap": "1.9.3",
     "ngx-fabric8-wit": "6.20.3",
     "ngx-forge": "0.1.6",
     "ngx-login-client": "1.4.1",

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -10,7 +10,8 @@ import {
   fakeAsync,
   flush,
   flushMicrotasks,
-  TestBed
+  TestBed,
+  tick
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
@@ -185,6 +186,7 @@ describe('DeploymentCardComponent async tests', () => {
       de.triggerEventHandler('click', new CustomEvent('click'));
 
       fixture.detectChanges();
+      tick();
 
       const menu: DebugElement = fixture.debugElement.query(By.css('.dropdown-menu'));
       menuItems = menu.queryAll(By.css('li'));


### PR DESCRIPTION
A while back ngx-bootstrap was updated to 1.9.3 and then downgraded back to 1.8.0.

Without fixing the webpack config, ngx-bootstrap 1.9.3 would throw errors because a rule that was meant for moment also matched a module in ngx-bootstrap 1.9.3. I updated the regex pattern to avoid matching ngx-bootstrap.

I had to update a test when upgrading ngx-bootstrap.

Both launcher and planner already depend on ngx-bootstrap 1.9.3 for popover outsideClick functionality. 