### PR TITLE
fix(recent-pipelines-widget): remove unused feature flag toggled html

### DIFF
--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
@@ -1,81 +1,42 @@
-<f8-feature-toggle featureName="Analyze.newHomeDashboard">
-  <div id="recent-apps-card" class="card-pf f8-card-lg" user-level>
-    <div class="card-pf-heading f8-card-heading">
-      <h2 class="card-pf-title">
-        Recent Workspaces
-      </h2>
+<div id="recent-pipelines-card" class="pipelines-widget card-pf f8-card" default-level>
+  <div class="card-pf-heading f8-card-heading">
+    <h2 class="card-pf-title">
+      Recent Active Pipelines
+      <span id="recent-pipelines-badge" class="badge f8-card-badge">{{buildConfigsCount}}</span>
+    </h2>
+  </div>
+  <div class="card-pf-body f8-card-body">
+    <fabric8-loading-widget message="Please wait while we load your recent active pipelines"
+                            *ngIf="loading === true"></fabric8-loading-widget>
+    <div class="f8-blank-slate-card blank-slate-recent-pipelines-card" *ngIf="!(buildConfigsCount) && loading !== true">
+      <h3>Pipelines reflect integration and deployment stages that code goes through</h3>
+      <p>
+        Pipelines display here when you commit and build your codebase.
+      </p>
     </div>
-    <div class="card-pf-body f8-card-body">
-      <div class="f8-blank-slate-card">
-        <h3>Create a workspace</h3>
-        <p>Learn how to
-          <a href="https://docs.openshift.io/user-guide.html#importing_a_codebase" target="top">
-            create a workspace
+    <ul id="recent-pipelines-list" class="list-group" *ngIf="(buildConfigsCount) > 0 && loading !== true">
+      <li class="list-group-item" *ngFor="let buildconfig of buildConfigs">
+        <div class="f8-card__pipeline-column">
+          <span class="{{buildconfig.iconStyle}} fa-spin" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle === 'pficon-running'"></span>
+          <span class="{{buildconfig.iconStyle}}" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle !== 'pficon-running'"></span>
+          <a id="spacehome-pipelines-title" [routerLink]="['/', contextPath, buildconfig.labels['space'], 'create', 'pipelines']"
+            class="f8-card__pipeline-column-name">
+            {{buildconfig.name}}
           </a>
-          by importing a codebase.
-        </p>
-      </div>
-      <!-- A list of the 5 most recent Workspaces will be displayed in place of the Blank Slate. -->
-      <!-- <div class="home-space-list-result">
-        <ul class="list-group list-view-pf list-view-pf-view list-view-pf-striped">
-          <li class="list-group-item" *ngFor="let space of recent">
-            <div class="list-view-pf-main-info">
-              <div class="list-view-pf-body">
-                <div class="list-view-pf-description">
-                  <div class="list-group-item-text">
-                    <a>
-                      Workspace name
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div> -->
-    </div>
+          <span>|</span>
+          <a [href]="buildconfig.openShiftConsoleUrl" target="_blank" class="f8-card__pipeline-column-build">
+            Build #{{buildconfig.lastVersion}}
+            <i class="fa fa-external-link" aria-hidden="true"></i>
+          </a>
+        </div>
+        <div class="f8-card__pipeline-column-start">
+          Started: {{buildconfig.lastBuild?.creationTimestamp | date:'short'}}
+        </div>
+        <div class="f8-card__pipeline-column-status">
+          Status:
+          <b>{{buildconfig.statusPhase || 'Unknown'}}</b>
+        </div>
+      </li>
+    </ul>
   </div>
-  <div id="recent-pipelines-card" class="pipelines-widget card-pf f8-card" default-level>
-    <div class="card-pf-heading f8-card-heading">
-      <h2 class="card-pf-title">
-        Recent Active Pipelines
-        <span id="recent-pipelines-badge" class="badge f8-card-badge">{{buildConfigsCount}}</span>
-      </h2>
-    </div>
-    <div class="card-pf-body f8-card-body">
-      <fabric8-loading-widget message="Please wait while we load your recent active pipelines"
-                              *ngIf="loading === true"></fabric8-loading-widget>
-      <div class="f8-blank-slate-card blank-slate-recent-pipelines-card" *ngIf="!(buildConfigsCount) && loading !== true">
-        <h3>Pipelines reflect integration and deployment stages that code goes through</h3>
-        <p>
-          Pipelines display here when you commit and build your codebase.
-        </p>
-      </div>
-      <ul id="recent-pipelines-list" class="list-group" *ngIf="(buildConfigsCount) > 0 && loading !== true">
-        <li class="list-group-item" *ngFor="let buildconfig of buildConfigs">
-          <div class="f8-card__pipeline-column">
-            <span class="{{buildconfig.iconStyle}} fa-spin" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle === 'pficon-running'"></span>
-            <span class="{{buildconfig.iconStyle}}" title="{{buildconfig.statusPhase}}" *ngIf="buildconfig.iconStyle !== 'pficon-running'"></span>
-            <a id="spacehome-pipelines-title" [routerLink]="['/', contextPath, buildconfig.labels['space'], 'create', 'pipelines']"
-              class="f8-card__pipeline-column-name">
-              {{buildconfig.name}}
-            </a>
-            <span>|</span>
-            <a [href]="buildconfig.openShiftConsoleUrl" target="_blank" class="f8-card__pipeline-column-build">
-              Build #{{buildconfig.lastVersion}}
-              <i class="fa fa-external-link" aria-hidden="true"></i>
-            </a>
-          </div>
-          <div class="f8-card__pipeline-column-start">
-            Started: {{buildconfig.lastBuild?.creationTimestamp | date:'short'}}
-          </div>
-          <div class="f8-card__pipeline-column-status">
-            Status:
-            <b>{{buildconfig.statusPhase || 'Unknown'}}</b>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>
-
-</f8-feature-toggle>
+</div>


### PR DESCRIPTION
A recent-workspaces-widget actually exists and the usage of the recent-pipelines-widget and recent-workspaces-widget on the home page means that the removed html is never used. It was also commented out for the most part anyways.