### PR TITLE
fix(webpack): create smaller chunks

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -79,8 +79,8 @@ module.exports = function (options) {
      * See: https://webpack.js.org/configuration/entry-context/#entry
      */
     entry: {
-      'polyfills': './src/polyfills.browser.ts',
       'vendor': './src/vendor.browser.ts',
+      'polyfills': './src/polyfills.browser.ts',
       // 'main': aotMode ? './src/main.browser.aot.ts' : './src/main.browser.ts'
       'main': './src/main.browser.ts'
     },
@@ -387,7 +387,22 @@ module.exports = function (options) {
        * See: https://github.com/webpack/docs/wiki/optimization#multi-page-app
        */
       new CommonsChunkPlugin({
-        name: ['polyfills', 'vendor'].reverse()
+        name: 'polyfills',
+        minChunks: Infinity,
+      }),
+      new CommonsChunkPlugin({
+        name: 'vendor',
+        async: true,
+        minChunks: Infinity,
+      }),
+      new CommonsChunkPlugin({
+        name: 'main',
+        async: true,
+        minChunks: 2,
+      }),
+      new CommonsChunkPlugin({
+        name: 'manifest',
+        minChunks: Infinity,
       }),
 
       /*
@@ -431,7 +446,10 @@ module.exports = function (options) {
       new HtmlWebpackPlugin({
         template: 'src/index.ejs',
         title: branding.assets[METADATA.FABRIC8_BRANDING].title.prefix,
-        chunksSortMode: 'dependency',
+        chunksSortMode: function (a, b) {
+          const entryPoints = ["manifest", "polyfills", "vendor", "main"];
+          return entryPoints.indexOf(a.names[0]) - entryPoints.indexOf(b.names[0]);
+        },
         metadata: METADATA
       }),
 


### PR DESCRIPTION
fixes https://github.com/openshiftio/openshift.io/issues/2955
fabric8-planner, and other components, were being duplicated in our chunks bloating the application in production. In the before screenshot below fabric8-planner is include in 5 different chunks.

Unfortunately the main chunk is still large. This will be looked at again when we move to webpack 4.

Before total size 9.36 MB:

![image](https://user-images.githubusercontent.com/14068621/41981892-06bb92f4-79f8-11e8-8b3a-38a4a4d76018.png)
![image](https://user-images.githubusercontent.com/14068621/41981910-136c2a36-79f8-11e8-9139-743ea466d35c.png)

After total size 5.69 MB:

![image](https://user-images.githubusercontent.com/14068621/41981939-24ae6c50-79f8-11e8-8fa5-4b886dc1c53d.png)
![image](https://user-images.githubusercontent.com/14068621/41982185-c1bf37c2-79f8-11e8-9bb3-b7936b5f6e76.png)

