### PR TITLE
Refactor environment card resource status

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -134,7 +134,7 @@ describe('DeploymentCardComponent async tests', () => {
     mockSvc = initMockSvc();
     mockSvc.isApplicationDeployedInEnvironment.and.returnValue(active);
     mockStatusSvc = createMock(DeploymentStatusService);
-    mockStatusSvc.getAggregateStatus.and.returnValue(Observable.never());
+    mockStatusSvc.getDeploymentAggregateStatus.and.returnValue(Observable.never());
     notifications = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
 
     TestBed.configureTestingModule({
@@ -248,7 +248,7 @@ describe('DeploymentCardComponent', () => {
     mockSvc.getDeploymentMemoryStat.and.returnValue(mockMemoryData);
     mockSvc.deleteDeployment.and.returnValue(deleting);
     mockStatusSvc = createMock(DeploymentStatusService);
-    mockStatusSvc.getAggregateStatus.and.returnValue(mockStatus);
+    mockStatusSvc.getDeploymentAggregateStatus.and.returnValue(mockStatus);
     notifications = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
 
     flush();
@@ -338,7 +338,7 @@ describe('DeploymentCardComponent', () => {
   }));
 
   it('should set icon status from DeploymentStatusService aggregate', function(this: Context) {
-    expect(mockStatusSvc.getAggregateStatus).toHaveBeenCalledWith('mockSpaceId', 'mockEnvironment', 'mockAppId');
+    expect(mockStatusSvc.getDeploymentAggregateStatus).toHaveBeenCalledWith('mockSpaceId', 'mockEnvironment', 'mockAppId');
     expect(this.testedDirective.toolTip).toEqual('warning message');
     expect(this.testedDirective.iconClass).toEqual('pficon-warning-triangle-o');
     expect(this.testedDirective.cardStatusClass).toEqual('status-ribbon-warn');

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -91,7 +91,7 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
     this.toolTip = DeploymentCardComponent.OK_TOOLTIP;
 
     this.subscriptions.push(
-      this.statusService.getAggregateStatus(this.spaceId, this.environment, this.applicationId)
+      this.statusService.getDeploymentAggregateStatus(this.spaceId, this.environment, this.applicationId)
         .subscribe((status: Status): void => this.changeStatus(status))
     );
 

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -148,9 +148,9 @@ describe('DeploymentDetailsComponent', () => {
 
     status = new BehaviorSubject<Status>({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' });
     mockStatusSvc = createMock(DeploymentStatusService);
-    mockStatusSvc.getAggregateStatus.and.returnValue(status);
-    mockStatusSvc.getCpuStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
-    mockStatusSvc.getMemoryStatus.and.returnValue(Observable.of({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' }));
+    mockStatusSvc.getDeploymentAggregateStatus.and.returnValue(status);
+    mockStatusSvc.getDeploymentCpuStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
+    mockStatusSvc.getDeploymentMemoryStatus.and.returnValue(Observable.of({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' }));
 
     cpuChart = {
       axis: {

--- a/src/app/space/create/deployments/apps/deployment-details.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.ts
@@ -173,7 +173,7 @@ export class DeploymentDetailsComponent {
     );
 
     this.subscriptions.push(
-      this.deploymentStatusService.getAggregateStatus(this.spaceId, this.environment, this.applicationId)
+      this.deploymentStatusService.getDeploymentAggregateStatus(this.spaceId, this.environment, this.applicationId)
         .subscribe((status: Status): void => {
           if (status.type === StatusType.OK) {
             this.usageMessage = '';
@@ -190,7 +190,7 @@ export class DeploymentDetailsComponent {
         if (chart === DeploymentDetailsComponent.NO_CHART) {
           return Observable.empty();
         }
-        return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getCpuStatus(this.spaceId, this.environment, this.applicationId));
+        return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getDeploymentCpuStatus(this.spaceId, this.environment, this.applicationId));
       })
         .subscribe((v: [ChartAPI, Status]): void => {
           const chart: ChartAPI = v[0];
@@ -219,7 +219,7 @@ export class DeploymentDetailsComponent {
         if (chart === DeploymentDetailsComponent.NO_CHART) {
           return Observable.empty();
         }
-        return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getMemoryStatus(this.spaceId, this.environment, this.applicationId));
+        return Observable.combineLatest(Observable.of(chart), this.deploymentStatusService.getDeploymentMemoryStatus(this.spaceId, this.environment, this.applicationId));
       })
         .subscribe((v: [ChartAPI, Status]): void => {
           const chart: ChartAPI = v[0];

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -1,7 +1,17 @@
 <div class="card-pf" *ngIf="environment && spaceId; else loading">
   <div class="card-pf-body resource-card-body">
-    <utilization-bar [resourceTitle]="'CPU'" [resourceUnit]="'Cores'" [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment)"></utilization-bar>
-    <utilization-bar [resourceTitle]="'Memory'" [resourceUnit]="memUnit | async" [stat]="deploymentsService.getEnvironmentMemoryStat(spaceId, environment)"></utilization-bar>
+    <utilization-bar
+      [resourceTitle]="'CPU'"
+      [resourceUnit]="'Cores'"
+      [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment)"
+      [status]="deploymentStatusService.getEnvironmentCpuStatus(spaceId, environment)"
+    ></utilization-bar>
+    <utilization-bar
+      [resourceTitle]="'Memory'"
+      [resourceUnit]="memUnit | async"
+      [stat]="deploymentsService.getEnvironmentMemoryStat(spaceId, environment)"
+      [status]="deploymentStatusService.getEnvironmentMemoryStatus(spaceId, environment)"
+    ></utilization-bar>
   </div>
 </div>
 <ng-template #loading>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -14,6 +14,11 @@ import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
 import { MemoryUnit } from '../models/memory-unit';
 import { Stat } from '../models/stat';
+import {
+  DeploymentStatusService,
+  Status,
+  StatusType
+} from '../services/deployment-status.service';
 import { DeploymentsService } from '../services/deployments.service';
 import { ResourceCardComponent } from './resource-card.component';
 
@@ -30,6 +35,7 @@ class FakeUtilizationBarComponent {
   @Input() resourceTitle: string;
   @Input() resourceUnit: string;
   @Input() stat: Observable<Stat>;
+  @Input() status: Observable<Status>;
 }
 
 @Component({
@@ -47,6 +53,7 @@ describe('ResourceCardComponent', () => {
 
   let mockResourceTitle: string = 'resource title';
   let mockSvc: jasmine.SpyObj<DeploymentsService>;
+  let mockStatusSvc: jasmine.SpyObj<DeploymentStatusService>;
   let cpuStatMock: Observable<CpuStat> = Observable.of({ used: 1, quota: 2 });
   let memoryStatMock: Observable<MemoryStat> = Observable.of({ used: 3, quota: 4, units: 'GB' as MemoryUnit  });
 
@@ -56,12 +63,19 @@ describe('ResourceCardComponent', () => {
     mockSvc.getEnvironments.and.returnValue(Observable.of(['stage', 'prod']));
     mockSvc.getEnvironmentCpuStat.and.returnValue(cpuStatMock);
     mockSvc.getEnvironmentMemoryStat.and.returnValue(memoryStatMock);
+
+    mockStatusSvc = createMock(DeploymentStatusService);
+    mockStatusSvc.getEnvironmentCpuStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
+    mockStatusSvc.getEnvironmentMemoryStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
   });
 
   initContext(ResourceCardComponent, HostComponent,
     {
       declarations: [FakeUtilizationBarComponent, FakeLoadingUtilizationBarComponent],
-      providers: [{ provide: DeploymentsService, useFactory: () => mockSvc }]
+      providers: [
+        { provide: DeploymentsService, useFactory: () => mockSvc },
+        { provide: DeploymentStatusService, useFactory: () => mockStatusSvc }
+      ]
     },
     (component: ResourceCardComponent) => {
       component.spaceId = 'spaceId';

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -7,6 +7,7 @@ import {
 import { Observable } from 'rxjs';
 
 import { MemoryStat } from 'app/space/create/deployments/models/memory-stat';
+import { DeploymentStatusService } from '../services/deployment-status.service';
 import { DeploymentsService } from '../services/deployments.service';
 
 @Component({
@@ -22,7 +23,8 @@ export class ResourceCardComponent implements OnInit {
   memUnit: Observable<string>;
 
   constructor(
-    private deploymentsService: DeploymentsService
+    private deploymentsService: DeploymentsService,
+    private deploymentStatusService: DeploymentStatusService
   ) { }
 
   ngOnInit(): void {

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -8,7 +8,10 @@ import {
 import { Observable, Subscription } from 'rxjs';
 
 import { Stat } from '../models/stat';
-import { DeploymentStatusService } from '../services/deployment-status.service';
+import {
+  Status,
+  StatusType
+} from '../services/deployment-status.service';
 
 @Component({
   selector: 'utilization-bar',
@@ -20,6 +23,7 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   @Input() resourceTitle: string;
   @Input() resourceUnit: string;
   @Input() stat: Observable<Stat>;
+  @Input() status: Observable<Status>;
 
   warn: boolean = false;
 
@@ -28,21 +32,28 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   usedPercent: number;
   unusedPercent: number;
 
-  private statSubscription: Subscription;
+  private readonly subscriptions: Subscription[] = [];
 
   ngOnInit(): void {
-    this.statSubscription = this.stat.subscribe((val: Stat): void => {
-      this.used = val.used;
-      this.total = val.quota;
-      this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
-      this.unusedPercent = 100 - this.usedPercent;
+    this.subscriptions.push(
+      this.stat.subscribe((val: Stat): void => {
+        this.used = val.used;
+        this.total = val.quota;
 
-      this.warn = val.used / val.quota >= DeploymentStatusService.WARNING_THRESHOLD;
-    });
+        this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
+        this.unusedPercent = 100 - this.usedPercent;
+      })
+    );
+
+    this.subscriptions.push(
+      this.status.subscribe((status: Status): void => {
+        this.warn = status.type != StatusType.OK;
+      })
+    );
   }
 
   ngOnDestroy(): void {
-    this.statSubscription.unsubscribe();
+    this.subscriptions.forEach((subscription: Subscription): void => subscription.unsubscribe());
   }
 
 }

--- a/src/app/space/create/deployments/services/deployment-status.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-status.service.spec.ts
@@ -26,20 +26,27 @@ describe('DeploymentStatusService', (): void => {
 
   let svc: DeploymentStatusService;
   let deploymentsService: jasmine.SpyObj<DeploymentsService>;
-  let cpuSubject: Subject<CpuStat[]>;
-  let memorySubject: Subject<MemoryStat[]>;
+  let deploymentCpuSubject: Subject<CpuStat[]>;
+  let deploymentMemorySubject: Subject<MemoryStat[]>;
+  let environmentCpuSubject: Subject<CpuStat>;
+  let environmentMemorySubject: Subject<MemoryStat>;
   let podsSubject: Subject<Pods>;
 
   beforeEach((): void => {
     deploymentsService = createMock(DeploymentsService);
 
-    cpuSubject = new BehaviorSubject<CpuStat[]>([{ used: 3, quota: 10 }]);
-    memorySubject = new BehaviorSubject<MemoryStat[]>([{ used: 4, quota: 10, units: MemoryUnit.GB }]);
+    deploymentCpuSubject = new BehaviorSubject<CpuStat[]>([{ used: 3, quota: 10 }]);
+    deploymentMemorySubject = new BehaviorSubject<MemoryStat[]>([{ used: 4, quota: 10, units: MemoryUnit.GB }]);
     podsSubject = new BehaviorSubject<Pods>({ total: 1, pods: [[PodPhase.RUNNING, 1]] });
 
-    deploymentsService.getDeploymentCpuStat.and.returnValue(cpuSubject);
-    deploymentsService.getDeploymentMemoryStat.and.returnValue(memorySubject);
+    environmentCpuSubject = new BehaviorSubject<CpuStat>({ used: 3, quota: 10 });
+    environmentMemorySubject = new BehaviorSubject<MemoryStat>({ used: 4, quota: 10, units: MemoryUnit.GB });
+
+    deploymentsService.getDeploymentCpuStat.and.returnValue(deploymentCpuSubject);
+    deploymentsService.getDeploymentMemoryStat.and.returnValue(deploymentMemorySubject);
     deploymentsService.getPods.and.returnValue(podsSubject);
+    deploymentsService.getEnvironmentCpuStat.and.returnValue(environmentCpuSubject);
+    deploymentsService.getEnvironmentMemoryStat.and.returnValue(environmentMemorySubject);
 
     svc = new DeploymentStatusService(deploymentsService);
   });
@@ -56,7 +63,7 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should mirror single status when one stat is nearing quota', (done: DoneFn): void => {
-      cpuSubject.next([{ used: 9, quota: 10 }]);
+      deploymentCpuSubject.next([{ used: 9, quota: 10 }]);
       Observable.combineLatest(
         svc.getDeploymentCpuStatus('foo', 'bar', 'baz'),
         svc.getDeploymentAggregateStatus('foo', 'bar', 'baz')
@@ -69,8 +76,8 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return combined status when multiple stats are nearing quota', (done: DoneFn): void => {
-      cpuSubject.next([{ used: 9, quota: 10 }]);
-      memorySubject.next([{ used: 9, quota: 10, units: MemoryUnit.MB }]);
+      deploymentCpuSubject.next([{ used: 9, quota: 10 }]);
+      deploymentMemorySubject.next([{ used: 9, quota: 10, units: MemoryUnit.MB }]);
       svc.getDeploymentAggregateStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
@@ -81,8 +88,8 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return combined status when multiple stats are nearing or at quota', (done: DoneFn): void => {
-      cpuSubject.next([{ used: 9, quota: 10 }]);
-      memorySubject.next([{ used: 10, quota: 10, units: MemoryUnit.MB }]);
+      deploymentCpuSubject.next([{ used: 9, quota: 10 }]);
+      deploymentMemorySubject.next([{ used: 10, quota: 10, units: MemoryUnit.MB }]);
       svc.getDeploymentAggregateStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
@@ -111,7 +118,7 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return WARN status when nearing quota', (done: DoneFn): void => {
-      cpuSubject.next([{ used: 9, quota: 10 }]);
+      deploymentCpuSubject.next([{ used: 9, quota: 10 }]);
       svc.getDeploymentCpuStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
@@ -122,7 +129,7 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return ERR status when at quota', (done: DoneFn): void => {
-      cpuSubject.next([{ used: 10, quota: 10 }]);
+      deploymentCpuSubject.next([{ used: 10, quota: 10 }]);
       svc.getDeploymentCpuStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
@@ -133,14 +140,14 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return OK status after scaling down to 0 pods', (done: DoneFn): void => {
-      cpuSubject.next([{ used: 10, quota: 10 }]);
+      deploymentCpuSubject.next([{ used: 10, quota: 10 }]);
       svc.getDeploymentCpuStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
           expect(status.type).toEqual(StatusType.ERR);
           expect(status.message).toEqual('CPU usage has reached capacity.');
           podsSubject.next({ total: 0, pods: [] });
-          cpuSubject.next([{ used: 0, quota: 0 }]);
+          deploymentCpuSubject.next([{ used: 0, quota: 0 }]);
           svc.getDeploymentCpuStatus('foo', 'bar', 'baz')
             .first()
             .subscribe((status: Status): void => {
@@ -170,7 +177,7 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return WARN status when nearing quota', (done: DoneFn): void => {
-      memorySubject.next([{ used: 9, quota: 10, units: MemoryUnit.MB }]);
+      deploymentMemorySubject.next([{ used: 9, quota: 10, units: MemoryUnit.MB }]);
       svc.getDeploymentMemoryStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
@@ -181,7 +188,7 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return ERR status when at quota', (done: DoneFn): void => {
-      memorySubject.next([{ used: 10, quota: 10, units: MemoryUnit.MB }]);
+      deploymentMemorySubject.next([{ used: 10, quota: 10, units: MemoryUnit.MB }]);
       svc.getDeploymentMemoryStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
@@ -192,14 +199,14 @@ describe('DeploymentStatusService', (): void => {
     });
 
     it('should return OK status after scaling down to 0 pods', (done: DoneFn): void => {
-      memorySubject.next([{ used: 10, quota: 10, units: MemoryUnit.MB }]);
+      deploymentMemorySubject.next([{ used: 10, quota: 10, units: MemoryUnit.MB }]);
       svc.getDeploymentMemoryStatus('foo', 'bar', 'baz')
         .first()
         .subscribe((status: Status): void => {
           expect(status.type).toEqual(StatusType.ERR);
           expect(status.message).toEqual('Memory usage has reached capacity.');
           podsSubject.next({ total: 0, pods: [] });
-          memorySubject.next([{ used: 0, quota: 0, units: MemoryUnit.MB }]);
+          deploymentMemorySubject.next([{ used: 0, quota: 0, units: MemoryUnit.MB }]);
           svc.getDeploymentMemoryStatus('foo', 'bar', 'baz')
             .first()
             .subscribe((status: Status): void => {
@@ -207,6 +214,84 @@ describe('DeploymentStatusService', (): void => {
               expect(status.message).toEqual('');
               done();
             });
+        });
+    });
+  });
+
+  describe('getEnvironmentCpuStatus', (): void => {
+    it('should correctly invoke the deployments service', () => {
+      svc.getEnvironmentCpuStatus(spaceId, environmentName);
+      expect(deploymentsService.getEnvironmentCpuStat).toHaveBeenCalledWith(spaceId, environmentName);
+    });
+
+    it('should return OK status when not nearing quota', (done: DoneFn): void => {
+      svc.getEnvironmentCpuStatus('foo', 'bar')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.OK);
+          expect(status.message).toEqual('');
+          done();
+        });
+    });
+
+    it('should return WARN status when nearing quota', (done: DoneFn): void => {
+      environmentCpuSubject.next({ used: 9, quota: 10 });
+      svc.getEnvironmentCpuStatus('foo', 'bar')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.WARN);
+          expect(status.message).toEqual('CPU usage is nearing capacity.');
+          done();
+        });
+    });
+
+    it('should return ERR status when at quota', (done: DoneFn): void => {
+      environmentCpuSubject.next({ used: 10, quota: 10 });
+      svc.getEnvironmentCpuStatus('foo', 'bar')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.ERR);
+          expect(status.message).toEqual('CPU usage has reached capacity.');
+          done();
+        });
+    });
+  });
+
+  describe('getEnvironmentMemoryStatus', (): void => {
+    it('should correctly invoke the deployments service', () => {
+      svc.getEnvironmentMemoryStatus(spaceId, environmentName);
+      expect(deploymentsService.getEnvironmentMemoryStat).toHaveBeenCalledWith(spaceId, environmentName);
+    });
+
+    it('should return OK status when not nearing quota', (done: DoneFn): void => {
+      svc.getEnvironmentMemoryStatus('foo', 'bar')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.OK);
+          expect(status.message).toEqual('');
+          done();
+        });
+    });
+
+    it('should return WARN status when nearing quota', (done: DoneFn): void => {
+      environmentMemorySubject.next({ used: 9, quota: 10, units: MemoryUnit.GB });
+      svc.getEnvironmentMemoryStatus('foo', 'bar')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.WARN);
+          expect(status.message).toEqual('Memory usage is nearing capacity.');
+          done();
+        });
+    });
+
+    it('should return ERR status when at quota', (done: DoneFn): void => {
+      environmentMemorySubject.next({ used: 10, quota: 10, units: MemoryUnit.GB });
+      svc.getEnvironmentMemoryStatus('foo', 'bar')
+        .first()
+        .subscribe((status: Status): void => {
+          expect(status.type).toEqual(StatusType.ERR);
+          expect(status.message).toEqual('Memory usage has reached capacity.');
+          done();
         });
     });
   });

--- a/src/app/space/create/deployments/services/deployment-status.service.ts
+++ b/src/app/space/create/deployments/services/deployment-status.service.ts
@@ -29,7 +29,7 @@ export class DeploymentStatusService {
 
   constructor(private readonly deploymentsService: DeploymentsService) { }
 
-  getCpuStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
+  getDeploymentCpuStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
     return this.adjustStatusForPods(
       this.deploymentsService.getPods(spaceId, environmentName, applicationName),
       this.deploymentsService.getDeploymentCpuStat(spaceId, environmentName, applicationName, 1)
@@ -37,7 +37,7 @@ export class DeploymentStatusService {
     );
   }
 
-  getMemoryStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
+  getDeploymentMemoryStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
     return this.adjustStatusForPods(
       this.deploymentsService.getPods(spaceId, environmentName, applicationName),
       this.deploymentsService.getDeploymentMemoryStat(spaceId, environmentName, applicationName, 1)
@@ -45,10 +45,10 @@ export class DeploymentStatusService {
     );
   }
 
-  getAggregateStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
+  getDeploymentAggregateStatus(spaceId: string, environmentName: string, applicationName: string): Observable<Status> {
     return Observable.combineLatest(
-      this.getCpuStatus(spaceId, environmentName, applicationName),
-      this.getMemoryStatus(spaceId, environmentName, applicationName)
+      this.getDeploymentCpuStatus(spaceId, environmentName, applicationName),
+      this.getDeploymentMemoryStatus(spaceId, environmentName, applicationName)
     ).map((statuses: [Status, Status]): Status => {
       const type: StatusType = statuses
         .map((status: Status): StatusType => status.type)

--- a/src/app/space/create/deployments/services/deployment-status.service.ts
+++ b/src/app/space/create/deployments/services/deployment-status.service.ts
@@ -23,8 +23,7 @@ export interface Status {
 @Injectable()
 export class DeploymentStatusService {
 
-  static readonly WARNING_THRESHOLD: number = .6;
-
+  private static readonly WARNING_THRESHOLD: number = .6;
   private static readonly OK_STATUS: Status = { type: StatusType.OK, message: '' };
 
   constructor(private readonly deploymentsService: DeploymentsService) { }
@@ -59,6 +58,18 @@ export class DeploymentStatusService {
         .trim();
       return { type, message };
     });
+  }
+
+  getEnvironmentCpuStatus(spaceId: string, environmentName: string): Observable<Status> {
+    return this.deploymentsService
+      .getEnvironmentCpuStat(spaceId, environmentName)
+      .map((stat: CpuStat): Status => this.getStatStatus(stat, 'CPU'));
+  }
+
+  getEnvironmentMemoryStatus(spaceId: string, environmentName: string): Observable<Status> {
+    return this.deploymentsService
+      .getEnvironmentMemoryStat(spaceId, environmentName)
+      .map((stat: MemoryStat): Status => this.getStatStatus(stat, 'Memory'));
   }
 
   private adjustStatusForPods(pods: Observable<Pods>, status: Observable<Status>): Observable<Status> {


### PR DESCRIPTION
This PR refactors some logic out of the resource card/utilization bar components into the DeploymentStatusService. This keeps the component as dumb and presentational as possible, and is also useful in preparation for https://github.com/openshiftio/openshift.io/issues/3128 .