### PR TITLE
fix(app-launcher): disallow starting number and spaces in application name

### DIFF
--- a/src/app/space/add-app-overlay/add-app-overlay.component.html
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.html
@@ -38,8 +38,9 @@
                     <ul>
                       <li>Be Unique</li>
                       <li>Contain 4-40 characters</li>
-                      <li>Contain only letters, numbers, spaces, underscores, or hyphens</li>
-                      <li>Not start or end with spaces, underscores, or hyphens</li>
+                      <li>Contain only letters, numbers, underscores or hyphens</li>
+                      <li>Not start with a number</li>
+                      <li>Not start or end with underscores or hyphens</li>
                     </ul>
                   </ng-template>
                   <span class="code-imports--step_tooltip-label" [popover]="namingTemplate" popoverTitle="Naming Requirements" placement="bottom" triggers="mouseenter:mouseleave">Naming Requirements<span class="pficon pficon-info"></span></span>

--- a/src/app/space/app-launcher/services/app-launcher-dependency-check.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-dependency-check.service.spec.ts
@@ -87,7 +87,7 @@ describe('Service: AppLauncherDependencyCheckService', () => {
   });
 
   it('validate Project Name to be truthy as length is satisfied', () => {
-    let valProjectName = appLauncherDependencyCheckService.validateProjectName('1234567890123456789012345678901234567890');
+    let valProjectName = appLauncherDependencyCheckService.validateProjectName('a123456789012345678901234567890123456789');
     expect(valProjectName).toBeTruthy();
   });
 
@@ -144,6 +144,16 @@ describe('Service: AppLauncherDependencyCheckService', () => {
   it('validate ProjectVersion to be falsy as length is not satisfied', () => {
     let valProjectVersion = appLauncherDependencyCheckService.validateProjectVersion('v.');
     expect(valProjectVersion).toBeFalsy();
+  });
+
+  it('should not allow project name with spaces', () => {
+    let valProjectName = appLauncherDependencyCheckService.validateProjectName('app_name name');
+    expect(valProjectName).toBeFalsy();
+  });
+
+  it('should not allow project name starting with a number', () => {
+    let valProjectName = appLauncherDependencyCheckService.validateProjectName('1app_namename');
+    expect(valProjectName).toBeFalsy();
   });
 
 });

--- a/src/app/space/app-launcher/services/app-launcher-dependency-check.service.ts
+++ b/src/app/space/app-launcher/services/app-launcher-dependency-check.service.ts
@@ -42,9 +42,9 @@ export class AppLauncherDependencyCheckService implements DependencyCheckService
    * @returns boolean
    */
   validateProjectName(projectName: string): boolean {
-    // allows only '-', '_', ' ' and 4-40 characters (must start and end with alphanumeric)
+    // allows only '-', '_' and 4-40 characters (must start with alphabetic and end with alphanumeric)
     // no continuous '-' or '_' is allowed
-    const pattern = /^[a-zA-Z0-9](?!.*--)(?!.*__)[A-Za-z0-9-_\s]{2,38}[a-zA-Z0-9]$/;
+    const pattern = /^[a-zA-Z](?!.*--)(?!.*__)[a-zA-Z0-9-_]{2,38}[a-zA-Z0-9]$/;
     return pattern.test(projectName);
   }
 


### PR DESCRIPTION
This makes the front end restrict application names to also
- not have spaces
- not start with a number

This addresses
- https://github.com/openshiftio/openshift.io/issues/3516
- https://github.com/openshiftio/openshift.io/issues/3781
- https://github.com/openshiftio/openshift.io/issues/3784