### PR TITLE
fix(workitemwidget): group feature flag to use page-cached feature-flag

### DIFF
--- a/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
+++ b/src/app/dashboard-widgets/applications-widget/applications-widget.component.html
@@ -1,4 +1,4 @@
-<f8-feature-toggle featureName="ApplicationsCard">
+<f8-feature-toggle featureName="Analyze.ApplicationsCard">
   <div class="applications-widget card-pf f8-card" user-level>
     <div class="card-pf-heading f8-card-heading">
       <div class="card-pf-heading-details"

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.html
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.html
@@ -1,4 +1,4 @@
-<f8-feature-toggle featureName="MyWorkItemsCard">
+<f8-feature-toggle featureName="Analyze.MyWorkItemsCard">
   <div id="spacehome-my-workitems-card" class="create-work-item-widget card-pf f8-card" user-level>
     <div class="card-pf-heading f8-card-heading">
       <div class="card-pf-heading-details f8-card-heading-details">

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.html
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.html
@@ -1,4 +1,4 @@
-<f8-feature-toggle featureName="WorkItemOverviewCard">
+<f8-feature-toggle featureName="Analyze.WorkItemOverviewCard">
   <div id="spacehome-workitems-card" class="create-work-item-widget card-pf f8-card" user-level>
     <div class="card-pf-heading f8-card-heading">
       <h2 class="card-pf-title">

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
@@ -38,7 +38,7 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
       this.loggedInUser = user;
     }));
 
-    this.subscriptions.push(this.featureTogglesService.getFeature('MyWorkItemsCard').subscribe((feature) => {
+    this.subscriptions.push(this.featureTogglesService.getFeature('Analyze.MyWorkItemsCard').subscribe((feature) => {
       if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
         this._myWorkItemsCard = true;
       }


### PR DESCRIPTION
improve feature-flag caching. As per [feature-flag doc](https://github.com/fabric8-ui/ngx-feature-flag/blob/master/README.md), grouping `Analyze.MyWorkItemsCard`, `Analyze.ApplicationsCard`,  `Analyze.WorkItemOverviewCard` under `Analyze` page will avoid 3 http page each time you reach Analyze page (use of cached values instead)
Part of https://openshift.io/openshiftio/Openshift_io/plan/detail/158 

> I've created on prod-review and prod newly name feature-flag to match the rename.