### PR TITLE
fix(telemetry): Using a single event for analytics tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -747,16 +747,6 @@
         "@types/uglify-js": "3.0.2"
       }
     },
-    "JSONStream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
-      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -2414,6 +2404,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3034,8 +3025,8 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.3",
         "lodash": "4.17.4",
         "meow": "4.0.1",
         "split2": "2.2.0",
@@ -5110,6 +5101,24 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fabric8-analytics-dependency-editor": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-dependency-editor/-/fabric8-analytics-dependency-editor-0.7.5.tgz",
+      "integrity": "sha512-rncVz/NjN/Cw3MI60RkSYQRcyRevHZNxSQFzbaW4wn7glIQy5HeCBOdB3AVZWsG5qZ65nQJaREFio+qW8BjjUQ==",
+      "requires": {
+        "c3": "0.4.23",
+        "ngx-base": "2.3.6",
+        "ngx-bootstrap": "1.9.3",
+        "ngx-modal": "0.0.29"
+      },
+      "dependencies": {
+        "ngx-base": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/ngx-base/-/ngx-base-2.3.6.tgz",
+          "integrity": "sha512-2yJ7VHH5FrtLnQD1Txc5mzojO7ahZBUB6ZshfvL6RT478JOhMcSJDKB14pBeSM9QwbabaHAUbbX+bs0IdEiW/w=="
+        }
+      }
+    },
     "fabric8-planner": {
       "version": "0.50.26",
       "resolved": "https://registry.npmjs.org/fabric8-planner/-/fabric8-planner-0.50.26.tgz",
@@ -5663,6 +5672,535 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -8198,6 +8736,16 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsontoxml": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz",
@@ -10426,13 +10974,13 @@
       }
     },
     "ngx-launcher": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ngx-launcher/-/ngx-launcher-1.0.6.tgz",
-      "integrity": "sha512-XxwcFm3y5b/hQo/KvBBCi97sywYrr9KHPagAE8Hu6/DV02BINBll+Ih1Xh4XRb0DDwP+UwZZ8D24MtLOOVBPRQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/ngx-launcher/-/ngx-launcher-1.0.8.tgz",
+      "integrity": "sha512-5DLOI2kwMKOUnf2h2kOD2+tHo6UdrnFvRjBZycQyqGqWqfa6bd6gahpEX8Q2c6GLap/XfIkpVcyaaEluPAjzdw==",
       "requires": {
         "@thisissoon/angular-inviewport": "1.3.2",
         "angular-2-dropdown-multiselect": "1.8.0",
-        "fabric8-analytics-dependency-editor": "0.7.2",
+        "fabric8-analytics-dependency-editor": "0.7.5",
         "lodash": "4.17.10",
         "ngx-base": "2.3.2",
         "ngx-bootstrap": "2.0.5",
@@ -10441,29 +10989,6 @@
         "patternfly-ng": "3.10.3"
       },
       "dependencies": {
-        "fabric8-analytics-dependency-editor": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/fabric8-analytics-dependency-editor/-/fabric8-analytics-dependency-editor-0.7.2.tgz",
-          "integrity": "sha512-18xuHmNZCOBaIzkBD+awB1Fd5lvATNppRI/eOAKJ1/HYyo2qIPLSGRzWDrWM0kHjq1Dh2hrTkJy8E+ud0ZLa4Q==",
-          "requires": {
-            "c3": "0.4.23",
-            "ngx-base": "2.3.6",
-            "ngx-bootstrap": "1.9.3",
-            "ngx-modal": "0.0.29"
-          },
-          "dependencies": {
-            "ngx-base": {
-              "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/ngx-base/-/ngx-base-2.3.6.tgz",
-              "integrity": "sha512-2yJ7VHH5FrtLnQD1Txc5mzojO7ahZBUB6ZshfvL6RT478JOhMcSJDKB14pBeSM9QwbabaHAUbbX+bs0IdEiW/w=="
-            },
-            "ngx-bootstrap": {
-              "version": "1.9.3",
-              "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.3.tgz",
-              "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
-            }
-          }
-        },
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -16536,6 +17061,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -16563,15 +17097,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
       "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns=",
       "dev": true
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
     },
     "stringify-entities": {
       "version": "1.3.2",
@@ -18470,6 +18995,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
+            "fsevents": "1.2.4",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5110,16 +5110,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fabric8-analytics-dependency-editor": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-dependency-editor/-/fabric8-analytics-dependency-editor-0.7.0.tgz",
-      "integrity": "sha512-+bUhsmQzMxcOuuObCITOIkoC5f/sqDGQX9FLr7vQfPar3CTLrugsC/KAd9edI4nQ6bRpFL9B7cnpkvXFFEe9TA==",
-      "requires": {
-        "c3": "0.4.23",
-        "ngx-bootstrap": "1.9.3",
-        "ngx-modal": "0.0.29"
-      }
-    },
     "fabric8-planner": {
       "version": "0.50.26",
       "resolved": "https://registry.npmjs.org/fabric8-planner/-/fabric8-planner-0.50.26.tgz",
@@ -10436,13 +10426,13 @@
       }
     },
     "ngx-launcher": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ngx-launcher/-/ngx-launcher-1.0.3.tgz",
