### PR TITLE
Fix Analyze overview feature flags

### DIFF
--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -1,45 +1,45 @@
-<f8-feature-toggle featureName="Analyze.newSpaceDashboard">
-  <div id="analyze-overview-dashboard" class="container-fluid analyze-overview-wrapper" user-level>
-    <div class="row f8-dashboard-masthead">
-      <div class="col-sm-10">
-        <fabric8-edit-space-description-widget [userOwnsSpace]='userOwnsSpace'></fabric8-edit-space-description-widget>
-      </div>
-      <div class="col-sm-2">
-        <div *ngIf="userOwnsSpace">
-          <button *ngIf="this.authentication.isLoggedIn()" id="user-level-analyze-overview-dashboard-create-space-button" class="btn btn-primary btn-lg f8-dashboard-masthead-create-application pull-right"
-            (click)="showAddAppOverlay()"> Create an Application </button>
-        </div>
-      </div>
+<div *ngIf="isUserEnabled; else defaultLevel" id="analyze-overview-dashboard" class="container-fluid analyze-overview-wrapper">
+  <div class="row f8-dashboard-masthead">
+    <div class="col-sm-10">
+      <fabric8-edit-space-description-widget [userOwnsSpace]='userOwnsSpace'></fabric8-edit-space-description-widget>
     </div>
-    <div class="cards-pf">
-      <div class="row row-cards-pf">
-        <div class="col-xs-12 col-md-4">
-          <fabric8-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-work-item-widget>
-        </div>
-        <div class="col-xs-12 col-md-8">
-          <fabric8-applications-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-applications-widget>
-        </div>
-      </div>
-    </div>
-    <div class="cards-pf">
-      <div class="row row-cards-pf">
-        <div class="col-xs-12 col-md-4">
-          <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
-        </div>
-        <div class="col-xs-12 col-md-8">
-          <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
-        </div>
+    <div class="col-sm-2">
+      <div *ngIf="userOwnsSpace">
+        <button *ngIf="this.authenticationService.isLoggedIn()" id="user-level-analyze-overview-dashboard-create-space-button" class="btn btn-primary btn-lg f8-dashboard-masthead-create-application pull-right"
+          (click)="showAddAppOverlay()"> Create an Application </button>
       </div>
     </div>
   </div>
-  <div id="analyze-overview" class="container-fluid analyze-overview-wrapper" default-level>
+  <div class="cards-pf">
+    <div class="row row-cards-pf">
+      <div class="col-xs-12 col-md-4">
+        <fabric8-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-work-item-widget>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        <fabric8-applications-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-applications-widget>
+      </div>
+    </div>
+  </div>
+  <div class="cards-pf">
+    <div class="row row-cards-pf">
+      <div class="col-xs-12 col-md-4">
+        <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
+      </div>
+    </div>
+  </div>
+</div>
+<ng-template #defaultLevel>
+  <div id="analyze-overview" class="container-fluid analyze-overview-wrapper">
     <div class="row margin-top-15">
       <div class="col-xs-12 col-sm-10">
         <fabric8-edit-space-description-widget-old [userOwnsSpace]="userOwnsSpace"></fabric8-edit-space-description-widget-old>
       </div>
       <div class="col-xs-4 col-xs-offset-4 col-sm-2 col-sm-offset-0">
         <ng-container *ngIf="userOwnsSpace">
-          <button *ngIf="this.authentication.isLoggedIn()" id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right"
+          <button *ngIf="this.authenticationService.isLoggedIn()" id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right"
             (click)="showAddAppOverlay()"> Add to space </button>
         </ng-container>
       </div>
@@ -60,15 +60,14 @@
           <fabric8-create-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-create-work-item-widget>
         </div>
         <div class="col-xs-12"
