### PR TITLE
fix(analyze-overview): correctly hide create app button

### DIFF
--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -2,10 +2,10 @@
   <div id="analyze-overview-dashboard" class="container-fluid analyze-overview-wrapper" user-level>
     <div class="row f8-dashboard-masthead">
       <div class="col-sm-10">
-        <fabric8-edit-space-description-widget [userOwnsSpace]='userOwnsSpace()'></fabric8-edit-space-description-widget>
+        <fabric8-edit-space-description-widget [userOwnsSpace]='userOwnsSpace'></fabric8-edit-space-description-widget>
       </div>
       <div class="col-sm-2">
-        <div *ngIf="userOwnsSpace()">
+        <div *ngIf="userOwnsSpace">
           <button *ngIf="this.authentication.isLoggedIn()" id="user-level-analyze-overview-dashboard-create-space-button" class="btn btn-primary btn-lg f8-dashboard-masthead-create-application pull-right"
             (click)="showAddAppOverlay()"> Create an Application </button>
         </div>
@@ -14,17 +14,17 @@
     <div class="cards-pf">
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-md-4">
-          <fabric8-work-item-widget [userOwnsSpace]="userOwnsSpace()"></fabric8-work-item-widget>
+          <fabric8-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-work-item-widget>
         </div>
         <div class="col-xs-12 col-md-8">
-          <fabric8-applications-widget [userOwnsSpace]="userOwnsSpace()" (addToSpace)="showAddAppOverlay()"></fabric8-applications-widget>
+          <fabric8-applications-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-applications-widget>
         </div>
       </div>
     </div>
     <div class="cards-pf">
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-md-4">
-          <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace()" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
+          <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
         </div>
         <div class="col-xs-12 col-md-8">
           <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
@@ -35,10 +35,10 @@
   <div id="analyze-overview" class="container-fluid analyze-overview-wrapper" default-level>
     <div class="row margin-top-15">
       <div class="col-xs-12 col-sm-10">
-        <fabric8-edit-space-description-widget-old [userOwnsSpace]="userOwnsSpace()"></fabric8-edit-space-description-widget-old>
+        <fabric8-edit-space-description-widget-old [userOwnsSpace]="userOwnsSpace"></fabric8-edit-space-description-widget-old>
       </div>
       <div class="col-xs-4 col-xs-offset-4 col-sm-2 col-sm-offset-0">
-        <ng-container *ngIf="userOwnsSpace()">
+        <ng-container *ngIf="userOwnsSpace">
           <button *ngIf="this.authentication.isLoggedIn()" id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right"
             (click)="showAddAppOverlay()"> Add to space </button>
         </ng-container>
@@ -47,7 +47,7 @@
     <div class="cards-pf">
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-md-4">
-          <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace()" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
+          <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
         </div>
         <div class="col-xs-12 col-md-8">
           <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
@@ -57,11 +57,11 @@
     <div class="cards-pf">
       <div class="row row-cards-pf padding-top-0">
         <div class="col-xs-12 col-md-4" *ngIf="myWorkItemsCard">
