### PR TITLE
fix(app): remove spaceName pipe usage

### DIFF
--- a/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget-old/edit-space-description-widget-old.component.html
@@ -1,6 +1,6 @@
 <div class="edit-space-description-widget-old">
   <h2 class="margin-0">
-    <b>{{space?.attributes.name | spaceName}}</b>
+    <b>{{space?.attributes.name}}</b>
   </h2>
   <!-- There must be no spaces here, otherwise we end up with random whitespace in the editable-->
   <div *ngIf="userOwnsSpace; else userDoesNotOwnSpace" class="form-group">

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -1,7 +1,7 @@
 <div class="edit-space-description-widget">
   <div class="col-sm-3 f8-space-masthead-space-info">
     <div>
-      <span class="f8-space-masthead-name">{{space?.attributes.name | spaceName}}</span> <span class="f8-space-masthead-owner">{{spaceOwner | async}}</span>
+      <span class="f8-space-masthead-name">{{space?.attributes.name}}</span> <span class="f8-space-masthead-owner">{{spaceOwner | async}}</span>
     </div>
     <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount | async}}
     <ng-container *ngIf='userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo'>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { Broadcaster } from 'ngx-base';
-import { CollaboratorService, Contexts, Space, SpaceNamePipe, Spaces, SpaceService } from 'ngx-fabric8-wit';
+import { CollaboratorService, Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
 import { User, UserService } from 'ngx-login-client';
 import { ConnectableObservable, Observable } from 'rxjs';
 import { createMock } from 'testing/mock';
@@ -42,7 +42,6 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
   ];
 
   initContext(EditSpaceDescriptionWidgetComponent, HostComponent, {
-    declarations: [SpaceNamePipe],
     providers: [
       { provide: Spaces, useFactory: () => {
           let mockSpaces: jasmine.SpyObj<Spaces> = createMock(Spaces);

--- a/src/app/home/recent-spaces-widget/recent-spaces-widget.component.html
+++ b/src/app/home/recent-spaces-widget/recent-spaces-widget.component.html
@@ -33,9 +33,9 @@
               <div class="list-view-pf-body">
                 <div class="list-view-pf-description">
                   <div class="list-group-item-text">
-                    <a [routerLink]="['/', space.relationalData.creator.attributes.username, space.attributes.name]" tooltip="{{space.attributes.name | spaceName}}"
+                    <a [routerLink]="['/', space.relationalData.creator.attributes.username, space.attributes.name]" tooltip="{{space.attributes.name}}"
                       placement="bottom">
-                      {{space.attributes.name | spaceName}}
+                      {{space.attributes.name}}
                     </a>
                   </div>
                 </div>

--- a/src/app/home/work-item-widget/work-item-widget.component.html
+++ b/src/app/home/work-item-widget/work-item-widget.component.html
@@ -11,7 +11,7 @@
               (ngModelChange)="fetchWorkItems()">
             <option value="default">Select a space to work with...</option>
             <option *ngFor="let space of recentSpaces" [value]="space.id">
-              {{space.attributes.name | spaceName}}
+              {{space.attributes.name}}
             </option>
           </select>
         </span>
@@ -67,7 +67,7 @@
                     (ngModelChange)="fetchWorkItems()">
               <option value="default">Select a space to work with...</option>
               <option *ngFor="let space of recentSpaces" [value]="space.id">
-                {{space.attributes.name | spaceName}}
+                {{space.attributes.name}}
               </option>
             </select>
           </span>

--- a/src/app/profile/my-spaces/my-spaces-item-actions/my-spaces-item-actions.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-item-actions/my-spaces-item-actions.component.spec.ts
@@ -9,7 +9,6 @@ import { LocalStorageService } from 'angular-2-local-storage';
 import { Broadcaster, Notifications } from 'ngx-base';
 import {
   Contexts,
-  SpaceNamePipe,
   SpaceService
 } from 'ngx-fabric8-wit';
 import { UserService } from 'ngx-login-client';
@@ -26,20 +25,17 @@ describe('My Spaces Item Actions Component', () => {
   let fixture;
   let mockRouter: any;
   let mockBroadcaster: any;
-  let mockContexts: any;
   let mockLocalStorage: any;
   let mockMenu: any;
   let mockNotifications: any;
   let mockProfileService: any;
   let mockRoute: any;
-  let mockSpaceNamePipe: any;
   let mockSpaceService: any;
   let mockUserService: any;
 
   let space: any;
 
   beforeEach(() => {
-    mockContexts = jasmine.createSpy('Contexts');
     mockRouter = jasmine.createSpy('Router');
     mockBroadcaster = jasmine.createSpy('Broadcaster');
     mockMenu = jasmine.createSpyObj('MenusService', ['attach']);
@@ -51,7 +47,6 @@ describe('My Spaces Item Actions Component', () => {
     mockRoute = jasmine.createSpy('ActivatedRoute');
     mockProfileService = jasmine.createSpy('ProfileService');
     mockProfileService.current = Observable.of(profile);
-    mockSpaceNamePipe = jasmine.createSpy('SpaceNamePipe');
     mockLocalStorage = jasmine.createSpy('LocalStorageService');
 
     TestBed.configureTestingModule({
@@ -88,9 +83,6 @@ describe('My Spaces Item Actions Component', () => {
         },
         {
           provide: LocalStorageService, useValue: mockLocalStorage
-        },
-        {
-          provide: SpaceNamePipe, useValue: mockSpaceNamePipe
         }
       ],
       // Tells the compiler not to error on unknown elements and attributes

--- a/src/app/profile/my-spaces/my-spaces-item/my-spaces-item.component.html
+++ b/src/app/profile/my-spaces/my-spaces-item/my-spaces-item.component.html
@@ -1,7 +1,7 @@
 <div class="my-spaces-item" *ngIf="space?.relationalData?.creator?.attributes">
   <div class="list-pf-title">
     <a [routerLink]="['/', space?.relationalData?.creator?.attributes?.username, space?.attributes?.name]">
-      {{space?.attributes?.name | spaceName}}</a>
+      {{space?.attributes?.name}}</a>
     <span class="avatar">
       <img src="{{space?.relationalData?.creator?.attributes?.imageURL}}">
       <span class="margin-left-10">{{space?.relationalData?.creator?.attributes?.username}}</span>

--- a/src/app/profile/overview/spaces/spaces.component.html
+++ b/src/app/profile/overview/spaces/spaces.component.html
@@ -35,7 +35,7 @@
                   <div class="list-view-pf-description">
                     <div class="list-group-item-text">
                       <a [routerLink]="['/', space.relationalData.creator.attributes.username, space.attributes.name]">
-                        {{space.attributes.name | spaceName}}
+                        {{space.attributes.name}}
                       </a>
                     </div>
                   </div>

--- a/src/app/profile/overview/work-items/work-items.component.html
+++ b/src/app/profile/overview/work-items/work-items.component.html
@@ -12,7 +12,7 @@
                 onblur="this.size=0;">
           <option value="default">Select a space to work with...</option>
           <option *ngFor="let space of spaces" [value]="space.id">
-            {{space.attributes.name | spaceName}}
+            {{space.attributes.name}}
           </option>
         </select>
       </span>

--- a/src/app/profile/overview/work-items/work-items.component.spec.ts
+++ b/src/app/profile/overview/work-items/work-items.component.spec.ts
@@ -1,14 +1,19 @@
 import { Component, DebugElement, NO_ERRORS_SCHEMA, Pipe, PipeTransform } from '@angular/core';
 import { HttpModule } from '@angular/http';
 import { By } from '@angular/platform-browser';
-import { WorkItemService } from 'fabric8-planner';
+
 import { List, take } from 'lodash';
-import { Contexts, Space, SpaceNamePipe, Spaces, SpaceService, WIT_API_URL } from 'ngx-fabric8-wit';
-import { User } from 'ngx-login-client';
 import { Observable } from 'rxjs';
+
+import { WorkItemService } from 'fabric8-planner';
+
+import { Contexts, Space, Spaces, SpaceService, WIT_API_URL } from 'ngx-fabric8-wit';
+import { User } from 'ngx-login-client';
+
 import { createMock } from 'testing/mock';
 import { initContext, TestContext } from 'testing/test-context';
 import { ContextService } from '../../../shared/context.service';
+
 import { WorkItemsComponent } from './work-items.component';
 
 @Component({
@@ -56,7 +61,7 @@ describe('WorkItemsComponent', () => {
   ];
 
   initContext(WorkItemsComponent, HostComponent, {
-    declarations: [SpaceNamePipe, TakePipe],
+    declarations: [TakePipe],
     imports: [HttpModule],
     providers: [
       { provide: Contexts, useFactory: () => {

--- a/src/app/profile/spaces/spaces.component.html
+++ b/src/app/profile/spaces/spaces.component.html
@@ -39,7 +39,7 @@
             <div *ngFor="let s of spaces">
               <div class="space-item" *ngIf="s.relationalData && s.relationalData.creator && s.relationalData.creator.attributes">
                 <h2>
-                  <a [routerLink]="['/', s.relationalData.creator.attributes.username, s.attributes.name]">{{s.attributes.name | spaceName}}</a>
+                  <a [routerLink]="['/', s.relationalData.creator.attributes.username, s.attributes.name]">{{s.attributes.name}}</a>
                   <i class="fa fa-trash" (click)="confirmDeleteSpace(s, deleteSpace)" *ngIf="canDeleteSpace(s.relationalData.creator.id)"></i>
                 </h2>
                 <p>{{s.description}}</p>

--- a/src/app/shared/context.service.spec.ts
+++ b/src/app/shared/context.service.spec.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { LocalStorageService } from 'angular-2-local-storage';
 import { cloneDeep } from 'lodash';
 import { Broadcaster, Notifications } from 'ngx-base';
-import { SpaceNamePipe, SpaceService } from 'ngx-fabric8-wit';
+import { SpaceService } from 'ngx-fabric8-wit';
 import { FeatureTogglesService } from 'ngx-feature-flag';
 import { UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs';
@@ -24,7 +24,6 @@ describe('Context Service:', () => {
   let mockNotifications: any;
   let mockRoute: any;
   let mockProfileService: any;
-  let mockSpaceNamePipe: any;
   let mockLocalStorage: any;
   let mockFeatureTogglesService: any;
   let contextService: ContextService;
@@ -42,8 +41,6 @@ describe('Context Service:', () => {
     mockRoute = jasmine.createSpy('ActivatedRoute');
     mockProfileService = jasmine.createSpy('ProfileService');
     mockProfileService.current = Observable.of(profile);
-    mockSpaceNamePipe = jasmine.createSpyObj('SpaceNamePipe', ['transform']);
-    mockSpaceNamePipe.transform.and.returnValue('SPACE');
     mockLocalStorage = jasmine.createSpy('LocalStorageService');
     mockFeatureTogglesService = jasmine.createSpyObj('FeatureTogglesService', ['getAllFeaturesEnabledByLevel']);
     mockFeatureTogglesService.getAllFeaturesEnabledByLevel.and.returnValue(Observable.of([]));
@@ -76,9 +73,6 @@ describe('Context Service:', () => {
         },
         {
           provide: LocalStorageService, useValue: mockLocalStorage
-        },
-        {
-          provide: SpaceNamePipe, useValue: mockSpaceNamePipe
         },
         {
           provide: FeatureTogglesService, useValue: mockFeatureTogglesService

--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -8,7 +8,6 @@ import {
   Contexts,
   ContextTypes,
   Space,
-  SpaceNamePipe,
   SpaceService
 } from 'ngx-fabric8-wit';
 import { FeatureTogglesService } from 'ngx-feature-flag';
@@ -54,7 +53,6 @@ export class ContextService implements Contexts {
     private userService: UserService,
     private notifications: Notifications,
     private profileService: ProfileService,
-    private spaceNamePipe: SpaceNamePipe,
     private eventService: EventService,
     private toggleService: FeatureTogglesService) {
 
@@ -271,7 +269,7 @@ export class ContextService implements Contexts {
       } as Context;
       c.type = ContextTypes.BUILTIN.get('space');
       c.path = '/' + c.user.attributes.username + '/' + c.space.attributes.name;
-      c.name = this.spaceNamePipe.transform(c.space.attributes.name);
+      c.name = c.space.attributes.name;
     } else if (val.user) {
       c = {
         'user': val.user,

--- a/src/app/space/add-app-overlay/add-app-overlay.component.spec.ts
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 
 import { Broadcaster, Logger, Notification, Notifications, NotificationType } from 'ngx-base';
 import { PopoverConfig, PopoverModule } from 'ngx-bootstrap/popover';
-import { Context, ProcessTemplate, Space, SpaceNamePipe, SpaceService } from 'ngx-fabric8-wit';
+import { Context, ProcessTemplate, Space, SpaceService } from 'ngx-fabric8-wit';
 import { DependencyCheckService } from 'ngx-launcher';
 import { Profile, User, UserService } from 'ngx-login-client';
 import { Subject } from 'rxjs';
@@ -51,7 +51,6 @@ describe('AddAppOverlayComponent', () => {
   let mockNotifications: any = jasmine.createSpyObj('Notifications', ['message']);
   let mockUserService: any = jasmine.createSpyObj('UserService', ['getUser']);
   let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
-  let mockSpaceNamePipe: any = jasmine.createSpy('SpaceNamePipe');
   let mockSpacesService: any = jasmine.createSpyObj('SpacesService', ['addRecent']);
   let mockLogger: any = jasmine.createSpyObj('Logger', ['error']);
   let mockErrorHandler: any = jasmine.createSpyObj('ErrorHandler', ['handleError']);
@@ -205,7 +204,6 @@ describe('AddAppOverlayComponent', () => {
         { provide: Notifications, useValue: mockNotifications },
         { provide: UserService, useValue: mockUserService },
         { provide: SpaceNamespaceService, useValue: mockSpaceNamespaceService },
-        { provide: SpaceNamePipe, useValue: mockSpaceNamePipe },
         { provide: SpacesService, useValue: mockSpacesService },
         { provide: ContextService, useClass: mockContextService },
         { provide: Logger, useValue: mockLogger },

--- a/src/app/space/add-space-overlay/add-space-overlay.component.html
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.html
@@ -28,17 +28,16 @@
                       Space Name is required to create a Space.
                     </div>
                     <div [hidden]="!name.errors.minLength">
-                      Space Name must be at least {{name.errors.minLength?.min}} characters long
+                      {{name.errors.minLength?.message}}
                     </div>
                     <div [hidden]="!name.errors.maxLength">
-                      Space Name cannot be more than {{name.errors.maxLength?.max}} characters long
+                      {{name.errors.maxLength?.message}}
                     </div>
                     <div [hidden]="!name.errors.unique">
-                      The Space Name '{{name.errors.unique?.requestedName}}' is already in use as {{name.errors.unique?.existingSpace.relationalData.creator.attributes.username}}/{{name.errors.unique?.existingSpace.attributes.name}}
+                      {{name.errors.unique?.message}}
                     </div>
                     <div [hidden]="!name.errors.invalid">
-                      Space Name must contain only letters (upper case or lower case), numbers, underscores (_) or hyphens(-)<br/>
-                      It cannot start or end with an underscore or a hyphen
+                      {{name.errors.invalid?.message}}
                     </div>
                   </div>
                 </div>

--- a/src/app/space/add-space-overlay/add-space-overlay.component.html
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.html
@@ -28,17 +28,17 @@
                       Space Name is required to create a Space.
                     </div>
                     <div [hidden]="!name.errors.minLength">
-                      Space Name must be at least {{name.errors.minLength?.min}} characters long.
+                      Space Name must be at least {{name.errors.minLength?.min}} characters long
                     </div>
                     <div [hidden]="!name.errors.maxLength">
-                      Space Name cannot be more than {{name.errors.maxLength?.max}} characters long.
+                      Space Name cannot be more than {{name.errors.maxLength?.max}} characters long
                     </div>
                     <div [hidden]="!name.errors.unique">
-                      The Space Name '{{name.errors.unique?.requestedName}}' is already in use as {{name.errors.unique?.existingSpace.relationalData.creator.attributes.username}}/{{name.errors.unique?.existingSpace.attributes.name}}.
+                      The Space Name '{{name.errors.unique?.requestedName}}' is already in use as {{name.errors.unique?.existingSpace.relationalData.creator.attributes.username}}/{{name.errors.unique?.existingSpace.attributes.name}}
                     </div>
                     <div [hidden]="!name.errors.invalid">
-                      Space Name must contain only letters (upper case or lower case), numbers, spaces, underscores (_) or hyphens(-).<br/>
-                      It cannot start or end with a space, an underscore or a hyphen.
+                      Space Name must contain only letters (upper case or lower case), numbers, underscores (_) or hyphens(-)<br/>
+                      It cannot start or end with an underscore or a hyphen
                     </div>
                   </div>
                 </div>

--- a/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 
 import { Broadcaster, Logger, Notification, Notifications, NotificationType } from 'ngx-base';
-import { ProcessTemplate, Space, SpaceNamePipe, SpaceService } from 'ngx-fabric8-wit';
+import { ProcessTemplate, Space, SpaceService } from 'ngx-fabric8-wit';
 import { Profile, User, UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs/Observable';
 
@@ -31,7 +31,6 @@ describe('AddSpaceOverlayComponent', () => {
   let mockNotifications: any = jasmine.createSpyObj('Notifications', ['message']);
   let mockUserService: any = jasmine.createSpy('UserService');
   let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
-  let mockSpaceNamePipe: any = jasmine.createSpy('SpaceNamePipe');
   let mockSpacesService: any = jasmine.createSpyObj('SpacesService', ['addRecent']);
   let mockContextService: any = jasmine.createSpy('ContextService');
   let mockLogger: any = jasmine.createSpyObj('Logger', ['error']);
@@ -136,7 +135,6 @@ describe('AddSpaceOverlayComponent', () => {
         { provide: Notifications, useValue: mockNotifications },
         { provide: UserService, useValue: mockUserService },
         { provide: SpaceNamespaceService, useValue: mockSpaceNamespaceService },
-        { provide: SpaceNamePipe, useValue: mockSpaceNamePipe },
         { provide: SpacesService, useValue: mockSpacesService },
         { provide: ContextService, useValue: mockContextService },
         { provide: Logger, useValue: mockLogger },

--- a/src/app/space/add-space-overlay/add-space-overlay.component.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.ts
@@ -9,7 +9,7 @@ import {
 import { Router } from '@angular/router';
 
 import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
-import { Context, SpaceNamePipe, SpaceService } from 'ngx-fabric8-wit';
+import { Context, SpaceService } from 'ngx-fabric8-wit';
 import { ProcessTemplate } from 'ngx-fabric8-wit';
 import { Space, SpaceAttributes } from 'ngx-fabric8-wit';
 import { UserService } from 'ngx-login-client';
@@ -45,7 +45,6 @@ export class AddSpaceOverlayComponent implements OnInit {
               private notifications: Notifications,
               private userService: UserService,
               private spaceNamespaceService: SpaceNamespaceService,
-              private spaceNamePipe: SpaceNamePipe,
               private spacesService: SpacesService,
               private spaceTemplateService: SpaceTemplateService,
               private context: ContextService,

--- a/src/app/space/settings/collaborators/collaborators.component.html
+++ b/src/app/space/settings/collaborators/collaborators.component.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-8 col-sm-8 col-md-9">
-      <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name | spaceName}} Space:</h3>
+      <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name}} Space:</h3>
     </div>
     <div class="col-xs-4 col-sm-4 col-md-3">
       <div class="table-action-heading" (click)="launchAddCollaborators()">


### PR DESCRIPTION
This addresses the recommendations in https://github.com/openshiftio/openshift.io/issues/3793

The usages of spaceName pipe are removed. The error message for space names is updated to not allow spaces in the name in anticipation of https://github.com/fabric8-ui/ngx-fabric8-wit/pull/179