### PR TITLE
fix(launcher): fails properly for continous hyphens or underscores in the application name.

### DIFF
--- a/src/app/space/app-launcher/services/app-launcher-dependency-check.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-dependency-check.service.spec.ts
@@ -91,6 +91,16 @@ describe('Service: AppLauncherDependencyCheckService', () => {
     expect(valProjectName).toBeTruthy();
   });
 
+  it('should return false if the project name has continous hyphens (-)', () => {
+    let valProjectName = appLauncherDependencyCheckService.validateProjectName('app_name--name');
+    expect(valProjectName).toBeFalsy();
+  });
+
+  it('should return false if the project name has continous underscores (_)', () => {
+    let valProjectName = appLauncherDependencyCheckService.validateProjectName('app_name__name');
+    expect(valProjectName).toBeFalsy();
+  });
+
   it('validate Artifact Id to be truthy', () => {
     let valArtifactId = appLauncherDependencyCheckService.validateArtifactId(dependencyCheck.mavenArtifact);
     expect(valArtifactId).toBeTruthy();

--- a/src/app/space/app-launcher/services/app-launcher-dependency-check.service.ts
+++ b/src/app/space/app-launcher/services/app-launcher-dependency-check.service.ts
@@ -43,7 +43,8 @@ export class AppLauncherDependencyCheckService implements DependencyCheckService
    */
   validateProjectName(projectName: string): boolean {
     // allows only '-', '_', ' ' and 4-40 characters (must start and end with alphanumeric)
-    const pattern = /^[a-zA-Z0-9][a-zA-Z0-9-_\s]{2,38}[a-zA-Z0-9]$/;
+    // no continuous '-' or '_' is allowed
+    const pattern = /^[a-zA-Z0-9](?!.*--)(?!.*__)[A-Za-z0-9-_\s]{2,38}[a-zA-Z0-9]$/;
     return pattern.test(projectName);
   }
 


### PR DESCRIPTION
Tracks: https://github.com/openshiftio/openshift.io/issues/2370