### PR TITLE
fix(codebases): prevent new tab opening when creating workspace via d…

### DIFF
--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -6,7 +6,7 @@
     <li [ngClass]="{'disabled': workspaceBusy || !codebase.gitHubRepo}"
         [attr.role]="'menuitem'">
       <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="!workspaceBusy && codebase.gitHubRepo; else createDisabled"
-         (click)="createAndOpenWorkspace()">Create workspace</a>
+         (click)="createWorkspace()">Create workspace</a>
       <ng-template #createDisabled>
         <a href="javascript:void(0)" class="dropdown-item secondary-action" *ngIf="workspaceBusy"
           tooltip="Waiting for Che..." disabled>Create workspace</a>

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.spec.ts
@@ -4,10 +4,9 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { Broadcaster, Notifications } from 'ngx-base';
-import { ModalDirective, ModalModule } from 'ngx-bootstrap/modal';
+import { ModalModule } from 'ngx-bootstrap/modal';
 import { Observable } from 'rxjs';
 
-import { WindowService } from '../../../../shared/window.service';
 import { CheService } from '../services/che.service';
 import { CodebasesService } from '../services/codebases.service';
 import { GitHubService } from '../services/github.service';
@@ -20,7 +19,6 @@ describe('Codebases Item Actions Component', () => {
   let notificationMock: any;
   let fixture;
   let broadcasterMock: any;
-  let windowServiceMock: any;
   let cheServiceMock: any;
   let workspacesServiceMock: any;
   let codebasesServiceMock: any;
@@ -30,7 +28,6 @@ describe('Codebases Item Actions Component', () => {
     dialogMock = jasmine.createSpyObj('bs-modal', ['show', 'hide']);
     notificationMock = jasmine.createSpyObj('Notifications', ['message']);
     broadcasterMock = jasmine.createSpyObj('Broadcaster', ['broadcast', 'on']);
-    windowServiceMock = jasmine.createSpyObj('WindowService', ['open']);
     cheServiceMock = jasmine.createSpyObj('CheService', ['getState']);
     workspacesServiceMock = jasmine.createSpyObj('WorkspacesService', ['createWorkspace']);
     codebasesServiceMock = jasmine.createSpyObj('CodebasesService', ['deleteCodebase']);
@@ -41,9 +38,6 @@ describe('Codebases Item Actions Component', () => {
       providers: [
         {
           provide: Broadcaster, useValue: broadcasterMock
-        },
-        {
-          provide: WindowService, useValue: windowServiceMock
         },
         {
           provide: CheService, useValue: cheServiceMock
@@ -78,7 +72,6 @@ describe('Codebases Item Actions Component', () => {
       }
     };
     workspacesServiceMock.createWorkspace.and.returnValue(Observable.of(workspaceLinks));
-    windowServiceMock.open.and.returnValue(new WindowService());
     const notificationAction = { name: 'created' };
     notificationMock.message.and.returnValue(Observable.of(notificationAction));
     broadcasterMock.broadcast.and.returnValue();
@@ -89,7 +82,6 @@ describe('Codebases Item Actions Component', () => {
     fixture.detectChanges();
     // then
     expect(notificationMock.message).toHaveBeenCalled();
-    expect(windowServiceMock.open).toHaveBeenCalled();
     expect(broadcasterMock.broadcast).toHaveBeenCalled();
   }));
 

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -9,8 +9,6 @@ import { Codebase } from '../services/codebase';
 import { CodebasesService } from '../services/codebases.service';
 import { WorkspacesService } from '../services/workspaces.service';
 
-import { WindowService } from '../../../../shared/window.service';
-
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'codebases-item-actions',
@@ -30,7 +28,6 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   constructor(
       private broadcaster: Broadcaster,
       private notifications: Notifications,
-      private windowService: WindowService,
       private cheService: CheService,
       private workspacesService: WorkspacesService,
       private codebasesService: CodebasesService) {
@@ -49,9 +46,9 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   // Actions
 
   /**
-   * Create workspace and open in editor
+   * Create workspace
    */
-  createAndOpenWorkspace(): void {
+  createWorkspace(): void {
     this.workspaceBusy = true;
     this.subscriptions.push(this.cheService.getState().switchMap(che => {
       if (!che.clusterFull) {
@@ -62,7 +59,6 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
             this.workspaceBusy = false;
             if (workspaceLinks != undefined) {
               let name = this.getWorkspaceName(workspaceLinks.links.open);
-              this.windowService.open(workspaceLinks.links.open, name);
               this.notifications.message({
                 message: `Workspace created!`,
                 type: NotificationType.SUCCESS
@@ -110,7 +106,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
   /**
    * Process the click on confirm dialog button.
    */
-  onDeleteCodebase() {
+  onDeleteCodebase(): void {
     this.deleteCodebase();
   }
 


### PR DESCRIPTION
…ropdown menu

This PR addresses issue #3995 [[0]](https://github.com/openshiftio/openshift.io/issues/3995), in which creating a workspace via the dropdown menu on the codebases page will still try to open a new tab.

The behaviour of opening and creating workspaces was tweaked in a recent PR that addressed ad-block preventing the opening of new tabs [[1]](https://github.com/openshiftio/openshift.io/issues/3565). During review, it was discussed that separating the creation & opening logic could be advantageous with regards to getting around ad-blockers [[2]](https://github.com/fabric8-ui/fabric8-ui/pull/2972#issue-191572823), but I missed tweaking the drop-down menu action.

[0] https://github.com/openshiftio/openshift.io/issues/3995
[1] https://github.com/openshiftio/openshift.io/issues/3565
[2] https://github.com/fabric8-ui/fabric8-ui/pull/2972#issue-191572823

