### PR TITLE
fix(space-description-widget): fix masthead to display real user info…

### DIFF
--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -6,7 +6,7 @@
     <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount | async}}
     <ng-container *ngIf='userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo'>
       <span class="f8-space-masthead-vertical-divider-collab"></span>
-      <a [routerLink]="['/', loggedInUser?.attributes?.username, space?.attributes.name, 'settings', 'collaborators']">
+      <a class="add-collaborators-link" [routerLink]="['/', loggedInUser?.attributes?.username, space?.attributes.name, 'settings', 'collaborators']">
         <span class="pficon pficon-add-circle-o fa-lg"></span> Add Collaborator
       </a>
     </ng-container>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -1,15 +1,17 @@
 <div class="edit-space-description-widget">
   <div class="col-sm-3 f8-space-masthead-space-info">
     <div>
-      <span class="f8-space-masthead-name">{{space?.attributes.name | spaceName}}</span> <span class="f8-space-masthead-owner">bobross_925</span>
+      <span class="f8-space-masthead-name">{{space?.attributes.name | spaceName}}</span> <span class="f8-space-masthead-owner">{{spaceOwner | async}}</span>
     </div>
-    <span class="pficon pficon-users fa-lg"></span> 59
+    <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount | async}}
     <ng-container *ngIf='userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo'>
       <span class="f8-space-masthead-vertical-divider-collab"></span>
-      <span class="pficon pficon-add-circle-o fa-lg"></span> Add Collaborator
+      <a [routerLink]="['/', loggedInUser?.attributes?.username, space?.attributes.name, 'settings', 'collaborators']">
+        <span class="pficon pficon-add-circle-o fa-lg"></span> Add Collaborator
+      </a>
     </ng-container>
     <ng-template #userDoesNotOwnSpaceHeaderInfo>
-      <span id="space-description-collaborators-placeholder">Collaborators</span>
+      <span id="space-description-collaborators-placeholder">Collaborator{{(collaboratorCount | async) > 1 ? 's' : ''}}</span>
     </ng-template>
   </div>
   <div *ngIf="userOwnsSpace || space?.attributes.description" class="f8-space-masthead-vertical-divider"></div>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -161,3 +161,13 @@
     }
   }
 }
+
+.add-collaborators-link {
+  color: @color-pf-white;
+  &:hover {
+    color: @color-pf-white;
+  }
+  &:active {
+    color: @color-pf-white;
+  }
+}

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -52,9 +52,6 @@
     font-weight: 300;
     .truncate;
   }
