### PR TITLE
Applications-widget: in-progress message for newly created apps

### DIFF
--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
@@ -1,13 +1,20 @@
 <f8-feature-toggle featureName="ApplicationsCard">
   <div class="applications-widget card-pf f8-card" user-level>
     <div class="card-pf-heading f8-card-heading">
+      <div class="card-pf-heading-details"
+           *ngIf="applicationsInProgress > 0 && (stageConfigsAvailable || runConfigsAvailable)">
+        <p>
+          Setting up {{applicationsInProgress}} applications.
+          <a [routerLink]="['/', loggedInUser?.attributes?.username, this.currentSpace?.attributes?.name, 'create', 'pipelines']">View progress.</a>
+        </p>
+      </div>
       <h2 class="card-pf-title">
         Applications
       </h2>
     </div>
     <div class="card-pf-body f8-card-body">
-      <ng-container *ngIf="buildConfigsAvailable; then showApplications else showBlankState"></ng-container>
-      <ng-template #showBlankState>
+      <ng-container *ngIf="buildConfigsAvailable; then showApplications else showEmptyState"></ng-container>
+      <ng-template #showEmptyState>
         <fabric8-loading-widget message="Please wait while we load your applications"
                                 *ngIf="loading === true"></fabric8-loading-widget>
         <div class="f8-blank-slate-card" *ngIf="loading !== true">
@@ -23,24 +30,34 @@
         </div>
       </ng-template>
       <ng-template #showApplications>
-        <div id="spacehome-applications-list" class="f8-card-applications-list">
-          <div class="col-md-12 col-lg-6 padding-none">
-            <div class="f8-card-applications-list-stage">
-              <h4 class="f8-card-applications-list-step">Stage</h4>
-              <div class="f8-card-applications-list-name">
-                <fabric8-applications-list [buildConfigs]="stageBuildConfigs"></fabric8-applications-list>
+        <ng-container *ngIf="stageConfigsAvailable || runConfigsAvailable; else showInProgress">
+          <div id="spacehome-applications-list" class="f8-card-applications-list">
+            <div class="col-md-12 col-lg-6 padding-none">
+              <div class="f8-card-applications-list-stage">
+                <h4 class="f8-card-applications-list-step">Stage</h4>
+                <div class="f8-card-applications-list-name">
+                  <fabric8-applications-list [buildConfigs]="stageBuildConfigs"></fabric8-applications-list>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-12 col-lg-6 padding-none">
+              <div class="f8-card-applications-list-run">
+                <h4 class="f8-card-applications-list-step">Run</h4>
+                <div class="f8-card-applications-list-name">
+                  <fabric8-applications-list [buildConfigs]="runBuildConfigs"></fabric8-applications-list>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div class="col-md-12 col-lg-6 padding-none">
-          <div class="f8-card-applications-list-run">
-            <h4 class="f8-card-applications-list-step">Run</h4>
-            <div class="f8-card-applications-list-name">
-              <fabric8-applications-list [buildConfigs]="runBuildConfigs"></fabric8-applications-list>
-            </div>
-          </div>
-        </div>
+        </ng-container>
+        <ng-template #showInProgress>
+          <fabric8-loading-widget
+              [title]="'Application Setup In Progress'"
+              [message]="'This may take a few minutes. Once setup is complete, you\'ll see your deployed applications here.'">
+            <a id="test-applications-pipelines-link"
+               [routerLink]="['/', loggedInUser?.attributes?.username, this.currentSpace?.attributes?.name, 'create', 'pipelines']">View setup progress</a>
+          </fabric8-loading-widget>
+        </ng-template>
       </ng-template>
     </div>
   </div>

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
@@ -4,7 +4,7 @@
       <div class="card-pf-heading-details"
            *ngIf="applicationsInProgress > 0 && (stageConfigsAvailable || runConfigsAvailable)">
         <p>
-          Setting up {{applicationsInProgress}} applications.
+          Setting up {{applicationsInProgress}} application{{applicationsInProgress > 1 ? 's' : ''}}.
           <a [routerLink]="['/', loggedInUser?.attributes?.username, this.currentSpace?.attributes?.name, 'create', 'pipelines']">View progress.</a>
         </p>
       </div>
@@ -24,7 +24,7 @@
           </p>
           <div class="f8-blank-slate-main-action">
             <div *ngIf="userOwnsSpace">
-              <button id="spacehome-applications-add-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Create an Application</button>
+              <button id="test-applications-add-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Create an Application</button>
             </div>
           </div>
         </div>

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
@@ -24,7 +24,7 @@
           </p>
           <div class="f8-blank-slate-main-action">
             <div *ngIf="userOwnsSpace">
