### PR TITLE
fix(codebases): remove createdAt and pushedAt filter

### DIFF
--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.spec.ts
@@ -58,4 +58,26 @@ describe('CodebasesToolbarComponent', () => {
 
     expect(this.testedDirective.filterConfig.resultsCount).toBe(nextCount);
   });
+
+  it('should emit filterChange event', function(this: Context) {
+    spyOn(this.hostComponent, 'filterChange');
+    this.testedDirective.filterChange({});
+    expect(this.hostComponent.filterChange).toHaveBeenCalledWith({});
+  });
+
+  it('should emit sortChange event', function(this: Context) {
+    spyOn(this.hostComponent, 'sortChange');
+    this.testedDirective.sortChange({
+      field: {
+        sortType: 'alphanumeric'
+      },
+      isAscending: false
+    });
+    expect(this.hostComponent.sortChange).toHaveBeenCalledWith({
+      field: {
+        sortType: 'alphanumeric'
+      },
+      isAscending: false
+    });
+  });
 });

--- a/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
+++ b/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.ts
@@ -53,16 +53,6 @@ export class CodebasesToolbarComponent implements OnChanges, OnInit {
         title: 'Name',
         placeholder: 'Filter by Name...',
         type: 'text'
-      }, {
-        id: 'createdAt',
-        title: 'Created Date',
-        placeholder: 'Filter by Created Date...',
-        type: 'text'
-      }, {
-        id: 'pushedAt',
-        title: 'Last Commit',
-        placeholder: 'Filter by Last Commit Date...',
-        type: 'text'
       }] as FilterField[],
       appliedFilters: [],
       resultsCount: 0,

--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -167,12 +167,6 @@ export class CodebasesComponent implements OnDestroy, OnInit {
 
     if (filter.field.id === 'name') {
       match = codebase.name.match(filter.value) !== null;
-    } else if (filter.field.id === 'createdAt') {
-      let date = this.datePipe.transform(codebase.gitHubRepo.createdAt, 'medium');
-      match = date.match(filter.value) !== null;
-    } else if (filter.field.id === 'pushedAt') {
-      let date = this.datePipe.transform(codebase.gitHubRepo.pushedAt, 'medium');
-      match = date.match(filter.value) !== null;
     }
     return match;
   }


### PR DESCRIPTION
This addresses the initial fix for https://github.com/openshiftio/openshift.io/issues/578

The filters relying on dates, createdAt && pushedAt are removed until there is calendar selection support in the patternfly-ng filter.