### PR TITLE
Tslint fixes

### DIFF
--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts
@@ -208,40 +208,40 @@ describe('ApplicationsWidgetComponent', () => {
   });
 
   describe('Applications widget with build configs', () => {
-    it('Build configs should be available', function (this: TestingContext) {
+    it('Build configs should be available', function(this: TestingContext) {
       expect(this.testedDirective.buildConfigsAvailable).toBeTruthy();
     });
 
-    it('Build configs should be set', function (this: TestingContext) {
+    it('Build configs should be set', function(this: TestingContext) {
       expect(this.testedDirective.buildConfigs as any[]).toContain(buildConfig1);
       expect(this.testedDirective.buildConfigs as any[]).toContain(buildConfig2);
       expect(this.testedDirective.buildConfigs as any[]).toContain(buildConfig3);
     });
 
-    it('Stage build configs should be set', function (this: TestingContext) {
+    it('Stage build configs should be set', function(this: TestingContext) {
       expect(this.testedDirective.stageBuildConfigs as any[]).toContain(buildConfig1);
       expect(this.testedDirective.stageBuildConfigs as any[]).toContain(buildConfig2);
       expect(this.testedDirective.stageBuildConfigs as any[]).toContain(buildConfig3);
     });
 
-    it('Run build configs should be set', function (this: TestingContext) {
+    it('Run build configs should be set', function(this: TestingContext) {
       expect(this.testedDirective.runBuildConfigs as any[]).toContain(buildConfig1);
       expect(this.testedDirective.runBuildConfigs as any[]).not.toContain(buildConfig2);
       expect(this.testedDirective.runBuildConfigs as any[]).toContain(buildConfig3);
     });
 
-    it('Stage build configs to be sorted', function (this: TestingContext) {
+    it('Stage build configs to be sorted', function(this: TestingContext) {
       expect(this.testedDirective.stageBuildConfigs as any[]).toEqual([buildConfig1, buildConfig3, buildConfig2]);
     });
 
-    it('Run build configs to be sorted', function (this: TestingContext) {
+    it('Run build configs to be sorted', function(this: TestingContext) {
       expect(this.testedDirective.runBuildConfigs as any[]).toEqual([buildConfig1, buildConfig3]);
     });
   });
 
   describe('Applications widget without build configs', () => {
 
-    it('should enable buttons if the user owns the space', function (this: TestingContext) {
+    it('should enable buttons if the user owns the space', function(this: TestingContext) {
       this.hostComponent.userOwnsSpace = true;
       this.testedDirective.runBuildConfigs.length = 0;
       this.testedDirective.stageBuildConfigs.length = 0;
@@ -250,7 +250,7 @@ describe('ApplicationsWidgetComponent', () => {
       expect(this.fixture.debugElement.query(By.css('#spacehome-applications-add-button'))).not.toBeNull();
     });
 
-    it('should disable buttons if the user does not own the space', function (this: TestingContext) {
+    it('should disable buttons if the user does not own the space', function(this: TestingContext) {
       this.hostComponent.userOwnsSpace = false;
       this.testedDirective.runBuildConfigs.length = 0;
       this.testedDirective.stageBuildConfigs.length = 0;

--- a/src/app/feature-flag/resolver/feature-flag.resolver.spec.ts
+++ b/src/app/feature-flag/resolver/feature-flag.resolver.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { Logger } from 'ngx-base';
-import {AuthenticationService, UserService} from 'ngx-login-client';
-import { Feature, FeatureTogglesService } from '../service/feature-toggles.service';
-
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
+
+import { Logger } from 'ngx-base';
+import { AuthenticationService, UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs';
+
 import { FeatureFlagConfig } from '../../models/feature-flag-config';
+import { Feature, FeatureTogglesService } from '../service/feature-toggles.service';
 import { FeatureFlagResolver } from './feature-flag.resolver';
 
 describe('FeatureFlag resolver: it', () => {

--- a/src/app/shared/owner-guard.service.spec.ts
+++ b/src/app/shared/owner-guard.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
-import { AuthenticationService } from 'ngx-login-client';
 import { cloneDeep } from 'lodash';
+import { AuthenticationService } from 'ngx-login-client';
+
 import { ContextService } from './context.service';
 import { LoginService } from './login.service';
 import { OwnerGuard } from './owner-guard.service';

--- a/src/app/space/app-launcher/services/app-launcher-mission-runtime.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-mission-runtime.service.spec.ts
@@ -8,9 +8,9 @@ import {
 import { MockBackend } from '@angular/http/testing';
 
 import {
+  Catalog,
   Config,
   HelperService,
-  Catalog,
   TokenProvider
 } from 'ngx-forge';
 
@@ -42,7 +42,7 @@ function fakeCatlog(): Catalog {
       name: 'CRUD',
       description: 'nice crud thing',
       metadata: {
-        level: "foundational"
+        level: 'foundational'
       }
     },
     {
@@ -55,12 +55,12 @@ function fakeCatlog(): Catalog {
       name: 'Eclipse Vert.x',
       icon: "data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 280'%3E%3Cpath fill='%23022B37' d='M107 170.8L67.7 72H46.9L100 204h13.9L167 72h-20.4zm64 33.2h80v-20h-61v-37h60v-19h-60V91h61V72h-80zm180.1-90.7c0-21-14.4-42.3-43.1-42.3h-48v133h19V91h29.1c16.1 0 24 11.1 24 22.4 0 11.5-7.9 22.6-24 22.6H286v9.6l48 58.4h24.7L317 154c22.6-4 34.1-22 34.1-40.7m56.4 90.7v-1c0-6 1.7-11.7 4.5-16.6V91h39V71h-99v20h41v113h14.5z'/%3E%3Cpath fill='%23623C94' d='M458 203c0-9.9-8.1-18-18-18s-18 8.1-18 18 8.1 18 18 18 18-8.1 18-18M577.4 72h-23.2l-27.5 37.8L499.1 72h-40.4c12.1 16 33.6 46.8 47.8 66.3l-37 50.9c2 4.2 3.1 8.9 3.1 13.8v1H499l95.2-132h-16.8zm-19.7 81.5l-20.1 27.9 16.5 22.6h40.2c-9.6-13.7-24-33.3-36.6-50.5z'/%3E%3C/svg%3E",
       metadata: {
-        pipelinePlatform: "maven"
+        pipelinePlatform: 'maven'
       },
       versions: [
         {
-          "id": "redhat",
-          "name": "3.5.1.redhat-003 (RHOAR)"
+          'id': 'redhat',
+          'name': '3.5.1.redhat-003 (RHOAR)'
         }
       ]
     }],
@@ -72,11 +72,11 @@ function fakeCatlog(): Catalog {
             }
           }
         },
-        mission: "health-check",
-        name: "WildFly Swarm - Health Checks",
-        description: "Demonstrates Health Checks in Wildfly Swarm",
-        runtime: "wildfly-swarm",
-        version: "community"
+        mission: 'health-check',
+        name: 'WildFly Swarm - Health Checks',
+        description: 'Demonstrates Health Checks in Wildfly Swarm',
+        runtime: 'wildfly-swarm',
+        version: 'community'
       }
     ]
   };


### PR DESCRIPTION
This PR fixes the linting issues shown below.

```
fabric8-ui> npm run lint

> fabric8-ui@0.0.0-development lint fabric8-ui
> find src -name '*.ts' | xargs tslint -p . -c tslint.json --force


ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[211, 53]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[215, 47]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[221, 53]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[227, 51]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[233, 52]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[237, 50]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[244, 68]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/dashboard-widgets/applications-widget/applications-widget.component.spec.ts[253, 77]: Spaces before function parens are disallowed
ERROR:fabric8-ui/src/app/feature-flag/resolver/feature-flag.resolver.spec.ts[3, 9]: missing whitespace
ERROR:fabric8-ui/src/app/feature-flag/resolver/feature-flag.resolver.spec.ts[3, 43]: missing whitespace
ERROR:fabric8-ui/src/app/shared/owner-guard.service.spec.ts[5, 1]: Import sources within a group must be alphabetized.
```