### PR TITLE
fix(deployments): adjust layout of placeholders when loading for smal…

### DIFF
--- a/src/app/space/create/deployments/apps/deployments-apps.component.html
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.html
@@ -41,7 +41,7 @@
 
     <div class="cards-pf">
       <div class="row row-cards-pf">
-        <div class="spacer col-xs-12 col-sm-4 col-md-2">&nbsp;</div>
+        <div class="spacer col-xs-12 col-sm-3 col-md-2">&nbsp;</div>
         <div class="filler col-xs-12 col-sm-4 col-md-3">&nbsp;</div>
         <div class="filler col-xs-12 col-sm-4 col-md-3">&nbsp;</div>
       </div>
@@ -50,7 +50,7 @@
     <div class="cards-pf">
       <div *ngFor="let number of [0,1,2,3]">
         <div class="row row-cards-pf">
-          <div class="filler col-xs-12 col-sm-4 col-md-2">&nbsp;</div>
+          <div class="filler col-xs-12 col-sm-3 col-md-2">&nbsp;</div>
           <div class="filler col-xs-12 col-sm-4 col-md-3"><br><br><br></div>
           <div class="filler col-xs-12 col-sm-4 col-md-3"><br><br><br></div>
         </div>


### PR DESCRIPTION
…l screen sizes

This PR addresses [issue 3735](https://github.com/openshiftio/openshift.io/issues/3735) [0], in which the loading page for the deployments page has a distorted layout when viewing with a small screen size. 

Here are some images of the before & after of this PR:

Before:
![before](https://user-images.githubusercontent.com/10425301/40924310-ef01737e-67e4-11e8-81ad-0fbf4dcadaa1.png)

After:
![after](https://user-images.githubusercontent.com/10425301/40924312-ef3a4ce4-67e4-11e8-9fb1-a2af0ebf3b95.png)

[0] https://github.com/openshiftio/openshift.io/issues/3735
