### PR TITLE
fix(work-item-widget): fix component updating when navigating differe…

### DIFF
--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.html
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.html
@@ -7,7 +7,7 @@
       </h2>
     </div>
     <div class="card-pf-body f8-card-body">
-      <ng-container *ngIf="(myWorkItemsCount | async) > 0; then showWorkItems else showBlankState"></ng-container>
+      <ng-container *ngIf="myWorkItemsCount > 0; then showWorkItems else showBlankState"></ng-container>
       <ng-template #showBlankState>
         <fabric8-loading-widget message="Please wait while we load your work item overview"
                                 *ngIf="loading === true"></fabric8-loading-widget>
@@ -18,7 +18,7 @@
           </p>
           <div class="f8-blank-slate-main-action">
             <div *ngIf="userOwnsSpace">
-              <button id="spacehome-workitems-create-button" class="btn btn-primary btn-lg" [routerLink]="[contextPath | async, 'plan']">Create work item</button>
+              <button id="spacehome-workitems-create-button" class="btn btn-primary btn-lg" [routerLink]="[contextPath, 'plan']">Create work item</button>
             </div>
           </div>
         </div>
@@ -27,10 +27,10 @@
         <div class="f8-card-body-grid">
           <div class="f8-work-item-card-data">
             <div class="f8-work-item-card-data-totals">
-              <h1 class="f8-work-item-card-data-totals--overview" id="total">{{myWorkItemsCount | async}}</h1>
+              <h1 class="f8-work-item-card-data-totals--overview" id="total">{{myWorkItemsCount}}</h1>
               <p class="f8-work-item-card-data-totals--overview-subtitle">Total work items</p>
               <p class="f8-work-item-card-data-totals--link">
-                <a [routerLink]="[contextPath | async, 'plan']">View Planner</a>
+                <a [routerLink]="[contextPath, 'plan']">View Planner</a>
               </p>
             </div>
             <div class="f8-work-item-card-data-status">

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.spec.ts
@@ -1,81 +1,76 @@
 import { LocationStrategy } from '@angular/common';
-import { DebugNode, NO_ERRORS_SCHEMA } from '@angular/core';
+import { DebugElement, DebugNode, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Event, Router, RouterModule } from '@angular/router';
 
 import { WorkItem, WorkItemService } from 'fabric8-planner';
-import { Contexts } from 'ngx-fabric8-wit';
-
+import { cloneDeep } from 'lodash';
+import { Context, Contexts } from 'ngx-fabric8-wit';
 import { Feature, FeatureTogglesService } from 'ngx-feature-flag';
+import { Observable } from 'rxjs';
+
+import { createMock } from 'testing/mock';
+import { MockFeatureToggleComponent } from 'testing/mock-feature-toggle.component';
 import { LoadingWidgetModule } from '../../dashboard-widgets/loading-widget/loading-widget.module';
 import { WorkItemBarchartModule } from './work-item-barchart/work-item-barchart.module';
 import { WorkItemWidgetComponent } from './work-item-widget.component';
