### PR TITLE
fix(deployments): remove filter for "test" environment

### DIFF
--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -152,15 +152,11 @@ describe('DeploymentsService', () => {
   });
 
   describe('#getEnvironments', () => {
-    it('should publish faked, filtered and sorted environments', function(this: TestContext, done: DoneFn): void {
+    it('should sort environments', function(this: TestContext, done: DoneFn): void {
       this.apiService.getEnvironments.and.returnValue(Observable.of([
         {
           attributes: {
             name: 'run'
-          }
-        }, {
-          attributes: {
-            name: 'test'
           }
         }, {
           attributes: {
@@ -173,6 +169,36 @@ describe('DeploymentsService', () => {
           expect(environments).toEqual(['stage', 'run']);
           done();
         });
+      this.timer.next();
+    });
+
+    it('should only emit on change', function(this: TestContext, done: DoneFn): void {
+      this.apiService.getEnvironments.and.returnValue(Observable.of([
+        {
+          attributes: {
+            name: 'run'
+          }
+        }, {
+          attributes: {
+            name: 'stage'
+          }
+        }
+      ]));
+      let callCount: number = 0;
+      this.service.getEnvironments('foo-spaceId')
+        .takeUntil(Observable.timer(1000))
+        .subscribe(
+          (environments: string[]): void => {
+            expect(environments).toEqual(['stage', 'run']);
+            callCount++;
+            if (callCount > 1) {
+              return done.fail('should only have been called once');
+            }
+            this.timer.next();
+          },
+          err => done.fail(err),
+          () => done()
+        );
       this.timer.next();
     });
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -97,16 +97,12 @@ export class DeploymentsService implements OnDestroy {
   }
 
   getEnvironments(spaceId: string): Observable<string[]> {
-    // Note: Sorting and filtering out "test" should ideally be moved to the backend
     return this.getEnvironmentsResponse(spaceId)
       .map((envs: EnvironmentStat[]) => envs || [])
       .map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => env.attributes))
-      .map((envs: EnvironmentAttributes[]) => envs.sort((a, b) => -1 * a.name.localeCompare(b.name)))
-      .map((envs: EnvironmentAttributes[]) => envs
-        .filter((env: EnvironmentAttributes) => env.name !== 'test')
-        .map((env: EnvironmentAttributes) => env.name)
-      )
-      .distinctUntilChanged((p: string[], q: string[]) => deepEqual(new Set<string>(p), new Set<string>(q)));
+      .map((envs: EnvironmentAttributes[]) => envs.map((env: EnvironmentAttributes) => env.name))
+      .map((envs: string[]): string[] => envs.sort((a: string, b: string): number => b.localeCompare(a)))
+      .distinctUntilChanged(deepEqual);
   }
 
   isApplicationDeployedInEnvironment(spaceId: string, environmentName: string, applicationId: string):


### PR DESCRIPTION
Remove no-longer-necessary filter for "test" environment in data returned from backend, and lightly
refactor surrounding code

