### PR TITLE
fix(webpack): resolve ngx-forge sourcemap warnings

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -154,7 +154,6 @@ module.exports = function (options) {
             helpers.nodeModulePath("angular2-flash-messages"),
             helpers.nodeModulePath("ngx-dropdown"),
             helpers.nodeModulePath("ngx-modal"),
-            helpers.nodeModulePath("ngx-modal"),
             helpers.nodeModulePath("ng2-dnd"),
             helpers.nodeModulePath("jw-bootstrap-switch-ng2"),
             helpers.nodeModulePath("ng2-truncate"),

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -149,17 +149,17 @@ module.exports = function (options) {
           exclude: [
             // Example helpers.nodeModulePath("fabric8-planner"),
             // Exclude any problematic sourcemaps
+            helpers.nodeModulePath("@angular"),
+            helpers.nodeModulePath("angular-2-dropdown-multiselect"),
+            helpers.nodeModulePath("angular2-flash-messages"),
+            helpers.nodeModulePath("fabric8-analytics-dependency-editor"),
+            helpers.nodeModulePath("jw-bootstrap-switch-ng2"),
             helpers.nodeModulePath("mydatepicker"),
             helpers.nodeModulePath("ng2-completer"),
-            helpers.nodeModulePath("angular2-flash-messages"),
-            helpers.nodeModulePath("ngx-dropdown"),
-            helpers.nodeModulePath("ngx-modal"),
             helpers.nodeModulePath("ng2-dnd"),
-            helpers.nodeModulePath("jw-bootstrap-switch-ng2"),
             helpers.nodeModulePath("ng2-truncate"),
-            helpers.nodeModulePath("angular-2-dropdown-multiselect"),
-            helpers.nodeModulePath("@angular"),
-            helpers.nodeModulePath("fabric8-analytics-dependency-editor")
+            helpers.nodeModulePath("ngx-dropdown"),
+            helpers.nodeModulePath("ngx-modal")
           ],
           use: ["source-map-loader"],
           enforce: "pre"

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -159,6 +159,7 @@ module.exports = function (options) {
             helpers.nodeModulePath("ng2-dnd"),
             helpers.nodeModulePath("ng2-truncate"),
             helpers.nodeModulePath("ngx-dropdown"),
+            helpers.nodeModulePath("ngx-forge"),
             helpers.nodeModulePath("ngx-modal")
           ],
           use: ["source-map-loader"],


### PR DESCRIPTION
This PR addresses the (~25) warnings in the console when running a local version of f8-ui.

![webpack-warnings](https://user-images.githubusercontent.com/10425301/40619359-c4f8d1a8-6262-11e8-89a4-88ca61058cc4.png)

Additionally there was a duplication of the `ngx-modal` in the exclusion list, so I removed it and ordered the list alphabetically so it will be easier to spot duplication.