### PR TITLE
fix(work-item-widget): fix the component to display all of a user's spaces instea…

### DIFF
--- a/src/app/home/work-item-widget/work-item-widget.component.html
+++ b/src/app/home/work-item-widget/work-item-widget.component.html
@@ -3,13 +3,13 @@
     <div class="card-pf-heading-bg">
       <div class="card-pf-heading f8-card-heading">
         <h2 class="card-pf-title">My Work Items
-        <span *ngIf="recentSpaces.length !== 0">
+        <span *ngIf="spaces.length !== 0">
           <select class="col-xs-3 col-sm-6 form-control work-item-combobox"
-              [disabled]="recentSpaces.length === 0"
+              [disabled]="spaces.length === 0"
               [(ngModel)]="currentSpaceId"
               (ngModelChange)="fetchWorkItems()">
             <option value="default">Select a space to work with...</option>
-            <option *ngFor="let space of recentSpaces" [value]="space.id">
+            <option *ngFor="let space of spaces" [value]="space.id">
               {{space.attributes.name | spaceName}}
             </option>
           </select>
@@ -57,13 +57,13 @@
     <div class="card-pf-heading-bg">
       <div class="card-pf-heading f8-card-heading">
         <h2 class="card-pf-title">My Work Items
-          <span *ngIf="recentSpaces.length !== 0">
+          <span *ngIf="spaces.length !== 0">
             <select class="col-xs-3 col-sm-6 form-control work-item-combobox"
-                    [disabled]="recentSpaces.length === 0"
+                    [disabled]="spaces.length === 0"
                     [(ngModel)]="currentSpaceId"
                     (ngModelChange)="fetchWorkItems()">
               <option value="default">Select a space to work with...</option>
-              <option *ngFor="let space of recentSpaces" [value]="space.id">
+              <option *ngFor="let space of spaces" [value]="space.id">
                 {{space.attributes.name | spaceName}}
               </option>
             </select>


### PR DESCRIPTION
…d of only recent spaces

This PR addresses issues [3621](https://github.com/openshiftio/openshift.io/issues/3621) [0] and [3504](https://github.com/openshiftio/openshift.io/issues/3504) [1], in which the home page work items widget only displays a subset of the user's spaces in the dropdown.

This is due to the widget only retrieving a list of 'recent' spaces via the `Spaces.current`[2]. As a result, only a subset of the user's spaces are displayed in the dropdown, which could be confusing because the title of the widget doesn't make reference to it only displaying recent spaces work items. This has been addressed by using the `SpaceService` to retrieve a list of the user's spaces instead.

Before:
![before](https://user-images.githubusercontent.com/10425301/40685230-abaa4164-6361-11e8-9530-b3d1d09fd775.png)

After:
![after-1](https://user-images.githubusercontent.com/10425301/40685240-afa005ce-6361-11e8-98da-7c6d6a628a52.png)

[0] https://github.com/openshiftio/openshift.io/issues/3621
[1] https://github.com/openshiftio/openshift.io/issues/3504
[2] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/home/work-item-widget/work-item-widget.component.ts#L32