-             [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
+              [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
           <fabric8-pipelines-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-pipelines-widget>
         </div>
         <div class="col-xs-12"
-             [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
+              [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
           <fabric8-environment-widget></fabric8-environment-widget>
         </div>
       </div>
     </div>
   </div>
-</f8-feature-toggle>
-
+</ng-template>

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.html
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="isUserEnabled; else defaultLevel" id="analyze-overview-dashboard" class="container-fluid analyze-overview-wrapper">
+<div *ngIf="isUserEnabled()" id="analyze-overview-dashboard" class="container-fluid analyze-overview-wrapper">
   <div class="row f8-dashboard-masthead">
     <div class="col-sm-10">
       <fabric8-edit-space-description-widget [userOwnsSpace]='userOwnsSpace'></fabric8-edit-space-description-widget>
@@ -31,43 +31,41 @@
     </div>
   </div>
 </div>
-<ng-template #defaultLevel>
-  <div id="analyze-overview" class="container-fluid analyze-overview-wrapper">
-    <div class="row margin-top-15">
-      <div class="col-xs-12 col-sm-10">
-        <fabric8-edit-space-description-widget-old [userOwnsSpace]="userOwnsSpace"></fabric8-edit-space-description-widget-old>
-      </div>
-      <div class="col-xs-4 col-xs-offset-4 col-sm-2 col-sm-offset-0">
-        <ng-container *ngIf="userOwnsSpace">
-          <button *ngIf="this.authenticationService.isLoggedIn()" id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right"
-            (click)="showAddAppOverlay()"> Add to space </button>
-        </ng-container>
-      </div>
+<div *ngIf="isDefaultEnabled()" id="analyze-overview" class="container-fluid analyze-overview-wrapper">
+  <div class="row margin-top-15">
+    <div class="col-xs-12 col-sm-10">
+      <fabric8-edit-space-description-widget-old [userOwnsSpace]="userOwnsSpace"></fabric8-edit-space-description-widget-old>
     </div>
-    <div class="cards-pf">
-      <div class="row row-cards-pf">
-        <div class="col-xs-12 col-md-4">
-          <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
-        </div>
-        <div class="col-xs-12 col-md-8">
-          <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
-        </div>
-      </div>
+    <div class="col-xs-4 col-xs-offset-4 col-sm-2 col-sm-offset-0">
+      <ng-container *ngIf="userOwnsSpace">
+        <button *ngIf="this.authenticationService.isLoggedIn()" id="analyze-overview-add-to-space-button" class="btn btn-primary btn-lg pull-right"
+          (click)="showAddAppOverlay()"> Add to space </button>
+      </ng-container>
     </div>
-    <div class="cards-pf">
-      <div class="row row-cards-pf padding-top-0">
-        <div class="col-xs-12 col-md-4" *ngIf="myWorkItemsCard">
-          <fabric8-create-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-create-work-item-widget>
-        </div>
-        <div class="col-xs-12"
-              [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
-          <fabric8-pipelines-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-pipelines-widget>
-        </div>
-        <div class="col-xs-12"
-              [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
-          <fabric8-environment-widget></fabric8-environment-widget>
-        </div>
+  </div>
+  <div class="cards-pf">
+    <div class="row row-cards-pf">
+      <div class="col-xs-12 col-md-4">
+        <fabric8-add-codebase-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-add-codebase-widget>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        <fabric8-analytical-report-widget></fabric8-analytical-report-widget>
       </div>
     </div>
   </div>
-</ng-template>
+  <div class="cards-pf">
+    <div class="row row-cards-pf padding-top-0">
+      <div class="col-xs-12 col-md-4" *ngIf="myWorkItemsCard">
+        <fabric8-create-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-create-work-item-widget>
+      </div>
+      <div class="col-xs-12"
+            [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
+        <fabric8-pipelines-widget [userOwnsSpace]="userOwnsSpace" (addToSpace)="showAddAppOverlay()"></fabric8-pipelines-widget>
+      </div>
+      <div class="col-xs-12"
+            [ngClass]="{'col-md-4': myWorkItemsCard, 'col-md-6': !myWorkItemsCard}">
+        <fabric8-environment-widget></fabric8-environment-widget>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.spec.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.spec.ts
@@ -2,7 +2,8 @@ import { AnalyzeOverviewComponent } from './analyze-overview.component';
 
 import {
   Component,
-  NO_ERRORS_SCHEMA
+  NO_ERRORS_SCHEMA,
+  OnInit
 } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
@@ -19,6 +20,17 @@ import {
   initContext,
   TestContext
 } from 'testing/test-context';
+
+let callCount: number = 0;
+@Component({
+  selector: 'fabric8-analytical-report-widget',
+  template: '<div></div>'
+})
+class FakeAnalyticalReportWidget implements OnInit {
+  ngOnInit() {
+    callCount++;
+  }
+}
 
 @Component({
   template: '<alm-analyzeOverview></alm-analyzeOverview>'
@@ -41,7 +53,14 @@ describe('AnalyzeOverviewComponent', () => {
   };
   mockFeatureTogglesService.getFeature.and.returnValue(Observable.of(mockFeature));
 
+  beforeEach(() => {
+    callCount = 0;
+  });
+
   initContext(AnalyzeOverviewComponent, HostComponent, {
+    declarations: [
+      FakeAnalyticalReportWidget
+    ],
     providers: [
       { provide: BsModalService, useFactory: (): jasmine.SpyObj<BsModalService> => createMock(BsModalService) },
       { provide: Broadcaster, useFactory: (): jasmine.SpyObj<Broadcaster> => createMock(Broadcaster) },
@@ -183,5 +202,11 @@ describe('AnalyzeOverviewComponent', () => {
     this.detectChanges();
 
     expect(this.fixture.debugElement.query(By.css('#user-level-analyze-overview-dashboard-create-space-button'))).toBeNull();
+  });
+
+  it('should only instantiate visible feature flagged components', () => {
+    // There are two instances of fabric8-analytical-report-widget in the html
+    // under user and default feature level; it should only instantiate once.
+    expect(callCount).toBe(1);
   });
 });

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.spec.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.spec.ts
@@ -4,14 +4,16 @@ import {
   Component,
   NO_ERRORS_SCHEMA
 } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { Observable, Subject } from 'rxjs';
+
 import { Broadcaster } from 'ngx-base';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { Context, Contexts, Space } from 'ngx-fabric8-wit';
 import { Feature, FeatureTogglesService } from 'ngx-feature-flag';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
-import { Observable, Subject } from 'rxjs';
+
 import { createMock } from 'testing/mock';
 import {
   initContext,
@@ -26,9 +28,6 @@ class HostComponent { }
 describe('AnalyzeOverviewComponent', () => {
   type TestingContext = TestContext<AnalyzeOverviewComponent, HostComponent>;
 
-  let modalService: jasmine.SpyObj<BsModalService>;
-  let broadcaster: jasmine.SpyObj<Broadcaster>;
-  let authentication: jasmine.SpyObj<AuthenticationService>;
   let ctxSubj: Subject<Context> = new Subject<Context>();
   let fakeUserObs: Subject<User> = new Subject<User>();
 
@@ -99,8 +98,6 @@ describe('AnalyzeOverviewComponent', () => {
   });
 
   it('should recognize that the user owns the space', function(this: TestingContext) {
-    const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
-
     fakeUserObs.next({
       id: 'loggedInUser'
     } as User);
@@ -123,8 +120,6 @@ describe('AnalyzeOverviewComponent', () => {
   });
 
   it('should recognize that the user does not own the space', function(this: TestingContext) {
-    const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
-
     fakeUserObs.next({
       id: 'loggedInUser'
     } as User);
@@ -147,8 +142,6 @@ describe('AnalyzeOverviewComponent', () => {
   });
 
   it('should show the Create an Application button if the user owns the space', function(this: TestingContext) {
-    const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
-
     fakeUserObs.next({
       id: 'loggedInUser'
     } as User);
@@ -171,8 +164,6 @@ describe('AnalyzeOverviewComponent', () => {
   });
 
   it('should hide the Create an Application button if the user does not own the space', function(this: TestingContext) {
-    const userService: jasmine.SpyObj<UserService> = TestBed.get(UserService);
-
     fakeUserObs.next({
       id: 'loggedInUser'
     } as User);

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
@@ -15,7 +15,7 @@ import { AuthenticationService, User, UserService } from 'ngx-login-client';
 })
 export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
   context: Context;
-  isUserEnabled: boolean = false;
+  _isUserEnabled: boolean;
   isLoggedIn: boolean;
 
   private loggedInUser: User;
@@ -48,9 +48,15 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.featureTogglesService
         .getFeature('Analyze.newSpaceDashboard')
-        .subscribe((feature: Feature) => {
-          this.isUserEnabled = feature.attributes.enabled && feature.attributes['user-enabled'];
-        })
+        .timeout(2000)
+        .subscribe(
+          (feature: Feature) => {
+            this._isUserEnabled = feature.attributes.enabled && feature.attributes['user-enabled'];
+          },
+          () => {
+            this._isUserEnabled = false;
+          }
+        )
     );
 
     this.subscriptions.push(
@@ -75,6 +81,14 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
     this.subscriptions.forEach((sub: Subscription) => {
       sub.unsubscribe();
     });
+  }
+
+  isUserEnabled(): boolean {
+    return this._isUserEnabled !== undefined && this._isUserEnabled;
+  }
+
+  isDefaultEnabled(): boolean {
+    return this._isUserEnabled !== undefined && !this._isUserEnabled;
   }
 
   showAddAppOverlay(): void {

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { Broadcaster } from 'ngx-base';
-import { Context, Contexts, Space } from 'ngx-fabric8-wit';
-import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import { Subscription } from 'rxjs';
 
-import { FeatureTogglesService } from 'ngx-feature-flag';
-
+import { Broadcaster } from 'ngx-base';
+import { Context, Contexts } from 'ngx-fabric8-wit';
+import { Feature, FeatureTogglesService  } from 'ngx-feature-flag';
+import { AuthenticationService, User, UserService } from 'ngx-login-client';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -15,34 +14,54 @@ import { FeatureTogglesService } from 'ngx-feature-flag';
   styleUrls: ['./analyze-overview.component.less']
 })
 export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
-  private subscriptions: Subscription[] = [];
-  private loggedInUser: User;
   context: Context;
-  private space: Space;
+  isUserEnabled: boolean = false;
+  isLoggedIn: boolean;
+
+  private loggedInUser: User;
   private _myWorkItemsCard: boolean = false;
   private _userOwnsSpace: boolean = false;
 
-  constructor(private authentication: AuthenticationService,
-              private broadcaster: Broadcaster,
-              private contexts: Contexts,
-              private featureTogglesService: FeatureTogglesService,
-              private userService: UserService) { }
+  private subscriptions: Subscription[] = [];
+
+  constructor(
+    private authenticationService: AuthenticationService,
+    private broadcaster: Broadcaster,
+    private contexts: Contexts,
+    private featureTogglesService: FeatureTogglesService,
+    private userService: UserService
+  ) {}
 
   ngOnInit() {
-    this.subscriptions.push(this.contexts.current.subscribe((ctx: Context) => {
-      this.context = ctx;
-      this.space = ctx.space;
-    }));
+    this.subscriptions.push(
+      this.contexts.current.subscribe((ctx: Context) => {
+        this.context = ctx;
+      })
+    );
 
-    this.subscriptions.push(this.userService.loggedInUser.subscribe((user: User) => {
-      this.loggedInUser = user;
-    }));
+    this.subscriptions.push(
+      this.userService.loggedInUser.subscribe((user: User) => {
+        this.loggedInUser = user;
+      })
+    );
 
-    this.subscriptions.push(this.featureTogglesService.getFeature('Analyze.MyWorkItemsCard').subscribe((feature) => {
-      if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
-        this._myWorkItemsCard = true;
-      }
-    }));
+    this.subscriptions.push(
+      this.featureTogglesService
+        .getFeature('Analyze.newSpaceDashboard')
+        .subscribe((feature: Feature) => {
+          this.isUserEnabled = feature.attributes.enabled && feature.attributes['user-enabled'];
+        })
+    );
+
+    this.subscriptions.push(
+      this.featureTogglesService
+        .getFeature('Analyze.MyWorkItemsCard')
+        .subscribe((feature: Feature) => {
+          if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+            this._myWorkItemsCard = true;
+          }
+        })
+    );
 
     this._userOwnsSpace = this.checkSpaceOwner();
   }


### PR DESCRIPTION
This addresses
https://github.com/openshiftio/openshift.io/issues/2908

for the Analyze Overview component, which is the 'home' page for a Space. The directives are no longer instantiated when hidden via feature flags. This prevents useless code from being executed, especially the http requests.

The second commit adds a test for this that fails without and passes with, but it is a little bit ugly. If anyone has suggestions on how to write a better test, I would appreciate it. I don't mind including or excluding it, as it is subject to change if the directives within a feature flag level changes, or the feature flags are removed for this component.

Thoughts?