### PR TITLE
fix(profile-update): form validations fixed.

### DIFF
--- a/src/app/profile/update/update.component.spec.ts
+++ b/src/app/profile/update/update.component.spec.ts
@@ -358,26 +358,9 @@ describe('UpdateComponent', () => {
     });
   });
 
-  describe('#validateImageUrl', () => {
-    // Wrongfully fails
-    xit('should verify https://fabric8.io/ to be an invalid image url', () => {
-      let url: string = 'https://fabric8.io/';
-      component.imageUrl = url;
-      component.validateImageUrl();
-      expect(component.imageUrlInvalid).toBeTruthy();
-    });
-
-    it('should verify http://design.jboss.org/fabric8/logo/final/fabric8_logo_600px.png to be a valid image url', () => {
-      let url: string = 'http://design.jboss.org/fabric8/logo/final/fabric8_logo_600px.png';
-      component.imageUrl = url;
-      component.validateImageUrl();
-      expect(component.imageUrlInvalid).toBeFalsy();
-    });
-  });
-
   describe('#validateUrl', () => {
     it('should verify not-a-real-url to be an invalid url', () => {
-      let url: string = 'not-a-real-url';
+      let url: string = 'htt:/not-a-real-url.some-thing.';
       component.url = url;
       component.validateUrl();
       expect(component.urlInvalid).toBeTruthy();

--- a/src/app/profile/update/update.component.spec.ts
+++ b/src/app/profile/update/update.component.spec.ts
@@ -360,10 +360,12 @@ describe('UpdateComponent', () => {
 
   describe('#validateUrl', () => {
     it('should verify not-a-real-url to be an invalid url', () => {
-      let url: string = 'htt:/not-a-real-url.some-thing.';
-      component.url = url;
-      component.validateUrl();
-      expect(component.urlInvalid).toBeTruthy();
+      let urls: string[] = ['not-a-real-url', 'http://', '.com', 'htt:/not-a-real-url.some-thing.'];
+      urls.forEach(url => {
+        component.url = url;
+        component.validateUrl();
+        expect(component.urlInvalid).toBeTruthy();
+      });
     });
 
     it('should verify https://fabric8.io/ to be a valid url', () => {

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -318,13 +318,6 @@ export class UpdateComponent implements AfterViewInit, OnInit {
   }
 
   /**
-   * Validate image URL
-   */
-  validateImageUrl(): void {
-    this.imageUrlInvalid = !this.isImageUrlValid();
-  }
-
-  /**
    * Validate URL
    */
   validateUrl(): void {
@@ -359,10 +352,10 @@ export class UpdateComponent implements AfterViewInit, OnInit {
     if (profile) {
       delete profile['registrationCompleted'];
     }
-    if (this.bio !== undefined && this.bio.length > 0) {
+    if (this.bio !== undefined) {
       profile.bio = this.bio.trim().substring(0, 255);
     }
-    if (this.company !== undefined && this.company.length > 0) {
+    if (this.company !== undefined) {
       profile.company = this.company.trim();
     }
     if (this.email !== undefined && this.email.trim().length > 0) {
@@ -374,7 +367,7 @@ export class UpdateComponent implements AfterViewInit, OnInit {
     if (this.imageUrl !== undefined && this.imageUrl.length > 0) {
       profile.imageURL = this.imageUrl.trim();
     }
-    if (this.url !== undefined && this.url.length > 0) {
+    if (this.url !== undefined) {
       profile.url = this.url.trim();
     }
     if (this.emailPrivate !== undefined) {
@@ -395,26 +388,14 @@ export class UpdateComponent implements AfterViewInit, OnInit {
   }
 
   /**
-   * Helper to test if image URL is valid
-   *
-   * @returns {boolean}
-   */
-  private isImageUrlValid(): boolean {
-    if (this.imageUrl !== undefined && this.imageUrl.trim().length > 0) {
-      return (this.imageUrl.trim().indexOf('http') === 0);
-    } else {
-      return true;
-    }
-  }
-
-  /**
    * Helper to test if URL is valid
    *
    * @returns {boolean}
    */
   private isUrlValid(): boolean {
+    const urlRegex: RegExp = /^(https?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/;
     if (this.url !== undefined && this.url.trim().length > 0) {
-      return (this.url.trim().indexOf('http') === 0);
+      return urlRegex.test(this.url.trim());
     } else {
       return true;
     }


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3708
Fixes https://github.com/openshiftio/openshift.io/issues/3701
Fixes https://github.com/fabric8-services/fabric8-auth/issues/508
Fixes https://github.com/fabric8-services/fabric8-auth/issues/509

Fixes a few validations in profile update page.
- Profile Bio cannot be removed or set to empty string.
- Company name cannot be removed.
- URL cannot be removed.
- URL validation is not working correctly. For example i can update URL to http:// and it gets updated.
- Also, removed imageUrlValidation since we don't take user input for that in new design.