### PR TITLE
fix(edit-space-description): prevent pointer cursor from appearing wh…

### DIFF
--- a/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.less
@@ -8,3 +8,10 @@
     resize: none;
   }
 }
+
+.edit-space-description-span {
+  line-height: 1.5;
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -55,7 +55,7 @@
   &-owner {
     font-size: .9em;
   }
-  &-description {
+  &-description-body {
     &:hover {
       cursor: pointer;
     }


### PR DESCRIPTION
…en hovering description of another user's space

This PR addresses [issue 3790](https://github.com/openshiftio/openshift.io/issues/3790) [0], in which hovering the space description of another user's space will display a pointer instead of the expected cursor. This pointer suggests that the user would be able to perform an action on the description (e.g., edit), but they cannot because the space belongs to another user. 

This PR addresses this by making the pointer cursor only available on the `<p ... edit-space-description-body ... /p>`, which displays if `userOwnsSpace` is true. This will properly display the correct cursor for the experimental/internal feature-opt levels.

Additionally, when the `edit-space-description-widget-old` was created, it's `.less` file didn't include the hover cursor, so it has been introduced in this commit. This will properly display the correct cursor for the default/beta feature-opt levels.  

[0] https://github.com/openshiftio/openshift.io/issues/3790