-      "integrity": "sha512-N0jQ2k+LolCw85sz087EvesH3ogsdVvoVzM1w7LT+lOKbUlFVd3HWHjtdY2D8rKbR71YiRL7Z1P3pPVkt182lA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ngx-launcher/-/ngx-launcher-1.0.6.tgz",
+      "integrity": "sha512-XxwcFm3y5b/hQo/KvBBCi97sywYrr9KHPagAE8Hu6/DV02BINBll+Ih1Xh4XRb0DDwP+UwZZ8D24MtLOOVBPRQ==",
       "requires": {
         "@thisissoon/angular-inviewport": "1.3.2",
         "angular-2-dropdown-multiselect": "1.8.0",
-        "fabric8-analytics-dependency-editor": "0.7.0",
+        "fabric8-analytics-dependency-editor": "0.7.2",
         "lodash": "4.17.10",
         "ngx-base": "2.3.2",
         "ngx-bootstrap": "2.0.5",
@@ -10451,6 +10441,29 @@
         "patternfly-ng": "3.10.3"
       },
       "dependencies": {
+        "fabric8-analytics-dependency-editor": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/fabric8-analytics-dependency-editor/-/fabric8-analytics-dependency-editor-0.7.2.tgz",
+          "integrity": "sha512-18xuHmNZCOBaIzkBD+awB1Fd5lvATNppRI/eOAKJ1/HYyo2qIPLSGRzWDrWM0kHjq1Dh2hrTkJy8E+ud0ZLa4Q==",
+          "requires": {
+            "c3": "0.4.23",
+            "ngx-base": "2.3.6",
+            "ngx-bootstrap": "1.9.3",
+            "ngx-modal": "0.0.29"
+          },
+          "dependencies": {
+            "ngx-base": {
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/ngx-base/-/ngx-base-2.3.6.tgz",
+              "integrity": "sha512-2yJ7VHH5FrtLnQD1Txc5mzojO7ahZBUB6ZshfvL6RT478JOhMcSJDKB14pBeSM9QwbabaHAUbbX+bs0IdEiW/w=="
+            },
+            "ngx-bootstrap": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.3.tgz",
+              "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
+            }
+          }
+        },
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "ngx-bootstrap": "1.9.3",
     "ngx-fabric8-wit": "6.21.0",
     "ngx-feature-flag": "0.4.1",
-    "ngx-launcher": "1.0.3",
+    "ngx-launcher": "1.0.6",
     "ngx-login-client": "1.4.3",
     "ngx-modal": "0.0.29",
     "ngx-restangular": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "ngx-bootstrap": "1.9.3",
     "ngx-fabric8-wit": "6.21.0",
     "ngx-feature-flag": "0.4.1",
