### PR TITLE
fix(recent-pipelines-widget): retrieve pipeline namespace from pipeli…

### DIFF
--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
@@ -56,7 +56,7 @@
           <div class="f8-card__pipeline-column">
             <span class="{{buildconfig.iconStyle}} fa-spin" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle === 'pficon-running'"></span>
             <span class="{{buildconfig.iconStyle}}" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle !== 'pficon-running'"></span>
-            <a id="spacehome-pipelines-title" [routerLink]="[contextPath, buildconfig.labels['space'], 'create', 'pipelines']"
+            <a id="spacehome-pipelines-title" [routerLink]="['/', contextPath, buildconfig.labels['space'], 'create', 'pipelines']"
               class="f8-card__pipeline-column-name">
               {{buildconfig.name}}
             </a>

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { Context, Contexts } from 'ngx-fabric8-wit';
-import { Observable, Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Rx';
 import { BuildConfigs } from '../../../a-runtime-console/index';
-
+import { ContextService } from '../../shared/context.service';
 import { PipelinesService } from '../../space/create/pipelines/services/pipelines.service';
 
 @Component({
@@ -24,20 +23,13 @@ export class RecentPipelinesWidgetComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
 
   constructor(
-    private context: Contexts,
-    private pipelinesService: PipelinesService
+    private pipelinesService: PipelinesService,
+    private contextService: ContextService
   ) { }
 
   ngOnInit() {
     // these values changing asynchronously triggers changes in the DOM;
     // force Angular Change Detection via setTimeout encapsulation
-    this.subscriptions.push(this.context.current.subscribe(
-      (ctx: Context) => {
-        setTimeout(() => {
-          this.contextPath = ctx.path;
-        });
-      }));
-
     this.subscriptions.push(this.pipelinesService.getRecentPipelines().share().subscribe(
       (configs: BuildConfigs) => {
         setTimeout(() => {
@@ -47,6 +39,7 @@ export class RecentPipelinesWidgetComponent implements OnInit, OnDestroy {
         });
       }
     ));
+    this.contextPath = this.contextService.currentUser;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
…nesService instead of Contexts

This PR addresses [issue 3841](https://github.com/openshiftio/openshift.io/issues/3841) [0], in which the URL to a recent active pipeline will contain an undefined value - resulting in an invalid URL.

The [line of code](https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts#L37) [1] that sets the `contextPath` is not being hit, and as a result the value is undefined when placed in the `routerLink`. This PR instead uses the value from the `config.namespace` retrieved from the `PipelinesService.getRecentPipelines()` to build the URL to the pipeline [2].  

[0] https://github.com/openshiftio/openshift.io/issues/3841
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts#L37
[2] https://github.com/aptmac/fabric8-ui/commit/dfd49a59056e58ea97a5aa9be2c7cb61dd094406#diff-0f9f68d891087e9b7384f274b6eb0bd7R59