### PR TITLE
fix(collaborators): fixed component height and vertical scroll enabled for infinite scroll

### DIFF
--- a/src/app/space/settings/collaborators/collaborators.component.less
+++ b/src/app/space/settings/collaborators/collaborators.component.less
@@ -28,3 +28,8 @@
 .collab-username {
   font-weight: normal;
 }
+
+.collaborator-list-scroll {
+  max-height: 680px;
+  overflow-y: scroll;
+}

--- a/src/app/space/settings/collaborators/collaborators.component.less
+++ b/src/app/space/settings/collaborators/collaborators.component.less
@@ -31,5 +31,5 @@
 
 .collaborator-list-scroll {
   max-height: 680px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4010
Fixes https://github.com/fabric8-services/fabric8-auth/issues/554

- Set `max-height: 680px` and `overflow-y:scroll` to enable vertical scroll for collaborators component which will trigger scroll event for infiniteScroll directive.


