### PR TITLE
Revert "Update .dockerignore"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 node_modules
 *~
 *.swp
-.git


### PR DESCRIPTION
Reverts fabric8-ui/fabric8-ui#2967

Build failed with `fatal: Not a git repository (or any of the parent directories): .git`