-
-import { cloneDeep } from 'lodash';
-import { Observable } from 'rxjs';
-
-import { MockFeatureToggleComponent } from 'testing/mock-feature-toggle.component';
 
 describe('WorkItemWidgetComponent', () => {
   let fixture: ComponentFixture<WorkItemWidgetComponent>;
   let component: DebugNode['componentInstance'];
 
-  let mockContext = {
-    'user': {
-      'attributes': {
-        'username': 'mock-username'
-      },
-      'id': 'mock-user'
-    }
-  };
-  let mockRouterEvent: any = {
+  let mockContext: Context;
+  let workItem: WorkItem;
+
+  const mockRouterEvent: Event = {
     'id': 1,
     'url': 'mock-url'
-  };
-  let workItem = {
-    attributes: {
-      description: 'description',
-      name: 'name'
-    },
-    type: 'workitems'
-  } as WorkItem;
+  } as Event;
 
-  let workItem1 = cloneDeep(workItem);
-  let workItem2 = cloneDeep(workItem);
-  let workItem3 = cloneDeep(workItem);
-  let workItem4 = cloneDeep(workItem);
-  let workItem5 = cloneDeep(workItem);
-
-  let mockActivatedRoute: any = jasmine.createSpy('ActivatedRoute');
-  let mockContexts: any = jasmine.createSpy('Contexts');
-  let mockFeatureTogglesService = jasmine.createSpyObj('FeatureTogglesService', ['getFeature']);
-  let mockLocationStrategy: any = jasmine.createSpyObj('LocationStrategy', ['prepareExternalUrl']);
-  let mockRouter = jasmine.createSpyObj('Router', ['createUrlTree', 'navigate', 'serializeUrl']);
-  let mockWorkItemService: any = jasmine.createSpyObj('WorkItemService', ['getWorkItems']);
-
-  let mockFeature: Feature = {
+  const mockFeature: Feature = {
     'attributes': {
       'name': 'mock-attribute',
       'enabled': true,
       'user-enabled': true
     }
-  };
-  mockFeatureTogglesService.getFeature.and.returnValue(Observable.of(mockFeature));
+  } as Feature;
+
+  let workItem1: WorkItem = cloneDeep(workItem);
+  let workItem2: WorkItem = cloneDeep(workItem);
+  let workItem3: WorkItem = cloneDeep(workItem);
+  let workItem4: WorkItem = cloneDeep(workItem);
+  let workItem5: WorkItem = cloneDeep(workItem);
 
   beforeEach(() => {
-    workItem1.attributes['system.state'] = 'open';
-    workItem2.attributes['system.state'] = 'open';
-    workItem3.attributes['system.state'] = 'in progress';
-    workItem4.attributes['system.state'] = 'resolved';
-    workItem5.attributes['system.state'] = 'new';
 
-    mockContexts.current = Observable.of(mockContext);
-    mockRouter.events = Observable.of(mockRouterEvent);
-    mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
-      workItems: [workItem1, workItem2, workItem3, workItem4, workItem5]
-    }));
+    mockContext = {
+      'user': {
+        'attributes': {
+          'username': 'mock-username'
+        },
+        'id': 'mock-user'
+      }
+    } as Context;
+
+    workItem = {
+      attributes: {
+        description: 'description',
+        name: 'name'
+      },
+      type: 'workitems'
+    } as WorkItem;
+
+    workItem1 = cloneDeep(workItem);
+    workItem1.attributes['system.state'] = 'open';
+    workItem2 = cloneDeep(workItem);
+    workItem2.attributes['system.state'] = 'open';
+    workItem3 = cloneDeep(workItem);
+    workItem3.attributes['system.state'] = 'in progress';
+    workItem4 = cloneDeep(workItem);
+    workItem4.attributes['system.state'] = 'resolved';
+    workItem5 = cloneDeep(workItem);
+    workItem5.attributes['system.state'] = 'new';
 
     TestBed.configureTestingModule({
       imports: [
@@ -88,12 +83,54 @@ describe('WorkItemWidgetComponent', () => {
         WorkItemWidgetComponent
       ],
       providers: [
-        { provide: FeatureTogglesService, useValue: mockFeatureTogglesService },
-        { provide: ActivatedRoute, useValue: mockActivatedRoute },
-        { provide: Contexts, useFactory: () => mockContexts },
-        { provide: LocationStrategy, useValue: mockLocationStrategy },
-        { provide: Router, useValue: mockRouter },
-        { provide: WorkItemService, useValue: mockWorkItemService }
+        {
+          provide: FeatureTogglesService,
+          useFactory: () => {
+            const mockFeatureTogglesService: jasmine.SpyObj<FeatureTogglesService> = createMock(FeatureTogglesService);
+            mockFeatureTogglesService.getFeature.and.returnValue(Observable.of(mockFeature));
+            return mockFeatureTogglesService;
+          }
+        },
+        {
+          provide: ActivatedRoute,
+          useFactory: () => {
+            const mockActivatedRoute: any = jasmine.createSpy('ActivatedRoute');
+            return mockActivatedRoute;
+          }
+        },
+        {
+          provide: Contexts,
+          useFactory: () => {
+            const mockContexts: any = createMock(Contexts);
+            mockContexts.current = Observable.of(mockContext);
+            return mockContexts;
+          }
+        },
+        {
+          provide: LocationStrategy,
+          useFactory: () => {
+            const mockLocationStrategy: jasmine.SpyObj<LocationStrategy> = jasmine.createSpyObj('LocationStrategy', ['prepareExternalUrl']);
+            return mockLocationStrategy;
+          }
+        },
+        {
+          provide: Router,
+          useFactory: () => {
+            const mockRouter: any = jasmine.createSpyObj('Router', ['createUrlTree', 'navigate', 'serializeUrl']);
+            mockRouter.events = Observable.of(mockRouterEvent);
+            return mockRouter;
+          }
+        },
+        {
+          provide: WorkItemService,
+          useFactory: () => {
+            const mockWorkItemService: jasmine.SpyObj<WorkItemService> = createMock(WorkItemService);
+            mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
+              workItems: [workItem1, workItem2, workItem3, workItem4, workItem5]
+            }));
+            return mockWorkItemService;
+          }
+        }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });
@@ -103,27 +140,27 @@ describe('WorkItemWidgetComponent', () => {
   });
 
   it('Should output open count', () => {
-    let element = fixture.debugElement.query(By.css('#open'));
+    let element: DebugElement = fixture.debugElement.query(By.css('#open'));
     expect(element.nativeElement.textContent.trim().slice(0, '2'.length)).toBe('2');
   });
 
   it('Should output resolved count', () => {
-    let element = fixture.debugElement.query(By.css('#resolved'));
+    let element: DebugElement = fixture.debugElement.query(By.css('#resolved'));
     expect(element.nativeElement.textContent.trim().slice(0, '2'.length)).toBe('1');
   });
 
   it('Should output in progress count', () => {
-    let element = fixture.debugElement.query(By.css('#in-progress'));
+    let element: DebugElement = fixture.debugElement.query(By.css('#in-progress'));
     expect(element.nativeElement.textContent.trim().slice(0, '1'.length)).toBe('1');
   });
 
   it('Should output total count', () => {
-    let element = fixture.debugElement.query(By.css('#total'));
+    let element: DebugElement = fixture.debugElement.query(By.css('#total'));
     expect(element.nativeElement.textContent.trim().slice(0, '5'.length)).toBe('5');
   });
 
   it('Should output a bar chart', () => {
-    let elements = fixture.debugElement.queryAll(By.css('fabric8-work-item-barchart div'));
+    let elements: DebugElement[] = fixture.debugElement.queryAll(By.css('fabric8-work-item-barchart div'));
     expect(elements.length).toBe(1);
   });
 
@@ -142,4 +179,5 @@ describe('WorkItemWidgetComponent', () => {
 
     expect(fixture.debugElement.query(By.css('#spacehome-workitems-create-button'))).toBeNull();
   });
+
 });

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 
-import { ConnectableObservable, Observable } from 'rxjs';
+import { ConnectableObservable, Observable, Subscription } from 'rxjs';
 
 import { WorkItem, WorkItemService } from 'fabric8-planner';
 import { Contexts } from 'ngx-fabric8-wit';
