### PR TITLE
fix(codebases): fix opening workspaces in a new tab

### DIFF
--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
@@ -14,7 +14,7 @@
           (click)="openWorkspace()">Open</button>
 </ng-template>
 <ng-template #showCreateWorkspace>
-  <a href="javascript:void(0)" (click)="createAndOpenWorkspace()" *ngIf="!workspaceBusy">
+  <a href="javascript:void(0)" (click)="createWorkspace()" *ngIf="!workspaceBusy">
     <i class="pficon pficon-add-circle-o margin-right-10"></i>Create workspace</a>
   <a class="workspace-busy disabled" href="javascript:void(0)" *ngIf="workspaceBusy"
      tooltip="Waiting for Che..." disabled>

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.spec.ts
@@ -85,7 +85,7 @@ describe('Codebases Item Details Component', () => {
     expect(broadcasterMock.on).toHaveBeenCalled();
   }));
 
-  it('Create and open workspace', async(() => {
+  it('Create workspace', async(() => {
     // given
     workspacesServiceMock.createWorkspace.and.returnValue(Observable.of(expectedWorkspace));
     const notificationAction = { name: 'created' };
@@ -93,14 +93,14 @@ describe('Codebases Item Details Component', () => {
     fixture.detectChanges();
 
     // when
-    comp.createAndOpenWorkspace();
+    comp.createWorkspace();
 
     // then
     expect(workspacesServiceMock.createWorkspace).toHaveBeenCalled();
     expect(notificationMock.message).toHaveBeenCalled();
   }));
 
-  it('Create And Open Workspace with capacity full', async(() => {
+  it('Create Workspace with capacity full', async(() => {
     // given
     let comp = fixture.componentInstance;
     cheServiceMock.getState.and.returnValue(Observable.of({clusterFull: true, multiTenant: true, running: true}));
@@ -108,31 +108,28 @@ describe('Codebases Item Details Component', () => {
     notificationMock.message.and.returnValue(Observable.of(notificationAction));
     fixture.detectChanges();
     // when
-    comp.createAndOpenWorkspace();
+    comp.createWorkspace();
     fixture.detectChanges();
     // then
     expect(notificationMock.message).toHaveBeenCalled();
   }));
 
-  it('Open workspace', async(() => {
+  it('Open workspace with valid url', async(() => {
     // given
     const workspaceLinks = {
       links: {
         open: 'http://somewhere.com'
       }
     };
-    workspacesServiceMock.getWorkspaces.and.returnValue(Observable.of(expectedWorkspaces));
     workspacesServiceMock.openWorkspace.and.returnValue(Observable.of(workspaceLinks));
     windowServiceMock.open.and.returnValue({location: { href: 'test'}});
-    const notificationAction = { name: 'created' };
-    notificationMock.message.and.returnValue(Observable.of(notificationAction));
     fixture.detectChanges();
 
     // when
     comp.openWorkspace();
 
     // then
-    expect(workspacesServiceMock.openWorkspace).toHaveBeenCalled();
+    expect(windowServiceMock.open).toHaveBeenCalled();
   }));
 
   it('Open workspace with capacity full', async(() => {

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
@@ -136,6 +136,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
           }
         });
       } else {
+        workspaceWindow.close();
         this.workspaceBusy = false;
         // display error message
         this.notifications.message({

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
@@ -48,7 +48,6 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
-
     this.workspaceBusy = false;
     this.workspacesAvailable = false;
 
@@ -68,9 +67,9 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
   // Actions
 
   /**
-   * Create workspace and open in editor
+   * Create workspace
    */
-  createAndOpenWorkspace(): void {
+  createWorkspace(): void {
     this.workspaceBusy = true;
     this.subscriptions.push(this.cheService.getState().switchMap(che => {
       if (!che.clusterFull) {
@@ -81,7 +80,6 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
             this.workspaceBusy = false;
             if (workspaceLinks != undefined) {
               let name = this.getWorkspaceName(workspaceLinks.links.open);
-              this.windowService.open(workspaceLinks.links.open, name);
               this.notifications.message({
                 message: `Workspace created!`,
                 type: NotificationType.SUCCESS
@@ -123,16 +121,16 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
   }
 
   /**
-   * Open workspace in editor
+   * Opens Eclipse Che workspace in a new tab
    */
   openWorkspace(): void {
+    let workspaceWindow = this.windowService.open('about:blank', '_blank');
     this.workspaceBusy = true;
     this.subscriptions.push(this.cheService.getState().switchMap(che => {
       if (!che.clusterFull) {
         // create
         return this.workspacesService.openWorkspace(this.workspaceUrl).map(workspaceLinks => {
           this.workspaceBusy = false;
-          let workspaceWindow = this.windowService.open('about:blank', '_blank');
           if (workspaceLinks != undefined) {
             workspaceWindow.location.href = workspaceLinks.links.open;
           }
@@ -153,6 +151,9 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
       }));
   }
 
+  /**
+   * When combobox element is selected, sets the selected workspace
+   */
   setWorkspaceSelected(): void {
     this.workspaceSelected = (this.workspaceUrl !== undefined && this.workspaceUrl.length !== 0
       && this.workspaceUrl !== 'default');


### PR DESCRIPTION
This PR addresses [issue 3565](https://github.com/openshiftio/openshift.io/issues/3565) [0], in which attempting to open a Che workspace for a codebase with ad-blocker enabled will not work, and an error notification gets displayed to the screen.

After a bit of digging, it seems that in order for a new page to appear with ad-block enabled is to have the window.open functionality called immediately after the component is clicked. Previously, our call to open a new window is nested inside of a subscribe is doesn't execute in time. This causes ad-block to block the new window and the `codebases-item-workspaces` to catch an error. In this PR, the `openWorkspace()` only performs the action of opening a new window based on the eclipse che url that is set when a combobox item is selected. Because of the sync nature, creating and opening a workspace in one function is not feasible, and has been separated.

Before (notice that it's being caught by ad-block):
![before](https://user-images.githubusercontent.com/10425301/40745802-7613a714-6426-11e8-8867-df3bcd7856cc.gif)

After (here I am opening two different workspaces associated to the same codebase):
![after](https://user-images.githubusercontent.com/10425301/40745799-7217baba-6426-11e8-87aa-4efb09effcea.gif)

[0] https://github.com/openshiftio/openshift.io/issues/3565