### PR TITLE
fix(areas): introduce error notifications for area names greater than…

### DIFF
--- a/src/app/models/area-error.ts
+++ b/src/app/models/area-error.ts
@@ -1,5 +1,0 @@
-export interface AreaError {
-  uniqueValidationFailure: boolean;
-  emptyNameFailure: boolean;
-  exceedLengthFailure: boolean;
-}

--- a/src/app/models/area-error.ts
+++ b/src/app/models/area-error.ts
@@ -1,3 +1,5 @@
 export interface AreaError {
-    uniqueValidationFailure: boolean;
+  uniqueValidationFailure: boolean;
+  emptyNameFailure: boolean;
+  exceedLengthFailure: boolean;
 }

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
@@ -11,15 +11,20 @@
           <span class="pficon pficon-error-circle-o"></span>
           <b>Unique Name</b> A unique name is required to add a new area.
         </div>
-        <div [hidden]="!(inputModel.hasError('required')) || inputModel.pristine" class="alert alert-danger">
+        <div [hidden]="!errors.exceedLengthFailure" class="alert alert-danger">
+          <span class="pficon pficon-error-circle-o"></span>
+          <b>Name Too Long</b> A name must not exceed 63 characters.
+        </div>
+        <div [hidden]="!errors.emptyNameFailure" class="alert alert-danger">
           <span class="pficon pficon-error-circle-o"></span>
           <b>Missing name</b> A name is required to add a new area.
         </div>
-        <div class="form-group" [ngClass]="{'has-error': errors.uniqueValidationFailure || !inputModel.pristine && !inputModel.valid}">
+        <div class="form-group" [ngClass]="{'has-error': errors.uniqueValidationFailure || errors.exceedLengthFailure || errors.emptyNameFailure || !inputModel.pristine && !inputModel.valid}">
           <label for="name" class="control-label">Name</label>
-          <input #rawInputField #inputModel="ngModel" id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" required />
+          <input #rawInputField #inputModel="ngModel" id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" (keyup)="validateAreaName()" required />
           <small [hidden]="!errors.uniqueValidationFailure">Please choose a unique name.</small>
-          <small [hidden]="!(inputModel.hasError('required')) || inputModel.pristine">Please enter a name.</small>
+          <small [hidden]="!errors.exceedLengthFailure">Please choose a name under 63 characters.</small>
+          <small [hidden]="!errors.emptyNameFailure">Please enter a name.</small>
         </div>
         <div class="form-group">
           <label class="control-label">Parent area</label>
@@ -32,7 +37,7 @@
     <div class="modal-footer">
       <div class="create-footer">
         <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
-        <button class="btn btn-primary" [disabled]="!areaForm.form.valid" type="submit">Create</button>
+        <button class="btn btn-primary" [disabled]="!areaForm.form.valid || errors.exceedLengthFailure || errors.emptyNameFailure" type="submit">Create</button>
       </div>
     </div>
   </form>

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.html
@@ -7,24 +7,28 @@
   <form role="form" #areaForm="ngForm" (ngSubmit)="createArea()" novalidate>
     <div class="form">
       <fieldset class="create-fieldset">
-        <div [hidden]="!errors.uniqueValidationFailure" class="alert alert-danger">
-          <span class="pficon pficon-error-circle-o"></span>
-          <b>Unique Name</b> A unique name is required to add a new area.
+        <div [ngSwitch]="areaCreationStatus">
+          <div *ngSwitchCase="AreaCreationStatus.UNIQUE_VALIDATION_FAILURE" class="alert alert-danger">
+            <span class="pficon pficon-error-circle-o"></span>
+            <b>Unique Name</b> A unique name is required to add a new area.
+          </div>
+          <div *ngSwitchCase="AreaCreationStatus.EXCEED_LENGTH_FAILURE" class="alert alert-danger">
+            <span class="pficon pficon-error-circle-o"></span>
+            <b>Name Too Long</b> A name must not exceed 63 characters.
+          </div>
+          <div *ngSwitchCase="AreaCreationStatus.EMPTY_NAME_FAILURE" class="alert alert-danger">
+            <span class="pficon pficon-error-circle-o"></span>
+            <b>Missing name</b> A name is required to add a new area.
+          </div>
         </div>