-              <button id="test-applications-add-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Create an Application</button>
+              <button id="spacehome-applications-add-button" class="btn btn-primary btn-lg" (click)="addToSpace.emit()">Create an Application</button>
             </div>
           </div>
         </div>
@@ -54,7 +54,7 @@
           <fabric8-loading-widget
               [title]="'Application Setup In Progress'"
               [message]="'This may take a few minutes. Once setup is complete, you\'ll see your deployed applications here.'">
-            <a id="test-applications-pipelines-link"
+            <a id="spacehome-applications-pipelines-link"
                [routerLink]="['/', loggedInUser?.attributes?.username, this.currentSpace?.attributes?.name, 'create', 'pipelines']">View setup progress</a>
           </fabric8-loading-widget>
         </ng-template>

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.less
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.less
@@ -1,6 +1,12 @@
 @import (reference) '../../../assets/stylesheets/shared/osio.less';
 
 .applications-widget {
+  .card-pf-heading-details {
+    font-size: @font-size-base;
+    a {
+      cursor: pointer;
+    }
+  }
   .f8-card-body {
     @media (min-width: @screen-lg-min) {
       overflow-y: hidden;

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
@@ -211,7 +211,7 @@ describe('ApplicationsWidgetComponent', () => {
     providers: [
       { provide: ActivatedRoute, useValue: jasmine.createSpy('ActivatedRoute') },
       { provide: Contexts, useValue: ({ current: ctxSubj }) },
-      { provide: LocationStrategy, useValue: jasmine.createSpyObj('LocationStrategy', ['prepareExternalUrl']); },
+      { provide: LocationStrategy, useValue: jasmine.createSpyObj('LocationStrategy', ['prepareExternalUrl']) },
       { provide: PipelinesService, useFactory: () => pipelinesService },
       {
         provide: FeatureTogglesService, useFactory: () => {

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
@@ -295,11 +295,11 @@ describe('ApplicationsWidgetComponent', () => {
       this.testedDirective.runBuildConfigs.length = 0;
       this.testedDirective.stageBuildConfigs.length = 0;
       this.detectChanges();
-      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).not.toBeNull();
     });
 
-    it('Stage or run build configs to show empty state', function(this: TestingContext) {
-      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).not.toBeNull();
+    it('Stage or run build configs not to show empty state', function(this: TestingContext) {
+      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).toBeNull();
     });
   });
 

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
@@ -4,13 +4,16 @@ import {
   Input
 } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { BehaviorSubject, Observable } from 'rxjs';
-
-import { initContext, TestContext } from 'testing/test-context';
+import { ConnectableObservable, Subject } from 'rxjs/Rx';
 
 import { Context, Contexts } from 'ngx-fabric8-wit';
+import { User, UserService } from 'ngx-login-client';
+
 import { createMock } from 'testing/mock';
+import { initContext, TestContext } from 'testing/test-context';
 
 import { BuildConfig } from '../../../a-runtime-console/index';
 import { LoadingWidgetModule } from '../../dashboard-widgets/loading-widget/loading-widget.module';
@@ -19,6 +22,7 @@ import { ApplicationsWidgetComponent } from './applications-widget.component';
 
 import { FeatureToggleComponent } from '../../feature-flag/feature-wrapper/feature-toggle.component';
 import { Feature, FeatureTogglesService } from '../../feature-flag/service/feature-toggles.service';
+
 @Component({
   selector: 'fabric8-applications-list',
   template: ''
@@ -39,6 +43,16 @@ describe('ApplicationsWidgetComponent', () => {
 
   let contexts: Contexts;
   let pipelinesService: { current: Observable<BuildConfig[]> };
+
+  let fakeUser: Observable<User> = Observable.of({
+    id: 'fakeId',
+    type: 'fakeType',
+    attributes: {
+      fullName: 'fakeName',
+      imageURL: 'null',
+      username: 'fakeUserName'
+    }
+  } as User);
 
   let buildConfig1 = {
     id: 'app1',
@@ -162,6 +176,8 @@ describe('ApplicationsWidgetComponent', () => {
     }]
   };
 
+  let ctxSubj: Subject<Context> = new Subject<Context>();
+
   beforeEach(() => {
     contexts = {
       current: new BehaviorSubject<Context>({
@@ -185,14 +201,16 @@ describe('ApplicationsWidgetComponent', () => {
   initContext(ApplicationsWidgetComponent, HostComponent, {
     imports: [
       CommonModule,
-      LoadingWidgetModule
+      LoadingWidgetModule,
+      RouterModule
     ],
     declarations: [
       FakeApplicationsListComponent,
       FeatureToggleComponent
     ],
     providers: [
-      { provide: Contexts, useFactory: () => contexts },
+      { provide: ActivatedRoute, useValue: jasmine.createSpy('ActivatedRoute') },
+      { provide: Contexts, useValue: ({ current: ctxSubj }) },
       { provide: PipelinesService, useFactory: () => pipelinesService },
       {
         provide: FeatureTogglesService, useFactory: () => {
@@ -203,7 +221,28 @@ describe('ApplicationsWidgetComponent', () => {
 
           return mock;
         }
-      }
+      },
+      {
+        provide: Router, useFactory: (): jasmine.SpyObj<Router> => {
+          let mockRouterEvent: any = {
+            'id': 1,
+            'url': 'mock-url'
+          };
+
+          let mockRouter = jasmine.createSpyObj('Router', ['createUrlTree', 'navigate', 'serializeUrl']);
+          mockRouter.events = Observable.of(mockRouterEvent);
+
+          return mockRouter;
+        }
+      },
+      {
+        provide: UserService, useFactory: () => {
+          let userService = createMock(UserService);
+          userService.getUser.and.returnValue(fakeUser);
+          userService.loggedInUser = fakeUser.publish() as ConnectableObservable<User> & jasmine.Spy;
+          return userService;
+        }
+      },
     ]
   });
 
@@ -243,8 +282,7 @@ describe('ApplicationsWidgetComponent', () => {
 
     it('should enable buttons if the user owns the space', function(this: TestingContext) {
       this.hostComponent.userOwnsSpace = true;
-      this.testedDirective.runBuildConfigs.length = 0;
-      this.testedDirective.stageBuildConfigs.length = 0;
+      this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
 
       expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).not.toBeNull();
@@ -252,8 +290,7 @@ describe('ApplicationsWidgetComponent', () => {
 
     it('should disable buttons if the user does not own the space', function(this: TestingContext) {
       this.hostComponent.userOwnsSpace = false;
-      this.testedDirective.runBuildConfigs.length = 0;
-      this.testedDirective.stageBuildConfigs.length = 0;
+      this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
 
       expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).toBeNull();

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule, LocationStrategy } from '@angular/common';
 import {
   Component,
   Input
@@ -211,6 +211,7 @@ describe('ApplicationsWidgetComponent', () => {
     providers: [
       { provide: ActivatedRoute, useValue: jasmine.createSpy('ActivatedRoute') },
       { provide: Contexts, useValue: ({ current: ctxSubj }) },
+      { provide: LocationStrategy, useValue: jasmine.createSpyObj('LocationStrategy', ['prepareExternalUrl']); },
       { provide: PipelinesService, useFactory: () => pipelinesService },
       {
         provide: FeatureTogglesService, useFactory: () => {
@@ -242,7 +243,7 @@ describe('ApplicationsWidgetComponent', () => {
           userService.loggedInUser = fakeUser.publish() as ConnectableObservable<User> & jasmine.Spy;
           return userService;
         }
-      },
+      }
     ]
   });
 
@@ -276,6 +277,30 @@ describe('ApplicationsWidgetComponent', () => {
     it('Run build configs to be sorted', function(this: TestingContext) {
       expect(this.testedDirective.runBuildConfigs as any[]).toEqual([buildConfig1, buildConfig3]);
     });
+
+    it('Empty build configs to not show empty state', function(this: TestingContext) {
+      this.hostComponent.userOwnsSpace = true;
+      this.detectChanges();
+      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).toBeNull();
+    });
+
+    it('Empty build configs to show empty state', function(this: TestingContext) {
+      this.hostComponent.userOwnsSpace = true;
+      this.testedDirective.buildConfigs.length = 0;
+      this.detectChanges();
+      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).not.toBeNull();
+    });
+
+    it('Empty stage and run build configs to show empty state', function(this: TestingContext) {
+      this.testedDirective.runBuildConfigs.length = 0;
+      this.testedDirective.stageBuildConfigs.length = 0;
+      this.detectChanges();
+      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).toBeNull();
+    });
+
+    it('Stage or run build configs to show empty state', function(this: TestingContext) {
+      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).not.toBeNull();
+    });
   });
 
   describe('Applications widget without build configs', () => {
@@ -285,7 +310,7 @@ describe('ApplicationsWidgetComponent', () => {
       this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
 
-      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).not.toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).not.toBeNull();
     });
 
     it('should disable buttons if the user does not own the space', function(this: TestingContext) {
@@ -293,7 +318,7 @@ describe('ApplicationsWidgetComponent', () => {
       this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
 
-      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).toBeNull();
     });
   });
 });

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
@@ -281,25 +281,25 @@ describe('ApplicationsWidgetComponent', () => {
     it('Empty build configs to not show empty state', function(this: TestingContext) {
       this.hostComponent.userOwnsSpace = true;
       this.detectChanges();
-      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).toBeNull();
     });
 
     it('Empty build configs to show empty state', function(this: TestingContext) {
       this.hostComponent.userOwnsSpace = true;
       this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
-      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).not.toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).not.toBeNull();
     });
 
     it('Empty stage and run build configs to show empty state', function(this: TestingContext) {
       this.testedDirective.runBuildConfigs.length = 0;
       this.testedDirective.stageBuildConfigs.length = 0;
       this.detectChanges();
-      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).not.toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-pipelines-link'))).not.toBeNull();
     });
 
     it('Stage or run build configs not to show empty state', function(this: TestingContext) {
-      expect(this.fixture.debugElement.query(By.css('#test-applications-pipelines-link'))).toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-pipelines-link'))).toBeNull();
     });
   });
 
@@ -310,7 +310,7 @@ describe('ApplicationsWidgetComponent', () => {
       this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
 
-      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).not.toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).not.toBeNull();
     });
 
     it('should disable buttons if the user does not own the space', function(this: TestingContext) {
@@ -318,7 +318,7 @@ describe('ApplicationsWidgetComponent', () => {
       this.testedDirective.buildConfigs.length = 0;
       this.detectChanges();
 
-      expect(this.fixture.debugElement.query(By.css('#test-applications-add-button'))).toBeNull();
+      expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).toBeNull();
     });
   });
 });

--- a/src/app/dashboard-widgets/applications-widget/applications-widget.module.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 
 import { LoadingWidgetModule } from '../../dashboard-widgets/loading-widget/loading-widget.module';
 import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
@@ -13,7 +14,8 @@ import { ApplicationsWidgetComponent } from './applications-widget.component';
     CommonModule,
     FeatureFlagModule,
     FormsModule,
-    LoadingWidgetModule
+    LoadingWidgetModule,
+    RouterModule
   ],
   declarations: [ApplicationsWidgetComponent],
   exports: [ApplicationsWidgetComponent]

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.html
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.html
@@ -2,5 +2,5 @@
   <div class="spinner spinner-lg"></div>
   <h3 *ngIf="title !== undefined">{{title}}</h3>
   <p *ngIf="message !== undefined">{{message}}</p>
-  <a *ngIf="hyperlinkText !== undefined" (click)="handleLinkAction($event)">{{hyperlinkText}}</a>
+  <ng-content></ng-content>
 </div>

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.html
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.html
@@ -1,4 +1,6 @@
 <div class="f8-loading f8-blank-slate-card">
   <div class="spinner spinner-lg"></div>
-  <p>{{message}}</p>
+  <h3 *ngIf="title !== undefined">{{title}}</h3>
+  <p *ngIf="message !== undefined">{{message}}</p>
+  <a *ngIf="hyperlinkText !== undefined" (click)="handleLinkAction($event)">{{hyperlinkText}}</a>
 </div>

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.less
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.less
@@ -2,4 +2,7 @@
 
 .f8-loading {
   width: 30%;
+  a {
+    cursor: pointer;
+  }
 }

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.spec.ts
@@ -7,7 +7,7 @@ import { initContext, TestContext } from 'testing/test-context';
 import { LoadingWidgetComponent } from './loading-widget.component';
 
 @Component({
-  template: '<fabric8-loading-widget message="test"></fabric8-loading-widget>'
+  template: '<fabric8-loading-widget [message]="\'test1\'" [title]="\'test2\'" [hyperlinkText]="\'test3\'"></fabric8-loading-widget>'
 })
 class HostComponent {
 }
@@ -27,7 +27,17 @@ describe('LoadingWidgetComponent', () => {
   describe('Loading widget', () => {
     it('Should have message', function(this: TestingContext) {
       this.detectChanges();
-      expect(this.testedDirective.message).toEqual('test');
+      expect(this.testedDirective.message).toEqual('test1');
+    });
+
+    it('Should have message title', function(this: TestingContext) {
+      this.detectChanges();
+      expect(this.testedDirective.title).toEqual('test2');
+    });
+
+    it('Should have hyperlink text', function(this: TestingContext) {
+      this.detectChanges();
+      expect(this.testedDirective.hyperlinkText).toEqual('test3');
     });
   });
 });

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.spec.ts
@@ -7,7 +7,7 @@ import { initContext, TestContext } from 'testing/test-context';
 import { LoadingWidgetComponent } from './loading-widget.component';
 
 @Component({
-  template: '<fabric8-loading-widget [message]="\'test1\'" [title]="\'test2\'" [hyperlinkText]="\'test3\'"></fabric8-loading-widget>'
+  template: '<fabric8-loading-widget [message]="\'test1\'" [title]="\'test2\'"></fabric8-loading-widget>'
 })
 class HostComponent {
 }
@@ -33,11 +33,6 @@ describe('LoadingWidgetComponent', () => {
     it('Should have message title', function(this: TestingContext) {
       this.detectChanges();
       expect(this.testedDirective.title).toEqual('test2');
-    });
-
-    it('Should have hyperlink text', function(this: TestingContext) {
-      this.detectChanges();
-      expect(this.testedDirective.hyperlinkText).toEqual('test3');
     });
   });
 });

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.ts
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.ts
@@ -1,7 +1,9 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnInit,
+  Output,
   ViewEncapsulation
 } from '@angular/core';
 
@@ -12,11 +14,40 @@ import {
   styleUrls: ['./loading-widget.component.less']
 })
 export class LoadingWidgetComponent implements OnInit {
+  /**
+   * The message
+   */
   @Input() message: string;
+
+  /**
+   * The hyperlink text
+   */
+  @Input() hyperlinkText: string;
+
+  /**
+   * The message title
+   */
+  @Input() title: string;
+
+  /**
+   * The event emitted when hyperlink has been clicked
+   */
+  @Output('onHyperlinkClick') onHyperlinkClick = new EventEmitter();
+
+  /**
+   * The router URL
+   */
+  @Input() routerUrl: string;
 
   constructor() {
   }
 
   ngOnInit(): void {
+  }
+
+  // Private
+
+  private handleLinkAction($event: MouseEvent): void {
+    this.onHyperlinkClick.emit();
   }
 }

--- a/src/app/dashboard-widgets/loading-widget/loading-widget.component.ts
+++ b/src/app/dashboard-widgets/loading-widget/loading-widget.component.ts
@@ -20,34 +20,13 @@ export class LoadingWidgetComponent implements OnInit {
   @Input() message: string;
 
   /**
-   * The hyperlink text
-   */
-  @Input() hyperlinkText: string;
-
-  /**
    * The message title
    */
   @Input() title: string;
-
-  /**
-   * The event emitted when hyperlink has been clicked
-   */
-  @Output('onHyperlinkClick') onHyperlinkClick = new EventEmitter();
-
-  /**
-   * The router URL
-   */
-  @Input() routerUrl: string;
 
   constructor() {
   }
 
   ngOnInit(): void {
-  }
-
-  // Private
-
-  private handleLinkAction($event: MouseEvent): void {
-    this.onHyperlinkClick.emit();
   }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -62,7 +62,7 @@
               </h2>
             </div>
             <div class="card-pf-body f8-card-body">
-              <fabric8-loading-widget message="Please wait while we load your recent spaces"
+              <fabric8-loading-widget [message]="'Please wait while we load your recent spaces'"
                                       *ngIf="loading === true"></fabric8-loading-widget>
               <div class="f8-blank-slate-card" *ngIf="_spaces.length === 0 && loading !== true">
                 <h3>Create a space</h3>
@@ -180,7 +180,7 @@
               </h2>
             </div>
             <div class="card-pf-body f8-card-body">
-              <fabric8-loading-widget message="Please wait while we load your recent spaces"
+              <fabric8-loading-widget [message]="'Please wait while we load your recent spaces'"
                                       *ngIf="loading === true"></fabric8-loading-widget>
               <div class="f8-blank-slate-card" *ngIf="_spaces.length === 0 && loading !== true">
                 <h3>Create a space</h3>


### PR DESCRIPTION
Show in-progress message for newly created applications. Also refactored the loading widget to accommodate additional messages and links.

Fixes: https://github.com/openshiftio/openshift.io/issues/3671

With no applications staged/running:
![screen shot 2018-05-29 at 3 11 34 pm](https://user-images.githubusercontent.com/17481322/40789539-a13ddb36-64c0-11e8-8085-2ff474181412.png)

With staged application:
![screen shot 2018-05-31 at 10 43 34 am](https://user-images.githubusercontent.com/17481322/40789556-aaa82668-64c0-11e8-9b3a-1229812a3ed4.png)