-    "ngx-launcher": "1.0.6",
+    "ngx-launcher": "1.0.8",
     "ngx-login-client": "1.4.3",
     "ngx-modal": "0.0.29",
     "ngx-restangular": "1.0.13",

--- a/src/app/shared/analytics.service.spec.ts
+++ b/src/app/shared/analytics.service.spec.ts
@@ -4,29 +4,37 @@ import { Router } from '@angular/router';
 import { Broadcaster } from 'ngx-base';
 import { Contexts, Spaces } from 'ngx-fabric8-wit';
 import { UserService } from 'ngx-login-client';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { createMock } from 'testing/mock';
 
 import { AnalyticService } from './analytics.service';
 import { Fabric8UIConfig } from './config/fabric8-ui-config';
 import { loggedInUser } from './context.service.mock';
 import { NotificationsService } from './notifications.service';
 
+interface BroadcastEvent {
+  key: any;
+  data?: any;
+}
+
 describe('Analytic Service:', () => {
   let mockRouter: any;
-  let mockBroadcaster: any;
+  let mockBroadcaster: jasmine.SpyObj<Broadcaster>;
   let mockUserService: any;
-  let mockNotifications: any;
   let analyticService: AnalyticService;
   let mockNotificationsService: jasmine.SpyObj<NotificationsService>;
 
   beforeEach(() => {
     mockRouter = jasmine.createSpy('Router');
-    mockBroadcaster = jasmine.createSpyObj('Broadcaster', ['broadcast']);
     mockUserService = jasmine.createSpyObj('UserService', ['getUserByUserId']);
     mockUserService.getUserByUserId.and.returnValue(Observable.of(loggedInUser));
     mockUserService.loggedInUser = Observable.of(loggedInUser);
-    mockNotifications = jasmine.createSpy('Notifications');
     mockNotificationsService = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
+    mockBroadcaster = createMock(Broadcaster);
+    mockBroadcaster.on.and.returnValue(() => {
+      return new Subject<BroadcastEvent>();
+    });
+
     TestBed.configureTestingModule({
       imports: [HttpModule],
       providers: [
@@ -34,7 +42,7 @@ describe('Analytic Service:', () => {
           provide: Router, useValue: mockRouter
         },
         {
-          provide: Broadcaster, useValue: mockBroadcaster
+          provide: Broadcaster, useFactory: () => mockBroadcaster
         },
         {
           provide: UserService, useValue: mockUserService
@@ -51,13 +59,50 @@ describe('Analytic Service:', () => {
     analyticService = TestBed.get(AnalyticService);
   });
 
-  it('analytics should be defined', () => {
-    // given
-    window.analytics = {
-        'invoked': ''
-    };
-    let anayticsData = analyticService.analytics;
-    expect(anayticsData).toBeDefined();
+  it('when writekey is not available, analytics should not be defined', () => {
+    // call the init method to initialize the analytics object
+    analyticService.init();
+    const anaytics = analyticService.analytics;
+    expect(anaytics).toBeUndefined();
+  });
+
+  describe('when write key is available,', () => {
+    let analytics: any;
+
+    beforeAll(() => {
+      analyticService.fabric8UIConfig.analyticsWriteKey = 'some-key';
+      spyOn(analyticService, 'track').and.returnValue(true);
+
+      // call the init method to initialize the analytics object
+      analyticService.init();
+      analytics = analyticService.analytics;
+    });
+
+    it('analytics.initialize should be falsy', () => {
+      expect(analytics.initialize).toBeFalsy();
+    });
+
+    it('analytics.invoked is truthy', () => {
+      expect(analytics.invoked).toBeTruthy();
+    });
+
+    it('analytics object is defined', () => {
+      expect(analytics).toBeDefined();
+    });
+
+    it('analytics object should have track method', () => {
+      expect(analytics.methods).toBeDefined();
+      expect(analytics.methods).toContain('track');
+    });
+
+    it('analytics object should have page method', () => {
+      expect(analytics.methods).toContain('page');
+    });
+
+    it('analytics object should have identify method', () => {
+      expect(analytics.methods).toContain('identify');
+    });
+
   });
 
 });

--- a/src/app/shared/analytics.service.spec.ts
+++ b/src/app/shared/analytics.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+import { Router } from '@angular/router';
+import { Broadcaster } from 'ngx-base';
+import { Contexts, Spaces } from 'ngx-fabric8-wit';
+import { UserService } from 'ngx-login-client';
+import { Observable } from 'rxjs';
+
+import { AnalyticService } from './analytics.service';
+import { Fabric8UIConfig } from './config/fabric8-ui-config';
+import { loggedInUser } from './context.service.mock';
+import { NotificationsService } from './notifications.service';
+
+describe('Analytic Service:', () => {
+  let mockRouter: any;
+  let mockBroadcaster: any;
+  let mockUserService: any;
+  let mockNotifications: any;
+  let analyticService: AnalyticService;
+  let mockNotificationsService: jasmine.SpyObj<NotificationsService>;
+
+  beforeEach(() => {
+    mockRouter = jasmine.createSpy('Router');
+    mockBroadcaster = jasmine.createSpyObj('Broadcaster', ['broadcast']);
+    mockUserService = jasmine.createSpyObj('UserService', ['getUserByUserId']);
+    mockUserService.getUserByUserId.and.returnValue(Observable.of(loggedInUser));
+    mockUserService.loggedInUser = Observable.of(loggedInUser);
+    mockNotifications = jasmine.createSpy('Notifications');
+    mockNotificationsService = jasmine.createSpyObj<NotificationsService>('NotificationsService', ['message']);
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        {
+          provide: Router, useValue: mockRouter
+        },
+        {
+          provide: Broadcaster, useValue: mockBroadcaster
+        },
+        {
+          provide: UserService, useValue: mockUserService
+        },
+        {
+          provide: NotificationsService, useValue: mockNotificationsService
+        },
+        AnalyticService,
+        Contexts,
+        Spaces,
+        Fabric8UIConfig
+      ]
+    });
+    analyticService = TestBed.get(AnalyticService);
+  });
+
+  it('analytics should be defined', () => {
+    // given
+    window.analytics = {
+        'invoked': ''
+    };
+    let anayticsData = analyticService.analytics;
+    expect(anayticsData).toBeDefined();
+  });
+
+});

--- a/src/app/shared/analytics.service.ts
+++ b/src/app/shared/analytics.service.ts
@@ -176,92 +176,15 @@ export class AnalyticService {
 
   private activateLauncherEventListeners(): void {
     this.broadcaster
-      .on('showAddAppOverlay')
-      .subscribe((val) => {
-        if (val === true) {
-          this.analytics.track('add app opened');
-        } else {
-          this.analytics.track('add app closed');
+      .on('analyticsTracker')
+      .subscribe((data: any) => {
+        const eventKey = data['event'];
+        const eventData = data['data'];
+        if (eventKey && eventData) {
+          this.analytics.track(eventKey, eventData);
+        } else if (eventKey) {
+          this.analytics.track(eventKey);
         }
-      });
-    this.broadcaster
-      .on('clickContinueAppOverlay')
-      .subscribe((data) => {
-        this.analytics.track('click continue app overlay', data);
-      });
-    this.broadcaster
-      .on('showCreateApp')
-      .subscribe((val) => {
-        if (val === true) {
-          this.analytics.track('create app opened');
-        } else {
-          this.analytics.track('create app closed');
-        }
-      });
-    this.broadcaster
-      .on('showImportApp')
-      .subscribe((val) => {
-        if (val === true) {
-          this.analytics.track('import app opened');
-        } else {
-          this.analytics.track('import app closed');
-        }
-      });
-    this.broadcaster
-      .on('completeMissionRuntimeStep')
-      .subscribe((data: any) => {
-        this.analytics.track('mission runtime completed', data);
-      });
-    this.broadcaster
-      .on('completeDependencyEditorStep')
-      .subscribe((data: any) => {
-        this.analytics.track('dependency editor completed', data);
-      });
-    this.broadcaster
-      .on('completePipelineStep_Create')
-      .subscribe((data: any) => {
-        this.analytics.track('pipeline completed in create', data);
-      });
-    this.broadcaster
-      .on('completeGitProviderStep_Create')
-      .subscribe((data: any) => {
-        this.analytics.track('git provider completed in create', data);
-      });
-    this.broadcaster
-      .on('completeSummaryStep_Create')
-      .subscribe((data: any) => {
-        this.analytics.track('summary completed in create', data);
-      });
-    this.broadcaster
-      .on('completePipelineStep_Import')
-      .subscribe((data: any) => {
-        this.analytics.track('pipeline completed in import', data);
-      });
-    this.broadcaster
-      .on('completeGitProviderStep_Import')
-      .subscribe((data: any) => {
-        this.analytics.track('git provider completed in import', data);
-      });
-    this.broadcaster
-      .on('completeSummaryStep_Import')
-      .subscribe((data: any) => {
-        this.analytics.track('summary completed in import', data);
-      });
-    this.broadcaster
-      .on('viewApplicationButtonClicked')
-      .subscribe(() => {
-        this.analytics.track('view application button clicked');
-      });
-    this.broadcaster
-      .on('stepIndicatorClicked')
-      .subscribe((data: any) => {
-        this.analytics.track('step indicator clicked', data);
-      });
-    this.broadcaster
-      .on('stepIndicatorProjectInputClicked')
-      .subscribe((data: any) => {
-        this.analytics.track('step indicator project name clicked');
       });
   }
-
 }

--- a/src/app/shared/analytics.service.ts
+++ b/src/app/shared/analytics.service.ts
@@ -18,25 +18,81 @@ declare global {
 export class AnalyticService {
 
   constructor(
-    private fabric8UIConfig: Fabric8UIConfig,
-    private broadcaster: Broadcaster,
+    public fabric8UIConfig: Fabric8UIConfig,
+    public broadcaster: Broadcaster,
     private userService: UserService,
     private router: Router,
     private contexts: Contexts,
     private notificationsService: NotificationsService,
     private spaces: Spaces
   ) {
-    if (this.fabric8UIConfig.analyticsWriteKey) {
-      this.initialize(this.fabric8UIConfig.analyticsWriteKey);
-      this.track();
-    }
+    this.init();
   }
 
   get analytics(): SegmentAnalytics.AnalyticsJS {
     return window.analytics;
   }
 
-  private track() {
+  public init() {
+    if (this.fabric8UIConfig.analyticsWriteKey) {
+      this.initialize(this.fabric8UIConfig.analyticsWriteKey);
+      this.track();
+    }
+  }
+
+  public initialize(apiWriteKey: string) {
+    // THIS CODE IS DIRECTLY PASTED FROM SEGMENT
+    let analytics = window.analytics = window.analytics || [];
+    if (!analytics.initialize) {
+      if (analytics.invoked) {
+        window.console && console.error && console.error('Segment snippet included twice.');
+      } else {
+        analytics.invoked = !0;
+        analytics.methods = [
+          'trackSubmit',
+          'trackClick',
+          'trackLink',
+          'trackForm',
+          'pageview',
+          'identify',
+          'reset',
+          'group',
+          'track',
+          'ready',
+          'alias',
+          'debug',
+          'page',
+          'once',
+          'off',
+          'on'
+        ];
+        analytics.factory = function(t) {
+          return function() {
+            var e = Array.prototype.slice.call(arguments);
+            e.unshift(t);
+            analytics.push(e);
+            return analytics;
+          };
+        };
+        for (var t = 0; t < analytics.methods.length; t++) {
+          var e = analytics.methods[t];
+          analytics[e] = analytics.factory(e);
+        }
+        analytics.load = function(t) {
+          var e = document.createElement('script');
+          e.type = 'text/javascript';
+          e.async = !0;
+          e.src = ('https:' === document.location.protocol ? 'https://' : 'http://') + 'cdn.segment.com/analytics.js/v1/' + t + '/analytics.min.js';
+          var n = document.getElementsByTagName('script')[0];
+          n.parentNode.insertBefore(e, n);
+        };
+        analytics.SNIPPET_VERSION = '4.0.0';
+        analytics.load(apiWriteKey);
+      }
+    }
+  }
+
+  public track() {
     // Navigation
     this.broadcaster
       .on('navigate')
@@ -108,56 +164,18 @@ export class AnalyticService {
     this.activateLauncherEventListeners();
   }
 
-  private initialize(apiWriteKey: string) {
-    // THIS IS CODE DIRECTLY PASTED FROM SEGMENT
-    let analytics = window.analytics = window.analytics || [];
-    if (!analytics.initialize) {
-      if (analytics.invoked) {
-        window.console && console.error && console.error('Segment snippet included twice.');
-      } else {
-        analytics.invoked = !0;
-        analytics.methods = [
-          'trackSubmit',
-          'trackClick',
-          'trackLink',
-          'trackForm',
-          'pageview',
-          'identify',
-          'reset',
-          'group',
-          'track',
-          'ready',
-          'alias',
-          'debug',
-          'page',
-          'once',
-          'off',
-          'on'
-        ];
-        analytics.factory = function(t) {
-          return function() {
-            var e = Array.prototype.slice.call(arguments);
-            e.unshift(t);
-            analytics.push(e);
-            return analytics;
-          };
-        };
-        for (var t = 0; t < analytics.methods.length; t++) {
-          var e = analytics.methods[t];
-          analytics[e] = analytics.factory(e);
+  public activateLauncherEventListeners(): void {
+    this.broadcaster
+      .on('analyticsTracker')
+      .subscribe((data: any) => {
+        const eventKey = data['event'];
+        const eventData = data['data'];
+        if (eventKey && eventData) {
+          this.analytics.track(eventKey, eventData);
+        } else if (eventKey) {
+          this.analytics.track(eventKey);
         }
-        analytics.load = function(t) {
-          var e = document.createElement('script');
-          e.type = 'text/javascript';
-          e.async = !0;
-          e.src = ('https:' === document.location.protocol ? 'https://' : 'http://') + 'cdn.segment.com/analytics.js/v1/' + t + '/analytics.min.js';
-          var n = document.getElementsByTagName('script')[0];
-          n.parentNode.insertBefore(e, n);
-        };
-        analytics.SNIPPET_VERSION = '4.0.0';
-        analytics.load(apiWriteKey);
-      }
-    }
+      });
   }
 
   private identifyUser(user: any): any {
@@ -172,19 +190,5 @@ export class AnalyticService {
     this.analytics.
       identify(
       user.id, traits);
-  }
-
-  private activateLauncherEventListeners(): void {
-    this.broadcaster
-      .on('analyticsTracker')
-      .subscribe((data: any) => {
-        const eventKey = data['event'];
-        const eventData = data['data'];
-        if (eventKey && eventData) {
-          this.analytics.track(eventKey, eventData);
-        } else if (eventKey) {
-          this.analytics.track(eventKey);
-        }
-      });
   }
 }

--- a/src/app/space/add-app-overlay/add-app-overlay.component.ts
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.ts
@@ -81,6 +81,9 @@ export class AddAppOverlayComponent implements OnDestroy {
    */
   hideAddAppOverlay(): void {
     this.broadcaster.broadcast('showAddAppOverlay', false);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'closeAddAppOverlay'
+    });
   }
 
   /**

--- a/src/app/space/add-space-overlay/add-space-overlay.component.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.ts
@@ -140,6 +140,12 @@ export class AddSpaceOverlayComponent implements OnInit {
 
   hideAddSpaceOverlay(): void {
     this.broadcaster.broadcast('showAddSpaceOverlay', false);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showAddAppOverlay',
+      data: {
+        source: 'space-overlay'
+      }
+    });
   }
 
   showAddAppOverlay(): void {

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
@@ -60,6 +60,12 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
 
   showAddAppOverlay(): void {
     this.broadcaster.broadcast('showAddAppOverlay', true);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showAddAppOverlay',
+      data: {
+        source: 'analyze-overview'
+      }
+    });
   }
 
   checkSpaceOwner(): boolean {

--- a/src/app/space/app-launcher/create-app/create-app.component.ts
+++ b/src/app/space/app-launcher/create-app/create-app.component.ts
@@ -43,7 +43,9 @@ export class CreateAppComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
-    this.broadcaster.broadcast('showCreateApp', true);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showCreateApp'
+    });
   }
 
   /**
@@ -51,7 +53,9 @@ export class CreateAppComponent implements OnDestroy, OnInit {
    */
   cancel($event: any): void {
     this.router.navigate(['/', this.loggedInUser.attributes.username, this.currentSpace.attributes.name]);
-    this.broadcaster.broadcast('showCreateApp', false);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'closeCreateApp'
+    });
   }
 
   /**

--- a/src/app/space/app-launcher/import-app/import-app.component.ts
+++ b/src/app/space/app-launcher/import-app/import-app.component.ts
@@ -43,7 +43,9 @@ export class ImportAppComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
-    this.broadcaster.broadcast('showImportApp', true);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showImportApp'
+    });
   }
 
   /**
@@ -51,7 +53,9 @@ export class ImportAppComponent implements OnDestroy, OnInit {
    */
   cancel($event: any): void {
     this.router.navigate(['/', this.loggedInUser.attributes.username, this.currentSpace.attributes.name]);
-    this.broadcaster.broadcast('showImportApp', false);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'closeImportApp'
+    });
   }
 
   /**

--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -140,6 +140,12 @@ export class CodebasesComponent implements OnDestroy, OnInit {
 
   showAddAppOverlay(): void {
     this.broadcaster.broadcast('showAddAppOverlay', true);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showAddAppOverlay',
+      data: {
+        source: 'codebases'
+      }
+    });
   }
   // Filter
 

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -119,6 +119,12 @@ export class DeploymentsAppsComponent implements OnInit, OnDestroy {
 
   showAddAppOverlay(): void {
     this.broadcaster.broadcast('showAddAppOverlay', true);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showAddAppOverlay',
+      data: {
+        source: 'deployment-apps'
+      }
+    });
   }
 
 }

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -131,6 +131,12 @@ export class PipelinesComponent implements OnInit, OnDestroy {
 
   showAddAppOverlay(): void {
     this.broadcaster.broadcast('showAddAppOverlay', true);
+    this.broadcaster.broadcast('analyticsTracker', {
+      event: 'showAddAppOverlay',
+      data: {
+        source: 'pipelines'
+      }
+    });
   }
 
   filterChange($event: FilterEvent): void {


### PR DESCRIPTION
- This PR uses a single event name to listen all the analytics tracking events
- Depends on https://github.com/fabric8-ui/fabric8-ui/pull/3130
- Depends on https://github.com/fabric8-launcher/ngx-launcher/pull/335. Before merging this PR the launcher package has to be bumped up
- Version upgrade for launcher to 1.0.8 to address some minor bugs

Addresses issue - https://github.com/openshiftio/openshift.io/issues/3239