### PR TITLE
fix(work-items): fix profile work-items combobox width and display all spaces

### DIFF
--- a/src/app/profile/overview/work-items/work-items.component.html
+++ b/src/app/profile/overview/work-items/work-items.component.html
@@ -4,9 +4,12 @@
       <h2 class="card-pf-title">
         Work Items
       <span class="work-item-dropdown" *ngIf="spaces.length !== 0">
-        <select class="form-control"
+        <select class="form-control" size=0
                 [(ngModel)]="currentSpaceId"
-                (ngModelChange)="fetchWorkItems()">
+                (ngModelChange)="fetchWorkItems()"
+                onmousedown="if(this.options.length>10){this.size=10;}"
+                onchange="this.size=0;"
+                onblur="this.size=0;">
           <option value="default">Select a space to work with...</option>
           <option *ngFor="let space of spaces" [value]="space.id">
             {{space.attributes.name | spaceName}}

--- a/src/app/profile/overview/work-items/work-items.component.less
+++ b/src/app/profile/overview/work-items/work-items.component.less
@@ -11,5 +11,7 @@
 
 .work-item-dropdown {
   position: absolute;
+  z-index: 1;
   right: 30px;
+  width: 45%;
 }

--- a/src/app/profile/overview/work-items/work-items.component.spec.ts
+++ b/src/app/profile/overview/work-items/work-items.component.spec.ts
@@ -1,0 +1,158 @@
+import { Component, DebugElement, NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
+import { HttpModule } from '@angular/http';
+import { By } from '@angular/platform-browser';
+import { WorkItemService } from 'fabric8-planner';
+import { List, take } from 'lodash';
+import { Broadcaster, Logger } from 'ngx-base';
+import { Contexts, Space, SpaceNamePipe, Spaces, SpaceService, WIT_API_URL } from 'ngx-fabric8-wit';
+import { AuthenticationService, User, UserService } from 'ngx-login-client';
+import { ConnectableObservable, Observable } from 'rxjs';
+import { createMock } from 'testing/mock';
+import { initContext, TestContext } from 'testing/test-context';
+import { ContextService } from '../../../shared/context.service';
+import { WorkItemsComponent } from './work-items.component';
+
+@Component({
+  template: '<alm-work-items></alm-work-items>'
+})
+class HostComponent {}
+
+@Pipe({ name: 'take' })
+class TakePipe implements PipeTransform {
+  transform(arr: List<string>, n?: number): List<string> {
+    return take(arr, n);
+  }
+}
+
+describe('WorkItemsComponent', () => {
+  type Context = TestContext<WorkItemsComponent, HostComponent>;
+  const mockContext: any = {
+    user: {
+      attributes: {
+        username: 'mock-username'
+      },
+      id: 'mock-user'
+    }
+  };
+  const mockSpace: any = {
+    name: 'mock-space',
+    path: 'mock-path',
+    id: 'mock-id',
+    attributes: {
+      name: 'mock-attribute',
+      description: 'mock-description',
+      'updated-at': 'mock-updated-at',
+      'created-at': 'mock-created-at',
+      version: 0
+    }
+  };
+  const mockSpaces: any = [
+    { name: 'mock-space-1', id: 'mock-space-id-1', attributes: { name: 'mock-space-1'} },
+    { name: 'mock-space-2', id: 'mock-space-id-2', attributes: { name: 'mock-space-2'} },
+    { name: 'mock-space-3', id: 'mock-space-id-3', attributes: { name: 'mock-space-3'} },
+    { name: 'mock-space-4', id: 'mock-space-id-4', attributes: { name: 'mock-space-4'} },
+    { name: 'mock-space-5', id: 'mock-space-id-5', attributes: { name: 'mock-space-5'} },
+    { name: 'mock-space-6', id: 'mock-space-id-6', attributes: { name: 'mock-space-6'} },
+    { name: 'mock-space-7', id: 'mock-space-id-7', attributes: { name: 'mock-space-7'} },
+    { name: 'mock-space-8', id: 'mock-space-id-8', attributes: { name: 'mock-space-8'} },
+    { name: 'mock-space-9', id: 'mock-space-id-9', attributes: { name: 'mock-space-9'} },
+    { name: 'mock-space-10', id: 'mock-space-id-10', attributes: { name: 'mock-space-10'} },
+    { name: 'mock-space-11', id: 'mock-space-id-11', attributes: { name: 'mock-space-11'} },
+    { name: 'mock-space-12', id: 'mock-space-id-12', attributes: { name: 'mock-space-12'} },
+    { name: 'mock-space-13', id: 'mock-space-id-13', attributes: { name: 'mock-space-13'} }
+  ];
+
+  initContext(WorkItemsComponent, HostComponent, {
+    declarations: [SpaceNamePipe, TakePipe],
+    imports: [HttpModule],
+    providers: [
+      { provide: Contexts, useFactory: () => {
+          let mockContexts: any = createMock(Contexts);
+          mockContexts.current = Observable.of(mockContext) as Observable<Context>;
+          return mockContexts;
+        }
+      },
+      { provide: Spaces, useFactory: () => {
+          let mockSpacesService: any = createMock(Spaces);
+          mockSpacesService.recent = Observable.of([mockSpace]) as Observable<Space[]>;
+          return mockSpacesService;
+        }
+      },
+      { provide: SpaceService, useFactory: () => {
+          let mockSpaceService: jasmine.SpyObj<SpaceService> = createMock(SpaceService);
+          mockSpaceService.getSpacesByUser.and.returnValue(Observable.of(mockSpaces) as Observable<Space[]>);
+          return mockSpaceService;
+        }
+      },
+      { provide: WorkItemService, useFactory: () => {
+          let mockWorkItemService: jasmine.SpyObj<WorkItemService> = createMock(WorkItemService);
+          mockWorkItemService.getWorkItems.and.returnValue(Observable.of({ workItems: [] }) as Observable<{workItems}>);
+          mockWorkItemService.buildUserIdMap.and.returnValue(Observable.of(mockContext.user) as Observable<User>);
+          return mockWorkItemService;
+        }
+      },
+      { provide: Broadcaster, useFactory: () => {
+          let mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
+          mockBroadcaster.on.and.returnValue(Observable.of(mockContext));
+          return mockBroadcaster;
+        }
+      },
+      { provide: UserService, useFactory: () => {
+          let mockUserService: jasmine.SpyObj<UserService> = createMock(UserService);
+          mockUserService.getUser.and.returnValue(Observable.of(mockContext.user) as Observable<User>);
+          mockUserService.loggedInUser = Observable.of(mockContext.user) as ConnectableObservable<User> & jasmine.Spy;
+          mockUserService.currentLoggedInUser = mockContext.user as User & jasmine.Spy;
+          return mockUserService;
+        }
+      },
+      { provide: ContextService, useFactory: () => {
+          let mockContextService: jasmine.SpyObj<ContextService> = createMock(ContextService);
+          mockContextService.viewingOwnContext.and.returnValue(true);
+          return mockContextService;
+        }
+      },
+      { provide: Logger, useFactory: () => {
+          let mockLogger: jasmine.SpyObj<Logger> = createMock(Logger);
+          return mockLogger;
+        }
+      },
+      { provide: AuthenticationService, useFactory: () => {
+          let mockAuthService: jasmine.SpyObj<AuthenticationService> = createMock(AuthenticationService);
+          mockAuthService.getToken.and.returnValue('mock-token');
+          return mockAuthService;
+        }
+      },
+      { provide: WIT_API_URL, useValue: 'http://example.com' }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
+
+  describe('Combobox', () => {
+    it('should exist when > 0 spaces', function(this: Context) {
+      let el: DebugElement = this.fixture.debugElement.query(By.css('.work-item-dropdown')).nativeElement;
+      expect(el).toBeDefined();
+    });
+
+    it('should contain all the user\'s spaces', function(this: Context) {
+      let de: DebugElement[] = this.fixture.debugElement.queryAll(By.css('option'));
+      // 13 mock spaces + default 'Select a space ..' message = 14 options
+      expect(de.length).toEqual(14);
+      for (let i: number = 1; i < mockSpaces.length; i++) {
+        expect(de[i].nativeElement.textContent.trim()).toEqual(mockSpaces[i - 1].name);
+      }
+    });
+
+    it('should limit the select size to 10 on a mousedown event', function(this: Context) {
+      let select = this.fixture.debugElement.query(By.css('select'));
+      expect(select.attributes['size']).toBeDefined();
+      expect(select.attributes['onmousedown']).toContain('this.size=10');
+    });
+
+    it('should reset the select options size to 0 on change and blur', function(this: Context) {
+      let select = this.fixture.debugElement.query(By.css('select'));
+      expect(select.attributes['onchange']).toEqual('this.size=0;');
+      expect(select.attributes['onblur']).toEqual('this.size=0;');
+    });
+  });
+
+});

--- a/src/app/profile/overview/work-items/work-items.component.ts
+++ b/src/app/profile/overview/work-items/work-items.component.ts
@@ -15,8 +15,7 @@ import { filterOutClosedItems } from '../../../shared/workitem-utils';
   encapsulation: ViewEncapsulation.None,
   selector: 'alm-work-items',
   templateUrl: './work-items.component.html',
-  styleUrls: ['./work-items.component.less'],
-  providers: [SpaceService]
+  styleUrls: ['./work-items.component.less']
 })
 export class WorkItemsComponent implements OnDestroy, OnInit  {
   context: Context;

--- a/src/app/profile/overview/work-items/work-items.component.ts
+++ b/src/app/profile/overview/work-items/work-items.component.ts
@@ -41,14 +41,14 @@ export class WorkItemsComponent implements OnDestroy, OnInit  {
     this.viewingOwnAccount = this.contextService.viewingOwnContext();
     this.subscriptions.push(contexts.current.subscribe(val => this.context = val));
     if (this.context.user.attributes) {
-      this.subscriptions.push(spaceService.getSpacesByUser(this.context.user.attributes.username, 10).subscribe(spaces => {
+      this.subscriptions.push(spaceService.getSpacesByUser(this.context.user.attributes.username).subscribe(spaces => {
         this.spaces = spaces;
       }));
     }
     this.subscriptions.push(this.broadcaster.on('contextChanged').subscribe(val => {
       this.context = val as Context;
       if (this.context.user.attributes) {
-        this.subscriptions.push(spaceService.getSpacesByUser(this.context.user.attributes.username, 10).subscribe(spaces => {
+        this.subscriptions.push(spaceService.getSpacesByUser(this.context.user.attributes.username).subscribe(spaces => {
           this.spaces = spaces;
         }));
       }
@@ -62,7 +62,7 @@ export class WorkItemsComponent implements OnDestroy, OnInit  {
   ngOnInit(): void {
     if (this.viewingOwnAccount && this.userService.currentLoggedInUser.attributes) {
       this.loggedInUser = this.userService.currentLoggedInUser;
-      this.subscriptions.push(this.spaceService.getSpacesByUser(this.loggedInUser.attributes.username, 10).subscribe(spaces => {
+      this.subscriptions.push(this.spaceService.getSpacesByUser(this.loggedInUser.attributes.username).subscribe(spaces => {
         this.spaces = spaces;
       }));
     }
@@ -183,7 +183,9 @@ export class WorkItemsComponent implements OnDestroy, OnInit  {
       return;
     }
     if (workItems !== undefined && workItems.length !== 0) {
-      this.currentSpaceId = this.recentSpaces[this.recentSpaceIndex].id;
+      if (this.recentSpaces[this.recentSpaceIndex]) {
+        this.currentSpaceId = this.recentSpaces[this.recentSpaceIndex].id;
+      }
       this.recentSpaceIndex = -1;
     } else {
       this.recentSpaceIndex++;


### PR DESCRIPTION
This short PR addresses [issue 1886](https://github.com/openshiftio/openshift.io/issues/1886), where if the user has a long space name then the combobox will overlap the title of the work item component in the profile view.

To fix, the width of the combobox has been made to be `width: 45%` just like the work items widget on the [home page](https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/home/work-item-widget/work-item-widget.component.less#L7) [1]. Additionally, the number of spaces being retrieved to display in the combobox was hardcoded at 10 spaces, so I've removed the limitation so all spaces should show up in the combobox.

Before:
![profile-before-1](https://user-images.githubusercontent.com/10425301/40725476-8a866392-63f1-11e8-93fb-5b638cdf5c0f.png)

![profile-before-2](https://user-images.githubusercontent.com/10425301/40725508-9ea63a8c-63f1-11e8-9b5b-a61538635e98.png)

After:
![profile-after](https://user-images.githubusercontent.com/10425301/40725487-9207631e-63f1-11e8-829c-0b80caff762a.png)

[0] https://github.com/openshiftio/openshift.io/issues/1886
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/home/work-item-widget/work-item-widget.component.less#L7