-  &-owner {
-    font-size: 1.0em;
-  }
   &-description-body {
     &:hover {
       cursor: pointer;

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -53,7 +53,7 @@
     .truncate;
   }
   &-owner {
-    font-size: .9em;
+    font-size: 1.0em;
   }
   &-description-body {
     &:hover {

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -14,6 +14,7 @@
   padding: 0 !important; /* stylelint-disable-line declaration-no-important */
   margin-bottom: 10px;
   margin-left: 5px;
+  margin-top: 10px;
   text-align: center;
   .pointer;
 }

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -1,74 +1,141 @@
-import { DebugNode } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { Broadcaster } from 'ngx-base';
-import { Contexts, SpaceNamePipe, Spaces, SpaceService } from 'ngx-fabric8-wit';
-import { UserService } from 'ngx-login-client';
-import { Observable } from 'rxjs';
+import { CollaboratorService, Contexts, Space, SpaceNamePipe, Spaces, SpaceService } from 'ngx-fabric8-wit';
+import { User, UserService } from 'ngx-login-client';
+import { ConnectableObservable, Observable } from 'rxjs';
+import { createMock } from 'testing/mock';
+import { initContext, TestContext } from 'testing/test-context';
 import { SpaceNamespaceService } from '../../shared/runtime-console/space-namespace.service';
 import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-widget.component';
 
-describe('EditSpaceDescriptionWidgetComponent', () => {
-  let fixture: ComponentFixture<EditSpaceDescriptionWidgetComponent>;
-  let component: DebugNode['componentInstance'];
+@Component({
+  template: '<fabric8-edit-space-description-widget></fabric8-edit-space-description-widget>'
+})
+class HostComponent {}
 
-  let mockSpaces: any = jasmine.createSpy('Spaces');
-  let mockContexts: any = jasmine.createSpy('Contexts');
-  let mockUserService: any = jasmine.createSpy('UserService');
-  let mockBroadcaster: any = jasmine.createSpy('Broadcaster');
-  let mockSpaceService: any = jasmine.createSpy('SpaceService');
-  let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
-  let mockElementRef: any = jasmine.createSpyObj('ElementRef', ['nativeElement']);
-  let mockDescriptionUpdater: any = jasmine.createSpyObj('Subject', ['next']);
-  let mockSpace: any = {
+describe('EditSpaceDescriptionWidgetComponent', () => {
+  type Context = TestContext<EditSpaceDescriptionWidgetComponent, HostComponent>;
+  const mockSpace: any = {
     name: 'mock-space',
     path: 'mock-path',
-    id: 'mock-id',
+    id: 'mock-id-1',
     attributes: {
       name: 'mock-attribute',
       description: 'mock-description',
       'updated-at': 'mock-updated-at',
       'created-at': 'mock-created-at',
       version: 0
+    },
+    relationships: {
+      'owned-by': {
+        data: {
+          id: 'mock-id-1'
+        }
+      }
     }
   };
+  const mockUsers: any = [
+    { id: 'mock-id-1', attributes: { username: 'mock-username-1' } },
+    { id: 'mock-id-2', attributes: { username: 'mock-username-2' } },
+    { id: 'mock-id-3', attributes: { username: 'mock-username-3' } }
+  ];
 
-  mockElementRef.nativeElement.value = {};
-  mockSpaces.current = Observable.of(mockSpace);
-  mockUserService.loggedInUser = Observable.of({});
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [EditSpaceDescriptionWidgetComponent, SpaceNamePipe],
-      providers: [
-        { provide: Spaces, useValue: mockSpaces },
-        { provide: Contexts, useValue: mockContexts },
-        { provide: UserService, useValue: mockUserService },
-        { provide: Broadcaster, useValue: mockBroadcaster },
-        { provide: SpaceService, useValue: mockSpaceService },
-        { provide: SpaceNamespaceService, useValue: mockSpaceNamespaceService }
-      ]
-    });
-    fixture = TestBed.createComponent(EditSpaceDescriptionWidgetComponent);
-    fixture.detectChanges();
-    component = fixture.debugElement.componentInstance;
-    component.description = mockElementRef;
-
+  initContext(EditSpaceDescriptionWidgetComponent, HostComponent, {
+    declarations: [SpaceNamePipe],
+    providers: [
+      { provide: Spaces, useFactory: () => {
+          let mockSpaces: jasmine.SpyObj<Spaces> = createMock(Spaces);
+          mockSpaces.current = Observable.of(mockSpace) as Observable<Space> & jasmine.Spy;
+          return mockSpaces;
+        }
+      },
+      { provide: Contexts, useFactory: () => {
+          let mockContexts: jasmine.SpyObj<Contexts> = createMock(Contexts);
+          return mockContexts;
+        }
+      },
+      { provide: UserService, useFactory: () => {
+          let mockUserService: jasmine.SpyObj<UserService> = createMock(UserService);
+          mockUserService.loggedInUser = Observable.of(mockUsers[0]) as ConnectableObservable<User> & jasmine.Spy;
+          mockUserService.getUserByUserId.and.returnValue(Observable.of(mockUsers[0]) as Observable<User>);
+          return mockUserService;
+        }
+      },
+      { provide: Broadcaster, useFactory: () => {
+          let mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
+          return mockBroadcaster;
+        }
+      },
+      { provide: SpaceService, useFactory: () => {
+          let mockSpaceService: jasmine.SpyObj<SpaceService> = createMock(SpaceService);
+          return mockSpaceService;
+        }
+      },
+      { provide: SpaceNamespaceService, useFactory: () => {
+          let mockSpaceNamespaceService: jasmine.SpyObj<SpaceNamespaceService> = createMock(SpaceNamespaceService);
+          return mockSpaceNamespaceService;
+        }
+      },
+      { provide: CollaboratorService, useFactory: () => {
+          let mockCollaboratorService: jasmine.SpyObj<CollaboratorService> = createMock(CollaboratorService);
+          mockCollaboratorService.getInitialBySpaceId.and.returnValue(Observable.of(mockUsers) as Observable<User[]>);
+          return mockCollaboratorService;
+        }
+      }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
   });
 
-  describe('#onUpdateDescription', () => {
-    it('should delegate to _descriptionUpdater', () => {
-      component._descriptionUpdater = mockDescriptionUpdater;
-      component.onUpdateDescription('new-description');
-      expect(component._descriptionUpdater.next).toHaveBeenCalledWith('new-description');
+  describe('Component', () => {
+    it('should display the space\'s creator in the masthead', function(this: Context) {
+      let el: DebugElement = this.fixture.debugElement.query(By.css('.f8-space-masthead-owner'));
+      expect(el.nativeElement.textContent.trim()).toEqual(mockUsers[0].attributes.username);
+    });
+
+    it('should display the number of collaborators in the masthead', function(this: Context) {
+      let el: DebugElement = this.fixture.debugElement.query(By.css('.f8-space-masthead-space-info'));
+      expect(el.nativeElement.textContent.trim()).toContain(mockUsers.length);
+    });
+
+    it('should have a link to add collaborators if the user owns the space', function(this: Context) {
+      this.testedDirective.userOwnsSpace = true;
+      this.fixture.detectChanges();
+      let link: DebugElement = this.fixture.debugElement.query(By.css('a'));
+      expect(link).toBeDefined();
+    });
+
+    it('should not have a link to add collaborators if the user doesn\'t own the space', function(this: Context) {
+      this.testedDirective.userOwnsSpace = false;
+      this.fixture.detectChanges();
+      let link: DebugElement = this.fixture.debugElement.query(By.css('a'));
+      expect(link).toBeNull();
     });
   });
 
   describe('#saveDescription', () => {
-    it('should delegate to _descriptionUpdater', () => {
-      component._descriptionUpdater = mockDescriptionUpdater;
-      mockElementRef.nativeElement.value = 'new-description';
-      component.saveDescription();
-      expect(component._descriptionUpdater.next).toHaveBeenCalledWith('new-description');
+    it('should be called when the save button is clicked', function(this: Context) {
+      spyOn(this.testedDirective, 'isEditable').and.returnValue(Observable.of(true));
+      spyOn(this.testedDirective, 'saveDescription');
+      this.testedDirective.userOwnsSpace = true;
+      this.testedDirective.startEditingDescription();
+      this.fixture.detectChanges();
+      let button: DebugElement = this.fixture.debugElement.query(By.css('#workItemTitle_btn_save_description'));
+      button.nativeElement.click();
+      expect(this.testedDirective.saveDescription).toHaveBeenCalled();
+    });
+  });
+
+  describe('#onUpdateDescription', () => {
+    it('should be called when the enter key is pressed', function(this: Context) {
+      spyOn(this.testedDirective, 'isEditable').and.returnValue(Observable.of(true));
+      spyOn(this.testedDirective, 'onUpdateDescription');
+      this.testedDirective.userOwnsSpace = true;
+      this.testedDirective.startEditingDescription();
+      this.fixture.detectChanges();
+      let textarea: DebugElement = this.fixture.debugElement.query(By.css('textarea'));
+      textarea.triggerEventHandler('keyup.enter', {});
+      expect(this.testedDirective.onUpdateDescription).toHaveBeenCalled();
     });
   });
 

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
@@ -33,22 +33,18 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit {
     private spaceService: SpaceService,
     private spaceNamespaceService: SpaceNamespaceService,
     private collaboratorService: CollaboratorService
-  ) {
-    spaces.current
+  ) { }
+
+  ngOnInit() {
+    this.userService.loggedInUser.subscribe(val => this.loggedInUser = val);
+    this.spaces.current
       .subscribe(space => {
         this.space = space;
         if (space) {
           this.collaboratorCount = this.collaboratorService.getInitialBySpaceId(space.id).map(c => c.length);
           this.spaceOwner = this.userService.getUserByUserId(space.relationships['owned-by'].data.id).map(u => u.attributes.username);
-        } else {
-          this.collaboratorCount = Observable.empty();
-          this.spaceOwner = Observable.empty();
         }
       });
-    userService.loggedInUser.subscribe(val => this.loggedInUser = val);
-  }
-
-  ngOnInit() {
     this._descriptionUpdater
       .debounceTime(1000)
       .map(description => {
@@ -59,7 +55,7 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit {
             version: this.space ? this.space.attributes.version : ''
           },
           type: 'spaces',
-          id: this.space.id
+          id: this.space ? this.space.id : ''
         } as Space;
         return patch;
       })

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { FeatureFlagModule } from 'ngx-feature-flag';
 import { AlmEditableModule, AlmIconModule } from 'ngx-widgets';
@@ -14,7 +16,8 @@ import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-wi
     AlmIconModule,
     AlmEditableModule,
     Fabric8WitModule,
-    FeatureFlagModule
+    FeatureFlagModule,
+    RouterModule
   ],
   declarations: [EditSpaceDescriptionWidgetComponent],
   exports: [EditSpaceDescriptionWidgetComponent]


### PR DESCRIPTION
…rmation instead of hardcoded values

This PR addresses the hardcoded values in the masthead of the edit-space-description-widget. The lack of real-values had been recorded as issue a couple few previously [0][1][2], but were closed due to the initial nature of the functionality. A PR [3] had initially been raised to remove hardcoded data, but didn't use real information so the PR was refused, noting that a future PR could be raised to implement these features. This PR retrieves the space's owner username and number of collaborators and updates the hardcoded values. Additionally, it changes the unactive `span` containing the "add collaborators" text to a `<a>` that links to the collaborators page so the user can add collaborators.

There were three changes required to make this happen:
1. Update the username field using the space's `owned-by` value [4]
2. Update the collaborator number field by displaying the length of the collaborators array using the collaborator service [5]
3. Update the add collaborator link to route to the space's collaborator page [6]. @mindreeper2420 what are your thoughts on this? It seems like the collaborator functionality is going to be replaced with teams/orgs, is this be okay as a current solution and amended once teams/orgs are completed or I can remove these changes from the PR otherwise.

Additionally, the unit tests have been overhauled to better test the functionality of the component.

Before: here's what the masthead looks like in production:
![before](https://user-images.githubusercontent.com/10425301/41856002-07ca79ea-7862-11e8-89f0-705060136f28.png)

After: here's what the masthead looks like when viewing own space:
EDIT (with white colour):
![white-text](https://user-images.githubusercontent.com/10425301/41859694-b778675a-786a-11e8-8f0f-48cedf2ff00d.png)

After: here's what the masthead looks like when viewing another user's space:
![after-different-space](https://user-images.githubusercontent.com/10425301/41857336-420aaf0a-7865-11e8-860a-d1bdbb39a612.png)

[0] https://github.com/openshiftio/openshift.io/issues/3261
[1] https://github.com/openshiftio/openshift.io/issues/3262
[2] https://github.com/openshiftio/openshift.io/issues/3263
[3] https://github.com/fabric8-ui/fabric8-ui/pull/2926
[4] https://github.com/aptmac/fabric8-ui/blob/42af2027719274573aaa7c13e57246e20b44e11d/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts#L42
[5] https://github.com/aptmac/fabric8-ui/blob/42af2027719274573aaa7c13e57246e20b44e11d/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts#L41
[6] https://github.com/aptmac/fabric8-ui/blob/42af2027719274573aaa7c13e57246e20b44e11d/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html#L9
[7] https://github.com/openshiftio/openshift.io/issues/3760