-        <div [hidden]="!errors.exceedLengthFailure" class="alert alert-danger">
-          <span class="pficon pficon-error-circle-o"></span>
-          <b>Name Too Long</b> A name must not exceed 63 characters.
-        </div>
-        <div [hidden]="!errors.emptyNameFailure" class="alert alert-danger">
-          <span class="pficon pficon-error-circle-o"></span>
-          <b>Missing name</b> A name is required to add a new area.
-        </div>
-        <div class="form-group" [ngClass]="{'has-error': errors.uniqueValidationFailure || errors.exceedLengthFailure || errors.emptyNameFailure || !inputModel.pristine && !inputModel.valid}">
+        <div class="form-group" [ngClass]="{'has-error': areaCreationStatus !== AreaCreationStatus.OK || !inputModel.pristine && !inputModel.valid}">
           <label for="name" class="control-label">Name</label>
           <input #rawInputField #inputModel="ngModel" id="name" name="name" type="text" class="form-control" placeholder="Enter a name for your area" [(ngModel)]="name" (keyup)="validateAreaName()" required />
-          <small [hidden]="!errors.uniqueValidationFailure">Please choose a unique name.</small>
-          <small [hidden]="!errors.exceedLengthFailure">Please choose a name under 63 characters.</small>
-          <small [hidden]="!errors.emptyNameFailure">Please enter a name.</small>
+          <div [ngSwitch]="areaCreationStatus">
+            <small *ngSwitchCase="AreaCreationStatus.UNIQUE_VALIDATION_FAILURE">Please choose a unique name.</small>
+            <small *ngSwitchCase="AreaCreationStatus.EXCEED_LENGTH_FAILURE">Please choose a name under 63 characters.</small>
+            <small *ngSwitchCase="AreaCreationStatus.EMPTY_NAME_FAILURE">Please enter a name.</small>
+          </div>
         </div>
         <div class="form-group">
           <label class="control-label">Parent area</label>
@@ -37,7 +41,7 @@
     <div class="modal-footer">
       <div class="create-footer">
         <button class="btn btn-default margin-right-5" type="button" (click)="cancel()">Cancel</button>
-        <button class="btn btn-primary" [disabled]="!areaForm.form.valid || errors.exceedLengthFailure || errors.emptyNameFailure" type="submit">Create</button>
+        <button class="btn btn-primary" [disabled]="!areaForm.form.valid || areaCreationStatus !== AreaCreationStatus.OK" type="submit">Create</button>
       </div>
     </div>
   </form>

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.spec.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { NgForm, NgModel } from '@angular/forms';
 import { Area, AreaService } from 'ngx-fabric8-wit';
 import { Observable } from 'rxjs/Observable';
 import { initContext, TestContext } from 'testing/test-context';
