### PR TITLE
fix(cors): remove `api` subdomain from wit api url

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -26,7 +26,7 @@ const HMR = helpers.hasProcessFlag('hot');
 // if env is 'inmemory', the inmemory debug resource is used
 const FABRIC8_FORGE_API_URL = process.env.FABRIC8_FORGE_API_URL || 'https://forge.api.prod-preview.openshift.io';
 const FABRIC8_FEATURE_TOGGLES_API_URL = process.env.FABRIC8_FEATURE_TOGGLES_API_URL;
-const FABRIC8_WIT_API_URL = process.env.FABRIC8_WIT_API_URL || 'https://api.prod-preview.openshift.io/api/';
+const FABRIC8_WIT_API_URL = process.env.FABRIC8_WIT_API_URL || 'https://prod-preview.openshift.io/api/';
 const FABRIC8_AUTH_API_URL = process.env.FABRIC8_AUTH_API_URL || 'https://auth.prod-preview.openshift.io/api/';
 const FABRIC8_REALM = process.env.FABRIC8_REALM || 'fabric8';
 const FABRIC8_SSO_API_URL = process.env.FABRIC8_SSO_API_URL || 'https://sso.prod-preview.openshift.io/';

--- a/environments/openshift-prod-cluster.sh
+++ b/environments/openshift-prod-cluster.sh
@@ -35,7 +35,7 @@ export WS_K8S_API_SERVER_PROTOCOL="wss"
 export WS_K8S_API_SERVER_BASE_PATH=""
 
 export FABRIC8_SSO_API_URL=https://sso.openshift.io/
-export FABRIC8_WIT_API_URL=https://api.openshift.io/api/
+export FABRIC8_WIT_API_URL=https://openshift.io/api/
 export FABRIC8_AUTH_API_URL=https://auth.openshift.io/api/
 
 

--- a/environments/openshift-prod-preview-cluster.sh
+++ b/environments/openshift-prod-preview-cluster.sh
@@ -35,7 +35,7 @@ export WS_K8S_API_SERVER_PROTOCOL="wss"
 export WS_K8S_API_SERVER_BASE_PATH=""
 
 export FABRIC8_SSO_API_URL=https://sso.prod-preview.openshift.io/
-export FABRIC8_WIT_API_URL=https://api.prod-preview.openshift.io/api/
+export FABRIC8_WIT_API_URL=https://prod-preview.openshift.io/api/
 export FABRIC8_AUTH_API_URL=https://auth.prod-preview.openshift.io/api/
 
 

--- a/release.groovy
+++ b/release.groovy
@@ -3,7 +3,7 @@ def ci (){
     stage('build npm'){
         sh 'npm install'
         sh '''
-        export FABRIC8_WIT_API_URL="https://api.prod-preview.openshift.io/api/"
+        export FABRIC8_WIT_API_URL="https://prod-preview.openshift.io/api/"
         export FABRIC8_RECOMMENDER_API_URL="https://api-bayesian.dev.rdu2c.fabric8.io/api/v1/"
         export FABRIC8_FORGE_API_URL="https://forge.api.prod-preview.openshift.io"
         export FABRIC8_SSO_API_URL="https://sso.prod-preview.openshift.io/"

--- a/src/app/shared/api-locator.service.ts
+++ b/src/app/shared/api-locator.service.ts
@@ -19,7 +19,6 @@ const DEFAULT_API_ENV_VAR_NAMES = new Map<string, string>(
 );
 
 const DEFAULT_API_PREFIXES = new Map<string, string>([
-  ['wit', 'api'],
   ['recommender', 'recommender'],
   ['analyticsRecommender', 'recommender.api'],
   ['analyticsLicense', 'license-analysis.api'],


### PR DESCRIPTION
In today's platform meeting, @aslakknutsen requested we change API calls from `https://api.openshift.io/api/` to `https://openshift.io/api/`.

Tested dev with prod and prod-preview environments.

- updated environment scripts
- updated webpack dev fallback
- removed wit prefix from `api-locator.service.ts`