-          <fabric8-create-work-item-widget [userOwnsSpace]="userOwnsSpace()"></fabric8-create-work-item-widget>
+          <fabric8-create-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-create-work-item-widget>
         </div>
         <div class="col-xs-12"
              [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
-          <fabric8-pipelines-widget [userOwnsSpace]="userOwnsSpace()" (addToSpace)="showAddAppOverlay()"></fabric8-pipelines-widget>
+          <fabric8-pipelines-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-pipelines-widget>
         </div>
         <div class="col-xs-12"
              [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.spec.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.spec.ts
@@ -67,7 +67,7 @@ describe('AnalyzeOverviewComponent', () => {
   });
 
   it('should call to check the user space', function(this: TestingContext) {
-    spyOn(this.testedDirective, 'userOwnsSpace');
+    spyOn(this.testedDirective, 'checkSpaceOwner');
 
     fakeUserObs.next({
       id: 'loggedInUser'
@@ -86,26 +86,26 @@ describe('AnalyzeOverviewComponent', () => {
     } as Context);
 
     this.detectChanges();
-    expect(this.testedDirective.userOwnsSpace).toHaveBeenCalled();
+    expect(this.testedDirective.checkSpaceOwner).toHaveBeenCalled();
   });
 
   it('should disable the button if user service unavailable', function(this: TestingContext) {
     fakeUserObs.next(null as User);
     this.detectChanges();
 
-    expect(this.testedDirective.userOwnsSpace()).toBe(false);
+    expect(this.testedDirective.checkSpaceOwner()).toBe(false);
   });
 
   it('should disable the button if context service unavailable', function(this: TestingContext) {
     this.detectChanges();
-    expect(this.testedDirective.userOwnsSpace()).toBe(false);
+    expect(this.testedDirective.checkSpaceOwner()).toBe(false);
   });
 
   it('should disable the button if both services are unavailable', function(this: TestingContext) {
     fakeUserObs.next(null as User);
     this.detectChanges();
 
-    expect(this.testedDirective.userOwnsSpace()).toBe(false);
+    expect(this.testedDirective.checkSpaceOwner()).toBe(false);
   });
 
   it('should recognize that the user owns the space', function(this: TestingContext) {
@@ -129,9 +129,8 @@ describe('AnalyzeOverviewComponent', () => {
 
     this.detectChanges();
 
-    expect(this.testedDirective.userOwnsSpace()).toBe(true);
+    expect(this.testedDirective.checkSpaceOwner()).toBe(true);
   });
-
 
   it('should recognize that the user does not own the space', function(this: TestingContext) {
     const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
@@ -154,6 +153,54 @@ describe('AnalyzeOverviewComponent', () => {
 
     this.detectChanges();
 
-    expect(this.testedDirective.userOwnsSpace()).toBe(false);
+    expect(this.testedDirective.checkSpaceOwner()).toBe(false);
+  });
+
+  it('should show the Create an Application button if the user owns the space', function(this: TestingContext) {
+    const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
+
+    fakeUserObs.next({
+      id: 'loggedInUser'
+    } as User);
+
+    ctxSubj.next({
+      space: {
+        relationships: {
+          'owned-by': {
+            data: {
+              id: 'loggedInUser'
+            }
+          }
+        }
+      } as Space
+    } as Context);
+
+    this.detectChanges();
+
+    expect(this.fixture.debugElement.query(By.css('#user-level-analyze-overview-dashboard-create-space-button'))).not.toBeNull();
+  });
+
+  it('should hide the Create an Application button if the user does not own the space', function(this: TestingContext) {
+    const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
+
+    fakeUserObs.next({
+      id: 'loggedInUser'
+    } as User);
+
+    ctxSubj.next({
+      space: {
+        relationships: {
+          'owned-by': {
+            data: {
+              id: 'someOtherUser'
+            }
+          }
+        }
+      } as Space
+    } as Context);
+
+    this.detectChanges();
+
+    expect(this.fixture.debugElement.query(By.css('#user-level-analyze-overview-dashboard-create-space-button'))).toBeNull();
   });
 });

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, DoCheck, OnDestroy, OnInit, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { Broadcaster } from 'ngx-base';
 import { Context, Contexts, Space } from 'ngx-fabric8-wit';
@@ -21,6 +21,7 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
   context: Context;
   private space: Space;
   private _myWorkItemsCard: boolean = false;
+  private _userOwnsSpace: boolean = false;
 
   constructor(private authentication: AuthenticationService,
               private broadcaster: Broadcaster,
@@ -43,6 +44,13 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
         this._myWorkItemsCard = true;
       }
     }));
+
+    this._userOwnsSpace = this.checkSpaceOwner();
+  }
+
+  ngDoCheck() {
+    // Must re-evaluate whenever user redirects from one space to another
+    this._userOwnsSpace = this.checkSpaceOwner();
   }
 
   ngOnDestroy() {
@@ -51,12 +59,11 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
     });
   }
 
-
   showAddAppOverlay(): void {
     this.broadcaster.broadcast('showAddAppOverlay', true);
   }
 
-  userOwnsSpace(): boolean {
+  checkSpaceOwner(): boolean {
     if (this.context && this.loggedInUser) {
       return this.context.space.relationships['owned-by'].data.id === this.loggedInUser.id;
     }
@@ -65,5 +72,9 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
 
   get myWorkItemsCard(): boolean {
     return this._myWorkItemsCard;
+  }
+
+  get userOwnsSpace(): boolean {
+    return this._userOwnsSpace;
   }
 }


### PR DESCRIPTION
This patch resolves an issue in which the "create an application" button is mistakenly hidden when users visit their own space. It also introduces a lifecycle hook to ensure that angular re-evaluates whether the button should be shown when navigating immediately from one space to another.

Solves: https://github.com/openshiftio/openshift.io/issues/3702 