### PR TITLE
fix(work-items): fix TypeError regarding undefined values viewing ano…

### DIFF
--- a/src/app/profile/overview/work-items/work-items.component.html
+++ b/src/app/profile/overview/work-items/work-items.component.html
@@ -39,7 +39,7 @@
                     <span class="color-grey pull-left fa {{workItem.relationships?.baseType?.data?.attributes?.icon}} f8-list-group-item-icon"></span>
                     <span>{{workItem.attributes['system.number']}}</span>
                     <span class="work-item-title" *ngIf="workItem.attributes">
-                      <a [routerLink]="['/', loggedInUser.attributes.username, currentSpace.attributes.name, 'plan', 'detail', workItem.attributes['system.number']]" class="f8-list-group-item-link">
+                      <a [routerLink]="['/', user.attributes.username, currentSpace.attributes.name, 'plan', 'detail', workItem.attributes['system.number']]" class="f8-list-group-item-link">
                         {{workItem.attributes['system.title']}}
                       </a>
                     </span>


### PR DESCRIPTION
…ther user's space

This PR addresses [issue 3837](https://github.com/openshiftio/openshift.io/issues/3837) [0], in which an error is thrown regarding an undefined value for `loggedInUser` in the profile work-item component.

Currently, the profile work-items component uses the `loggedInUser` value to retrieve work items and create links to work items, however, this does not make any sense in the context of viewing another user's space. If I'm viewing a different users profile, the component starts loading my work items because I'm logged in, which is what causes this error. Furthermore, the work item related variables aren't reset in the subscription to `broadcaster.on('contextChanged')`, so if I view a subsequent profile page then the original values still linger.

[0] https://github.com/openshiftio/openshift.io/issues/3837