### PR TITLE
fix(my-spaces): introduce case insensitive filtering

### DIFF
--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -15,9 +15,7 @@ import { spaceMock } from '../../shared/context.service.mock';
 import { EventService } from '../../shared/event.service';
 import { MySpacesComponent } from './my-spaces.component';
 
-
 describe('MySpacesComponent', () => {
-
   let fixture: ComponentFixture<MySpacesComponent>;
   let component: DebugNode['componentInstance'];
   let mockContexts: any = jasmine.createSpy('Contexts');
@@ -98,7 +96,7 @@ describe('MySpacesComponent', () => {
     spaceMock1 = cloneDeep(spaceMock);
     spaceMock2 = cloneDeep(spaceMock);
     spaceMock2.id = '2';
-    spaceMock2.attributes.name = 'spaceMock2-id';
+    spaceMock2.attributes.name = 'spaceMock2-name';
     mockContexts.current = Observable.of(mockContext);
     mockUserService.loggedInUser = Observable.of(mockUser);
     mockGettingStartedService.createTransientProfile.and.returnValue(mockExtProfile);
@@ -147,7 +145,7 @@ describe('MySpacesComponent', () => {
     it('should delegate to savePins and updateSpaces if the selected space exists in the user\'s spaces', () => {
       spyOn(component, 'savePins').and.callFake(() => {});
       spyOn(component, 'updateSpaces');
-      component.allSpaces = [ spaceMock1 ];
+      component.allSpaces = [spaceMock1];
       component.handlePinChange(spaceMock1);
       expect(component.savePins).toHaveBeenCalled();
       expect(component.updateSpaces).toHaveBeenCalled();
@@ -174,7 +172,7 @@ describe('MySpacesComponent', () => {
       spyOn(component, 'savePins').and.callFake(() => {});
       spyOn(component, 'updateSpaces');
       spaceMock1.showPin = true;
-      component.allSpaces = [ spaceMock1 ];
+      component.allSpaces = [spaceMock1];
       component.handlePinChange(spaceMock1);
       expect(spaceMock1.showPin).toBeDefined();
       expect(spaceMock1.showPin).toBeFalsy();
@@ -194,10 +192,12 @@ describe('MySpacesComponent', () => {
 
   describe('#applyFilters', () => {
     it('should use matchesFilters to select qualifying spaces', () => {
+      spyOn(component, 'matchesFilters');
       component.appliedFilters = [mockFilter1, mockFilter2]; // 'space' && '2'
+      component.allSpaces = [spaceMock1, spaceMock2];
       component.ngOnInit();
       component.applyFilters();
-      expect(component._spaces).toEqual([spaceMock2]);
+      expect(component.matchesFilters).toHaveBeenCalled();
     });
 
     it('should return all spaces if there are no filters', () => {
@@ -223,18 +223,25 @@ describe('MySpacesComponent', () => {
       let result: boolean = component.matchesFilter(spaceMock1, mockFilter3);
       expect(result).toBeTruthy();
     });
+
+    it('should be case-insensitive', () => {
+      let mockFilterCaseInsensitive = cloneDeep(mockFilter1);
+      mockFilterCaseInsensitive.value = mockFilter1.value.toUpperCase();
+      let result: boolean = component.matchesFilter(spaceMock1, mockFilterCaseInsensitive);
+      expect(result).toBe(true);
+    });
   });
 
   describe('#matchesFilters', () => {
     it('should delegate to the matchesFilter method for each filter', () => {
       let mockFilters = [mockFilter1, mockFilter2];
       spyOn(component, 'matchesFilter');
-      let result = component.matchesFilters(spaceMock1, mockFilters);
+      component.matchesFilters(spaceMock1, mockFilters);
       expect(component.matchesFilter).toHaveBeenCalledTimes(2);
     });
 
     it('should return true if all of the filters are satisfied', () => {
-      let mockFilters = [mockFilter1, mockFilter2];
+      let mockFilters = [mockFilter1, mockFilter3];
       let result = component.matchesFilters(spaceMock2, mockFilters);
       expect(result).toBeTruthy();
     });
@@ -242,7 +249,7 @@ describe('MySpacesComponent', () => {
     it('should return false if at least one of the filters results in zero matches', () => {
       let mockFilters = [mockFilter1, mockFilter2, mockFilter3];
       let result = component.matchesFilters(spaceMock1, mockFilters);
-      expect(result).toBeFalsy();
+      expect(result).toBe(false);
     });
   });
 

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -145,7 +145,8 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   matchesFilter(space: Space, filter: Filter): boolean {
     let match = true;
     if (filter.field.id === 'name') {
-      match = space.attributes.name.match(filter.value) !== null;
+      let re = new RegExp(filter.value, 'i');
+      match = space.attributes.name.match(re) !== null;
     }
     return match;
   }


### PR DESCRIPTION
…e filtering

fixes https://github.com/openshiftio/openshift.io/issues/3857

This PR tweaks the filtering of spaces in the `my-spaces.component`with regards to combination of filters and case insensitivity. 

The `my-spaces.component` uses `name` as a filter attribute, and based on the PatternFly design explanations [[0]](http://www.patternfly.org/pattern-library/forms-and-controls/filter/#design) should be combined with a logical OR. Instead, patternfly-ng [[1]](http://www.patternfly.org/patternfly-ng/#/filters) seems to use logical AND, but this is an implementation detail and has been changed here. I have spaces numbered 1 through 13, and using the the following filters I would expect the following results:

-  filter '1' = [1, 10, 11, 12, 13]
-  filter '2' = [2, 12]
-  filter '1' with '2' = [1, 2, 10, 11, 12, 13]

However, the current result is [12], because of the way the filters are being aggregated.

Before:
![before-1-2](https://user-images.githubusercontent.com/10425301/41924331-b5bb8834-7937-11e8-82dc-fcb7eef13d90.png)

After:
![after-1-2](https://user-images.githubusercontent.com/10425301/41924324-b0dc2404-7937-11e8-99c5-57dab49d8616.png)


Previously, the case had to match exactly what you were looking for. When trying to find my spaces that contain 'em' in them, I expected to have two results show up but instead here are the results:
Before:
![before-em](https://user-images.githubusercontent.com/10425301/41924161-4b6597c2-7937-11e8-8520-b08cf4651d9c.png)

After:
![after-em](https://user-images.githubusercontent.com/10425301/41924156-47e41ede-7937-11e8-8e51-d5b6bb60f3d0.png)

[0] http://www.patternfly.org/pattern-library/forms-and-controls/filter/#design
[1] http://www.patternfly.org/patternfly-ng/#/filters