### PR TITLE
Secondary tab styling

### DIFF
--- a/src/app/profile/overview/overview.component.html
+++ b/src/app/profile/overview/overview.component.html
@@ -95,14 +95,14 @@
 
   <div class="row profile-overview-nav" role="navigation">
     <div class="col-md-10 col-md-offset-1">
-      <ul>
-        <li>
-          <a [routerLink]="['/', context?.user?.attributes?.username, '_profile', 'workitems']" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}">
+      <ul class="nav nav-tabs nav-tabs-pf">
+        <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+          <a [routerLink]="['/', context?.user?.attributes?.username, '_profile', 'workitems']">
             {{ viewingOwnAccount ? 'My' : context.user.attributes.fullName + '\'s'}} Work Items
           </a>
         </li>
-        <li>
-          <a [routerLink]="['/', context?.user?.attributes?.username, '_profile', 'spaces']" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}">
+        <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+          <a [routerLink]="['/', context?.user?.attributes?.username, '_profile', 'spaces']">
             {{ viewingOwnAccount ? 'My' : context.user.attributes.fullName + '\'s'}} Spaces
           </a>
         </li>

--- a/src/app/profile/overview/overview.component.less
+++ b/src/app/profile/overview/overview.component.less
@@ -113,14 +113,6 @@
   ul {
     list-style-type: none;
     padding-left: 25px;
-    li {
-      a.active-link {
-        color: @color-pf-blue;
-        border-bottom: 3px solid @color-pf-blue;
-        padding-bottom: 9px;
-        text-decoration: none;
-      }
-    }
   }
   li {
     padding-right: 10px;

--- a/src/app/profile/settings/settings.component.html
+++ b/src/app/profile/settings/settings.component.html
@@ -2,22 +2,26 @@
   <h3 class="settings-title-nav-text">User Settings</h3>
 </div>
 <div class="settings-nav" id="settings-options-nav" role="navigation">
-  <ul>
-    <li>
-      <a [routerLink]="['/' + loggedInUserName + '/_settings/']" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact:
-        true}">Connected Accounts</a>
+  <ul class="nav nav-tabs nav-tabs-pf">
+    <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+      <a [routerLink]="['/' + loggedInUserName + '/_settings/']">
+        Connected Accounts
+      </a>
     </li>
-    <li>
-      <a [routerLink]="['/' + loggedInUserName + '/_settings/feature-opt-in']" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact:
-        true}">Features Opt-in</a>
+    <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+      <a [routerLink]="['/' + loggedInUserName + '/_settings/feature-opt-in']">
+        Features Opt-in
+      </a>
     </li>
-    <li>
-      <a [routerLink]="['/' + loggedInUserName + '/_settings/notifications']" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact:
-        true}">Notifications</a>
+    <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+      <a [routerLink]="['/' + loggedInUserName + '/_settings/notifications']">
+        Notifications
+      </a>
     </li>
-    <li>
-      <a [routerLink]="['/' + loggedInUserName + '/_settings/resources']" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact:
-        true}">Resources</a>
+    <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+      <a [routerLink]="['/' + loggedInUserName + '/_settings/resources']">
+        Resources
+      </a>
     </li>
   </ul>
 </div>

--- a/src/app/profile/settings/settings.component.less
+++ b/src/app/profile/settings/settings.component.less
@@ -23,14 +23,6 @@
   ul {
     list-style-type: none;
     padding-left: 25px;
-    li {
-      a.active-link {
-        color: @color-pf-blue;
-        border-bottom: 3px solid @color-pf-blue;
-        padding-bottom: 9px;
-        text-decoration: none;
-      }
-    }
   }
   li {
     padding-right: 10px;


### PR DESCRIPTION
Removes custom, non-standard styling of secondary tab navigation elements in the Settings and Profile pages, and applies Patternfly standard styling instead.

https://github.com/openshiftio/openshift.io/issues/3889