### PR TITLE
fix(header): correct gradient and underline in navbars

### DIFF
--- a/src/app/layout/header/header.component.less
+++ b/src/app/layout/header/header.component.less
@@ -71,13 +71,11 @@
   .navbar-primary {
     > .active > a {
       background-color: @color-pf-black-900;
-      background-image: linear-gradient(to bottom, @color-pf-black-700 0, @color-pf-black-900 100%);
-      border-bottom-color: @color-pf-black-300;
+      background-image: linear-gradient(to top, @color-pf-black-700 0, @color-pf-black-900 100%);
     }
     &.persistent-secondary {
-      background-color: @color-pf-black-150;
+      //background-color: @color-pf-black-150;
       > li {
-        background-color: none;
         &.active {
           &.with-no-children { margin-bottom: 0; }
         }

--- a/src/assets/stylesheets/shared/_animations.less
+++ b/src/assets/stylesheets/shared/_animations.less
@@ -27,13 +27,11 @@ a {
 //
 .navbar-pf {
   .navbar-primary>li {
-    background-color: #000;
     transition: all .3s;
     &:hover {
       background-color: #1d1d1d;
     }
     &>a {
-      background-color: #000;
       transition: all .3s;
     }
     &>a:hover {


### PR DESCRIPTION
This small patch corrects the gradient direction and removes a white underline from the selected link of the principle navbar when viewing a space.

Preview: 
![2018-06-15-123447_1920x1080_scrot](https://user-images.githubusercontent.com/17230733/41479248-8e9cc09e-7098-11e8-896c-a4d787e0b62a.png)
