### PR TITLE
`WorkItemDetailAddTypeSelectorModule` is Deprecated

### DIFF
--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.module.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 import { NgArrayPipesModule } from 'angular-pipes';
-import { PlannerListModule, WorkItemDetailAddTypeSelectorModule, WorkItemDetailModule } from 'fabric8-planner';
+import { PlannerListModule, WorkItemDetailModule } from 'fabric8-planner';
 import { WidgetsModule } from 'ngx-widgets';
 
 import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
@@ -19,8 +19,7 @@ import { CreateWorkItemWidgetComponent } from './create-work-item-widget.compone
     WidgetsModule,
     PlannerListModule,
     NgArrayPipesModule,
-    WorkItemDetailModule,
-    WorkItemDetailAddTypeSelectorModule
+    WorkItemDetailModule
   ],
   declarations: [CreateWorkItemWidgetComponent],
   exports: [CreateWorkItemWidgetComponent]

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.module.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 import { NgArrayPipesModule } from 'angular-pipes';
-import { PlannerListModule, WorkItemDetailAddTypeSelectorModule, WorkItemDetailModule } from 'fabric8-planner';
+import { PlannerListModule, WorkItemDetailModule } from 'fabric8-planner';
 import { WidgetsModule } from 'ngx-widgets';
 
 import { LoadingWidgetModule } from '../../dashboard-widgets/loading-widget/loading-widget.module';
@@ -23,8 +23,7 @@ import { WorkItemWidgetComponent } from './work-item-widget.component';
     PlannerListModule,
     NgArrayPipesModule,
     WorkItemBarchartModule,
-    WorkItemDetailModule,
-    WorkItemDetailAddTypeSelectorModule
+    WorkItemDetailModule
   ],
   declarations: [WorkItemWidgetComponent],
   exports: [WorkItemWidgetComponent]

--- a/src/app/home/work-item-widget/work-item-widget.module.ts
+++ b/src/app/home/work-item-widget/work-item-widget.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 import { NgArrayPipesModule } from 'angular-pipes';
-import { PlannerListModule, WorkItemDetailAddTypeSelectorModule, WorkItemDetailModule } from 'fabric8-planner';
+import { PlannerListModule, WorkItemDetailModule } from 'fabric8-planner';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { WidgetsModule } from 'ngx-widgets';
 import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
@@ -24,7 +24,6 @@ import { WorkItemWidgetComponent } from './work-item-widget.component';
     NgArrayPipesModule,
     WorkItemWidgetRoutingModule,
     WorkItemDetailModule,
-    WorkItemDetailAddTypeSelectorModule,
     Fabric8WitModule,
     FeatureFlagModule
   ],

--- a/src/app/profile/overview/work-items/work-items.module.ts
+++ b/src/app/profile/overview/work-items/work-items.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 import { NgArrayPipesModule } from 'angular-pipes';
-import { PlannerListModule, WorkItemDetailAddTypeSelectorModule, WorkItemDetailModule } from 'fabric8-planner';
+import { PlannerListModule, WorkItemDetailModule } from 'fabric8-planner';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { WidgetsModule } from 'ngx-widgets';
 
@@ -19,7 +19,6 @@ import { WorkItemsComponent } from './work-items.component';
     PlannerListModule,
     NgArrayPipesModule,
     WorkItemDetailModule,
-    WorkItemDetailAddTypeSelectorModule,
     Fabric8WitModule
   ],
   declarations: [WorkItemsComponent],


### PR DESCRIPTION
What Does this Pr do?
`WorkItemDetailAddTypeSelectorModule` is removed from planner because we don't use this anymore.
