### PR TITLE
fix(nav-tabs): prevent flickering when navigating between tabs

### DIFF
--- a/src/app/profile/overview/overview.component.less
+++ b/src/app/profile/overview/overview.component.less
@@ -110,19 +110,23 @@
   margin-left: -48px;
   background-color: @color-pf-black-150;
   border-bottom: 1px solid @color-pf-black-300;
-  ul {
-    list-style-type: none;
-    padding-left: 25px;
-  }
-  li {
-    padding-right: 10px;
-    display: inline-block;
-  }
-  a {
-    color: @color-pf-black;
-    text-decoration: none;
-  }
-  a:hover {
-    color: @color-pf-blue;
+  .nav-tabs {
+    ul {
+      list-style-type: none;
+      padding-left: 25px;
+    }
+    li {
+      padding-right: 10px;
+      display: inline-block;
+    }
+    a {
+      border: none;
+      margin-bottom: 1px;
+      color: @color-pf-black;
+      text-decoration: none;
+    }
+    a:hover {
+      color: @color-pf-blue;
+    }
   }
 }

--- a/src/app/profile/settings/settings.component.less
+++ b/src/app/profile/settings/settings.component.less
@@ -29,7 +29,9 @@
     display: inline-block;
   }
   a {
+    border: none;
     color: @color-pf-black;
+    margin-bottom: 1px;
     text-decoration: none;
   }
   a:hover {

--- a/src/app/profile/update/update.component.less
+++ b/src/app/profile/update/update.component.less
@@ -145,6 +145,25 @@ textarea {
 }
 
 .profile-overview-nav {
+  padding: 4px 0 0;
+  margin-left: -48px;
   background-color: @color-pf-black-150;
   border-bottom: 1px solid @color-pf-black-300;
+  ul {
+    list-style-type: none;
+    padding-left: 25px;
+    li {
+      padding-right: 10px;
+      display: inline-block;
+      a {
+        border: none;
+        margin-bottom: 1px;
+        color: @color-pf-black;
+        text-decoration: none;
+      }
+      a:hover {
+        color: @color-pf-blue;
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR addresses issue 3986 [[0]](https://github.com/openshiftio/openshift.io/issues/3986) , where the nav-tabs have a noticeable visual stutter when clicking between tabs. This was also referenced in the images of a prior issue [1].

This flicker was due to the nav-tab border that was being briefly displayed when highlighting and/or clicking a tab. Even when hovering a tab there is a noticeable border that appears:
Before: notice the border around "My Spaces"
![before](https://user-images.githubusercontent.com/10425301/42698542-34af17d0-868c-11e8-8b8c-94853d2e522a.png)

This PR simply removes the border from the css, and uses a 1px margin bottom to recreate the same visual layout. It also fixes another issue where the `a:hover` isn't turning the text blue.

After:
![after](https://user-images.githubusercontent.com/10425301/42698541-349df824-868c-11e8-8c34-54d6b5e1158f.png)

Here are a couple gifs of the changes in action:

Before (settings nav): notice the flicker when clicking between tabs
![old-settings](https://user-images.githubusercontent.com/10425301/42698552-3b61ef12-868c-11e8-9f69-3d4275727322.gif)

After (settings nav):
![new-settings](https://user-images.githubusercontent.com/10425301/42698553-3d20236e-868c-11e8-93db-f8aa8314ae1f.gif)

[0] https://github.com/openshiftio/openshift.io/issues/3986
[1] https://github.com/openshiftio/openshift.io/issues/3724#issue-328664172