@@ -20,12 +20,13 @@ export class WorkItemWidgetComponent implements OnInit {
 
   @Input() userOwnsSpace: boolean;
   private _myWorkItems: ConnectableObservable<WorkItem[]>;
-  myWorkItemsCount: Observable<number>;
+  private subscriptions: Subscription[] = [];
+  myWorkItemsCount: number;
   myWorkItemsResolved: number = 0;
   myWorkItemsInProgress: number = 0;
   myWorkItemsOpen: number = 0;
-  contextPath: Observable<string>;
-  loading: boolean = true;
+  contextPath: string;
+  loading: boolean;
 
   LABEL_RESOLVED: string = 'Resolved';
   LABEL_IN_PROGRESS: string = 'In Progress';
@@ -52,11 +53,32 @@ export class WorkItemWidgetComponent implements OnInit {
               private workItemService: WorkItemService) {
   }
 
-  ngOnInit() {
-    this.contextPath = this.contexts.current.map(context => context.path);
+  ngOnInit(): void {
+    this.subscriptions.push(this.contexts.current.subscribe(context => {
+      this.contextPath = context.path;
+      this.resetWorkItemCounts();
+      this.updateWorkItems();
+    }));
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => {
+      sub.unsubscribe();
+    });
+  }
+
+  private resetWorkItemCounts(): void {
+    this.myWorkItemsCount = this.myWorkItemsOpen = this.myWorkItemsInProgress = this.myWorkItemsResolved = 0;
+  }
+
+  private updateWorkItems(): void {
+    this.loading = true;
     this._myWorkItems = this.workItemService.getWorkItems(100000, [])
       .map(val => val.workItems)
-      .do(workItems => workItems.forEach(workItem => {
+      .do(workItems => {
+        this.myWorkItemsCount = workItems.length;
+        this.loading = false;
+        workItems.forEach(workItem => {
           let state = workItem.attributes['system.state'];
           if (state !== undefined) {
             if (state === this.STATE_OPEN) {
@@ -67,14 +89,11 @@ export class WorkItemWidgetComponent implements OnInit {
               this.myWorkItemsResolved++;
             }
           }
-        }))
-      .do(workItems => {
+        });
         this.initChartData();
       })
       .publishReplay(1);
     this._myWorkItems.connect();
-    this.myWorkItemsCount = this._myWorkItems.map(workItems => workItems.length);
-    this.loading = false;
   }
 
   get myWorkItems(): Observable<WorkItem[]> {

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
@@ -49,9 +49,10 @@ export class WorkItemWidgetComponent implements OnInit {
     yData: []
   };
 
-  constructor(private contexts: Contexts,
-              private workItemService: WorkItemService) {
-  }
+  constructor(
+    private contexts: Contexts,
+    private workItemService: WorkItemService
+  ) { }
 
   ngOnInit(): void {
     this.subscriptions.push(this.contexts.current.subscribe(context => {


### PR DESCRIPTION
…nt spaces

This PR addresses issue #3946 [[0]](https://github.com/openshiftio/openshift.io/issues/3946), in which the dashboard work-items-widget does not update when changing. This was because the component wasn't calling the work-items service when the context is changed, and even if it was, the variables containing the counts weren't being reset.

Here are a couple of gifs showing the before/after behaviour of this PR.

**Before:**
![before](https://user-images.githubusercontent.com/10425301/43145851-e9008576-8f2d-11e8-9ff9-23127ade36c1.gif)

**After:**
![after](https://user-images.githubusercontent.com/10425301/43145836-e5ca51e8-8f2d-11e8-8b9e-8a9d9936b7f9.gif)

[0] https://github.com/openshiftio/openshift.io/issues/3946