-import { CreateAreaDialogComponent } from './create-area-dialog.component';
+import { AreaCreationStatus, CreateAreaDialogComponent } from './create-area-dialog.component';
 
 @Component({
   template: '<create-area-dialog></create-area-dialog>'
@@ -29,63 +29,53 @@ describe('CreateAreaDialogComponent', () => {
   });
 
   describe('#validateAreaName', () => {
-    it('should reset the current error states when called', function(this: Context) {
+    it('should reset the current error state when called', function(this: Context) {
       spyOn(this.testedDirective, 'resetErrors');
       this.testedDirective.name = 'mock-name';
       this.testedDirective.validateAreaName();
       expect(this.testedDirective.resetErrors).toHaveBeenCalled();
     });
 
-    it('should not set any error booleans to true if the name is valid', function(this: Context) {
+    it('should not set an error state if the name is valid', function(this: Context) {
       spyOn(this.testedDirective, 'handleError');
       this.testedDirective.host = jasmine.createSpyObj('ModalDirective', ['hide']);
       this.testedDirective.name = 'mock-name';
       this.testedDirective.validateAreaName();
       this.testedDirective.createArea();
-      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
-      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
-      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+      expect(this.testedDirective.areaCreationStatus).toEqual(AreaCreationStatus.OK);
       expect(this.testedDirective.handleError).toHaveBeenCalledTimes(0);
     });
 
-    it('should set the emptyNameFailure to true if the name is an empty string', function(this: Context) {
+    it('should set the areaCreationStatus to EMPTY_NAME_FAILURE if the name is an empty string', function(this: Context) {
       this.testedDirective.name = ' ';
       this.testedDirective.validateAreaName();
-      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
-      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
-      expect(this.testedDirective.errors.emptyNameFailure).toBeTruthy();
+      expect(this.testedDirective.areaCreationStatus).toEqual(AreaCreationStatus.EMPTY_NAME_FAILURE);
     });
 
-    it('should set the exceedLengthFailure to true if the name is longer than 63 chars', function(this: Context) {
+    it('should set the areaCreationStatus to EXCEED_LENGTH_FAILURE if the name is longer than 63 chars', function(this: Context) {
       this.testedDirective.name = 'thisisanareanamethatisprettylongitsactuallymorethan63characters!';
       this.testedDirective.validateAreaName();
-      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
-      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
-      expect(this.testedDirective.errors.exceedLengthFailure).toBeTruthy();
+      expect(this.testedDirective.areaCreationStatus).toEqual(AreaCreationStatus.EXCEED_LENGTH_FAILURE);
     });
   });
 
   describe('#handleError', () => {
-    it('should set the uniqueValidationFailure to true if a 409 error is recorded', function(this: Context) {
+    it('should set the areaCreationStatus to UNIQUE_VALIDATION_FAILURE if a 409 error is recorded', function(this: Context) {
       let error: any = {
         errors: [{
           status: '409'
         }]
       };
       this.testedDirective.handleError(error);
-      expect(this.testedDirective.errors.uniqueValidationFailure).toBeTruthy();
-      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
-      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+      expect(this.testedDirective.areaCreationStatus).toEqual(AreaCreationStatus.UNIQUE_VALIDATION_FAILURE);
     });
 
-    it('should set the uniqueValidationFailure to false if there are no errors', function(this: Context) {
+    it('should set the areaCreationStatus to OK if there are no errors', function(this: Context) {
       let error: any = {
         errors: []
       };
       this.testedDirective.handleError(error);
-      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
-      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
-      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+      expect(this.testedDirective.areaCreationStatus).toEqual(AreaCreationStatus.OK);
     });
   });
 

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.spec.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.spec.ts
@@ -1,0 +1,92 @@
+import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NgForm, NgModel } from '@angular/forms';
+import { Area, AreaService } from 'ngx-fabric8-wit';
+import { Observable } from 'rxjs/Observable';
+import { initContext, TestContext } from 'testing/test-context';
+import { CreateAreaDialogComponent } from './create-area-dialog.component';
+
+@Component({
+  template: '<create-area-dialog></create-area-dialog>'
+})
+class HostComponent {}
+
+describe('CreateAreaDialogComponent', () => {
+  type Context = TestContext<CreateAreaDialogComponent, HostComponent>;
+  let mockAreaService: jasmine.SpyObj<AreaService> = jasmine.createSpyObj('AreaService', ['create']);
+  mockAreaService.create.and.returnValue(Observable.of({
+    id: 'mock-id',
+    attributes: {
+      name: 'mock-name'
+    }
+  } as Area));
+
+  initContext(CreateAreaDialogComponent, HostComponent, {
+    declarations: [NgForm, NgModel],
+    providers: [
+      { provide: AreaService, useValue: mockAreaService}
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
+
+  describe('#validateAreaName', () => {
+    it('should reset the current error states when called', function(this: Context) {
+      spyOn(this.testedDirective, 'resetErrors');
+      this.testedDirective.name = 'mock-name';
+      this.testedDirective.validateAreaName();
+      expect(this.testedDirective.resetErrors).toHaveBeenCalled();
+    });
+
+    it('should not set any error booleans to true if the name is valid', function(this: Context) {
+      spyOn(this.testedDirective, 'handleError');
+      this.testedDirective.host = jasmine.createSpyObj('ModalDirective', ['hide']);
+      this.testedDirective.name = 'mock-name';
+      this.testedDirective.validateAreaName();
+      this.testedDirective.createArea();
+      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
+      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
+      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+      expect(this.testedDirective.handleError).toHaveBeenCalledTimes(0);
+    });
+
+    it('should set the emptyNameFailure to true if the name is an empty string', function(this: Context) {
+      this.testedDirective.name = ' ';
+      this.testedDirective.validateAreaName();
+      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
+      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
+      expect(this.testedDirective.errors.emptyNameFailure).toBeTruthy();
+    });
+
+    it('should set the exceedLengthFailure to true if the name is longer than 63 chars', function(this: Context) {
+      this.testedDirective.name = 'thisisanareanamethatisprettylongitsactuallymorethan63characters!';
+      this.testedDirective.validateAreaName();
+      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
+      expect(this.testedDirective.errors.exceedLengthFailure).toBeTruthy();
+    });
+  });
+
+  describe('#handleError', () => {
+    it('should set the uniqueValidationFailure to true if a 409 error is recorded', function(this: Context) {
+      let error: any = {
+        errors: [{
+          status: '409'
+        }]
+      };
+      this.testedDirective.handleError(error);
+      expect(this.testedDirective.errors.uniqueValidationFailure).toBeTruthy();
+      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
+      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+    });
+
+    it('should set the uniqueValidationFailure to false if there are no errors', function(this: Context) {
+      let error: any = {
+        errors: []
+      };
+      this.testedDirective.handleError(error);
+      expect(this.testedDirective.errors.uniqueValidationFailure).toBeFalsy();
+      expect(this.testedDirective.errors.exceedLengthFailure).toBeFalsy();
+      expect(this.testedDirective.errors.emptyNameFailure).toBeFalsy();
+    });
+  });
+
+});

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -51,7 +51,7 @@ export class CreateAreaDialogComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.errors = {uniqueValidationFailure: false};
+    this.resetErrors();
   }
 
   clearField() {
@@ -59,13 +59,27 @@ export class CreateAreaDialogComponent implements OnInit {
   }
 
   resetErrors() {
-    this.errors = {uniqueValidationFailure: false};
+    this.errors = {
+      uniqueValidationFailure: false,
+      emptyNameFailure: false,
+      exceedLengthFailure: false
+    };
+  }
+
+  validateAreaName(): void {
+    this.resetErrors();
+    if (this.name.trim().length === 0) {
+      this.errors.emptyNameFailure = true;
+    }
+    if (this.name.trim().length > 63) {
+      this.errors.exceedLengthFailure = true;
+    }
   }
 
   createArea() {
     let area = {} as Area;
     area.attributes = new AreaAttributes();
-    area.attributes.name = this.name;
+    area.attributes.name = this.name.trim();
     area.type = 'areas';
     this.areaService.create(this.parentId, area).subscribe(newArea => {
       this.onAdded.emit(newArea);

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -26,8 +26,8 @@ export class CreateAreaDialogComponent implements OnInit {
   @ViewChild('rawInputField') rawInputField: ElementRef;
   @ViewChild('inputModel') inputModel: NgModel;
 
-  private name: string;
-  private errors: AreaError;
+  name: string;
+  errors: AreaError;
 
   constructor(
     private areaService: AreaService) {

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -4,7 +4,12 @@ import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Area, AreaAttributes, AreaService } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
 
-import { AreaError } from '../../../../models/area-error';
+export enum AreaCreationStatus {
+  OK,
+  EMPTY_NAME_FAILURE,
+  EXCEED_LENGTH_FAILURE,
+  UNIQUE_VALIDATION_FAILURE
+}
 
 @Component({
   host: {
@@ -15,6 +20,7 @@ import { AreaError } from '../../../../models/area-error';
   templateUrl: './create-area-dialog.component.html',
   styleUrls: ['./create-area-dialog.component.less']
 })
+
 export class CreateAreaDialogComponent implements OnInit {
 
   @Input() host: ModalDirective;
@@ -26,8 +32,11 @@ export class CreateAreaDialogComponent implements OnInit {
   @ViewChild('rawInputField') rawInputField: ElementRef;
   @ViewChild('inputModel') inputModel: NgModel;
 
+  // Declare the enum for usage in the template
+  AreaCreationStatus: typeof AreaCreationStatus = AreaCreationStatus;
+
   name: string;
-  errors: AreaError;
+  private _areaCreationStatus: AreaCreationStatus;
 
   constructor(
     private areaService: AreaService) {
@@ -55,20 +64,16 @@ export class CreateAreaDialogComponent implements OnInit {
   }
 
   resetErrors() {
-    this.errors = {
-      uniqueValidationFailure: false,
-      emptyNameFailure: false,
-      exceedLengthFailure: false
-    };
+    this._areaCreationStatus = AreaCreationStatus.OK;
   }
 
   validateAreaName(): void {
     this.resetErrors();
     if (this.name.trim().length === 0) {
-      this.errors.emptyNameFailure = true;
+      this._areaCreationStatus = AreaCreationStatus.EMPTY_NAME_FAILURE;
     }
     if (this.name.trim().length > 63) {
-      this.errors.exceedLengthFailure = true;
+      this._areaCreationStatus = AreaCreationStatus.EXCEED_LENGTH_FAILURE;
     }
   }
 
@@ -102,9 +107,14 @@ export class CreateAreaDialogComponent implements OnInit {
     if (error.errors.length) {
       error.errors.forEach(error => {
         if (error.status === '409') {
-          this.errors.uniqueValidationFailure = true;
+          this._areaCreationStatus = AreaCreationStatus.UNIQUE_VALIDATION_FAILURE;
         }
       });
     }
   }
+
+  get areaCreationStatus(): AreaCreationStatus {
+    return this._areaCreationStatus;
+  }
+
 }

--- a/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
+++ b/src/app/space/settings/areas/create-area-dialog/create-area-dialog.component.ts
@@ -1,11 +1,10 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { NgForm, NgModel } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap/modal';
-import { Area, AreaAttributes, AreaService, Context } from 'ngx-fabric8-wit';
+import { Area, AreaAttributes, AreaService } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
 
 import { AreaError } from '../../../../models/area-error';
-import { ContextService } from '../../../../shared/context.service';
 
 @Component({
   host: {
@@ -27,14 +26,11 @@ export class CreateAreaDialogComponent implements OnInit {
   @ViewChild('rawInputField') rawInputField: ElementRef;
   @ViewChild('inputModel') inputModel: NgModel;
 
-  private context: Context;
   private name: string;
   private errors: AreaError;
 
   constructor(
-    private contexts: ContextService,
     private areaService: AreaService) {
-    this.contexts.current.subscribe(val => this.context = val);
   }
 
   public onOpen() {


### PR DESCRIPTION
… 63 characters or empty area name values

This PR addresses two issues regarding the create area dialog whereby the user doesn't receive an error notification when trying to create an area name greater than 63 characters [[0]](https://github.com/openshiftio/openshift.io/issues/2645), or the user can create an area name with an empty string [[1]](https://github.com/openshiftio/openshift.io/issues/2740).

Example: The area name contains the letter 'a' more than 63 times in a row, so the dialog should tell me that my area name is invalid for exceeding 63 characters. This fixes [issue 2645](https://github.com/openshiftio/openshift.io/issues/2645) [0]
![exceed-name](https://user-images.githubusercontent.com/10425301/40939787-ba55eb12-6813-11e8-897a-5b596a77010c.png)


Example: The area name I entered here was ' ', so the dialog should tell me that my area name is invalid for not having a name. This fixes [issue 2740](https://github.com/openshiftio/openshift.io/issues/2740) [1]
![empty-name](https://user-images.githubusercontent.com/10425301/40939788-ba656f2e-6813-11e8-9ce7-a6611eafdade.png)

[0] https://github.com/openshiftio/openshift.io/issues/2645
[1] https://github.com/openshiftio/openshift.io/issues/2740