### PR TITLE
Deployments upgrade to HttpClient

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { HttpClientModule } from '@angular/common/http';
 import { ApplicationRef, ErrorHandler, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Http, HttpModule } from '@angular/http';
@@ -152,6 +153,7 @@ export type StoreType = {
     EffectsModule.forRoot([]),
     EmptyStateModule,
     FormsModule,
+    HttpClientModule,
     HttpModule,
     KubernetesRestangularModule,
     KubernetesStoreModule,

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -183,23 +183,25 @@ export class DeploymentApiService {
       .map((response: TimeseriesResponse) => response.data.attributes);
   }
 
-  deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<HttpResponse<any>> {
+  deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<void> {
     const encSpaceId: string = encodeURIComponent(spaceId);
     const encEnvironmentName: string = encodeURIComponent(environmentName);
     const encApplicationId: string = encodeURIComponent(applicationId);
     const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
     return this.http.delete(url, { headers: this.headers, responseType: 'text' })
-      .catch((err: HttpErrorResponse) => this.handleHttpError(err));
+      .catch((err: HttpErrorResponse) => this.handleHttpError(err))
+      .map(() => null);
   }
 
-  scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<HttpResponse<any>> {
+  scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<void> {
     const encSpaceId: string = encodeURIComponent(spaceId);
     const encEnvironmentName: string = encodeURIComponent(environmentName);
     const encApplicationId: string = encodeURIComponent(applicationId);
     const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
     const params: HttpParams = new HttpParams().set('podCount', String(desiredReplicas));
     return this.http.put(url, '', { headers: this.headers, params, responseType: 'text' })
-      .catch((err: HttpErrorResponse) => this.handleHttpError(err));
+      .catch((err: HttpErrorResponse) => this.handleHttpError(err))
+      .map(() => null);
   }
 
   private httpGet<T>(url: string, params: HttpParams = new HttpParams()): Observable<T> {

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -1,13 +1,14 @@
 import {
+  HttpClient,
+  HttpErrorResponse,
+  HttpHeaders,
+  HttpResponse
+} from '@angular/common/http';
+import {
   ErrorHandler,
   Inject,
   Injectable
 } from '@angular/core';
-import {
-  Headers,
-  Http,
-  Response
-} from '@angular/http';
 import { Observable } from 'rxjs';
 
 import { Logger } from 'ngx-base';
@@ -134,32 +135,32 @@ export interface SeriesData {
 @Injectable()
 export class DeploymentApiService {
 
-  private readonly headers: Headers = new Headers();
+  private readonly headers: HttpHeaders = new HttpHeaders();
   private readonly apiUrl: string;
 
   constructor(
-    private readonly http: Http,
+    private readonly http: HttpClient,
     @Inject(WIT_API_URL) private readonly witUrl: string,
     private readonly auth: AuthenticationService,
     private readonly logger: Logger,
     private readonly errorHandler: ErrorHandler
   ) {
     if (this.auth.getToken() != null) {
-      this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
+      this.headers = this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
     }
     this.apiUrl = witUrl + 'deployments/spaces/';
   }
 
   getEnvironments(spaceId: string): Observable<EnvironmentStat[]> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    return this.httpGet(`${this.apiUrl}${encSpaceId}/environments`)
-      .map((response: Response): EnvironmentStat[] => (response.json() as EnvironmentsResponse).data);
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    return this.httpGet<EnvironmentsResponse>(`${this.apiUrl}${encSpaceId}/environments`)
+      .map((response: EnvironmentsResponse): EnvironmentStat[] => response.data);
   }
 
   getApplications(spaceId: string): Observable<Application[]> {
     const encSpaceId = encodeURIComponent(spaceId);
-    return this.httpGet(`${this.apiUrl}${encSpaceId}`)
-      .map((response: Response): Application[] => (response.json() as ApplicationsResponse).data.attributes.applications);
+    return this.httpGet<ApplicationsResponse>(`${this.apiUrl}${encSpaceId}`)
+      .map((response: ApplicationsResponse): Application[] => response.data.attributes.applications);
   }
 
   getTimeseriesData(spaceId: string, environmentName: string, applicationId: string, startTime: number, endTime: number): Observable<MultiTimeseriesData> {
@@ -167,8 +168,8 @@ export class DeploymentApiService {
     const encEnvironmentName = encodeURIComponent(environmentName);
     const encApplicationId = encodeURIComponent(applicationId);
     const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/statseries?start=${startTime}&end=${endTime}`;
-    return this.httpGet(url)
-      .map((response: Response) => (response.json() as MultiTimeseriesResponse).data);
+    return this.httpGet<MultiTimeseriesResponse>(url)
+      .map((response: MultiTimeseriesResponse) => response.data);
   }
 
   getLatestTimeseriesData(spaceId: string, environmentName: string, applicationId: string): Observable<TimeseriesData> {
@@ -176,37 +177,37 @@ export class DeploymentApiService {
     const encEnvironmentName = encodeURIComponent(environmentName);
     const encApplicationId = encodeURIComponent(applicationId);
     const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/stats`;
-    return this.httpGet(url)
-      .map((response: Response) => (response.json() as TimeseriesResponse).data.attributes);
+    return this.httpGet<TimeseriesResponse>(url)
+      .map((response: TimeseriesResponse) => response.data.attributes);
   }
 
-  deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<Response> {
+  deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<HttpResponse<any>> {
     const encSpaceId = encodeURIComponent(spaceId);
     const encEnvironmentName = encodeURIComponent(environmentName);
     const encApplicationId = encodeURIComponent(applicationId);
     const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
-    return this.http.delete(url, { headers: this.headers })
-      .catch((err: Response) => this.handleHttpError(err));
+    return this.http.delete(url, { headers: this.headers, responseType: 'text' })
+      .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }
 
-  scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<Response> {
+  scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<HttpResponse<any>> {
     const encSpaceId = encodeURIComponent(spaceId);
     const encEnvironmentName = encodeURIComponent(environmentName);
     const encApplicationId = encodeURIComponent(applicationId);
     const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}?podCount=${desiredReplicas}`;
-    return this.http.put(url, '', { headers: this.headers })
-      .catch((err: Response) => this.handleHttpError(err));
+    return this.http.put(url, '', { headers: this.headers, responseType: 'text' })
+      .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }
 
-  private httpGet(url: string): Observable<Response> {
-    return this.http.get(url, { headers: this.headers })
-      .catch((err: Response) => this.handleHttpError(err));
+  private httpGet<T>(url: string): Observable<T> {
+    return this.http.get<T>(url, { headers: this.headers })
+      .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }
 
-  private handleHttpError(response: Response): Observable<Response> {
-    this.errorHandler.handleError(response);
-    this.logger.error(response);
-    return Observable.throw(response);
+  private handleHttpError(err: HttpErrorResponse): Observable<any> {
+    this.errorHandler.handleError(err);
+    this.logger.error(err);
+    return Observable.throw(err);
   }
 
 }

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -140,7 +140,7 @@ export class DeploymentApiService {
 
   constructor(
     private readonly http: HttpClient,
-    @Inject(WIT_API_URL) private readonly witUrl: string,
+    @Inject(WIT_API_URL) witUrl: string,
     private readonly auth: AuthenticationService,
     private readonly logger: Logger,
     private readonly errorHandler: ErrorHandler
@@ -158,43 +158,43 @@ export class DeploymentApiService {
   }
 
   getApplications(spaceId: string): Observable<Application[]> {
-    const encSpaceId = encodeURIComponent(spaceId);
+    const encSpaceId: string = encodeURIComponent(spaceId);
     return this.httpGet<ApplicationsResponse>(`${this.apiUrl}${encSpaceId}`)
       .map((response: ApplicationsResponse): Application[] => response.data.attributes.applications);
   }
 
   getTimeseriesData(spaceId: string, environmentName: string, applicationId: string, startTime: number, endTime: number): Observable<MultiTimeseriesData> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    const encEnvironmentName = encodeURIComponent(environmentName);
-    const encApplicationId = encodeURIComponent(applicationId);
-    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/statseries?start=${startTime}&end=${endTime}`;
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    const encEnvironmentName: string = encodeURIComponent(environmentName);
+    const encApplicationId: string = encodeURIComponent(applicationId);
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/statseries?start=${startTime}&end=${endTime}`;
     return this.httpGet<MultiTimeseriesResponse>(url)
       .map((response: MultiTimeseriesResponse) => response.data);
   }
 
   getLatestTimeseriesData(spaceId: string, environmentName: string, applicationId: string): Observable<TimeseriesData> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    const encEnvironmentName = encodeURIComponent(environmentName);
-    const encApplicationId = encodeURIComponent(applicationId);
-    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/stats`;
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    const encEnvironmentName: string = encodeURIComponent(environmentName);
+    const encApplicationId: string = encodeURIComponent(applicationId);
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/stats`;
     return this.httpGet<TimeseriesResponse>(url)
       .map((response: TimeseriesResponse) => response.data.attributes);
   }
 
   deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<HttpResponse<any>> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    const encEnvironmentName = encodeURIComponent(environmentName);
-    const encApplicationId = encodeURIComponent(applicationId);
-    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    const encEnvironmentName: string = encodeURIComponent(environmentName);
+    const encApplicationId: string = encodeURIComponent(applicationId);
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
     return this.http.delete(url, { headers: this.headers, responseType: 'text' })
       .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }
 
   scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<HttpResponse<any>> {
-    const encSpaceId = encodeURIComponent(spaceId);
-    const encEnvironmentName = encodeURIComponent(environmentName);
-    const encApplicationId = encodeURIComponent(applicationId);
-    const url = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}?podCount=${desiredReplicas}`;
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    const encEnvironmentName: string = encodeURIComponent(environmentName);
+    const encApplicationId: string = encodeURIComponent(applicationId);
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}?podCount=${desiredReplicas}`;
     return this.http.put(url, '', { headers: this.headers, responseType: 'text' })
       .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -2,6 +2,7 @@ import {
   HttpClient,
   HttpErrorResponse,
   HttpHeaders,
+  HttpParams,
   HttpResponse
 } from '@angular/common/http';
 import {
@@ -167,8 +168,9 @@ export class DeploymentApiService {
     const encSpaceId: string = encodeURIComponent(spaceId);
     const encEnvironmentName: string = encodeURIComponent(environmentName);
     const encApplicationId: string = encodeURIComponent(applicationId);
-    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/statseries?start=${startTime}&end=${endTime}`;
-    return this.httpGet<MultiTimeseriesResponse>(url)
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/statseries`;
+    const params: HttpParams = new HttpParams().set('start', String(startTime)).set('end', String(endTime));
+    return this.httpGet<MultiTimeseriesResponse>(url, params)
       .map((response: MultiTimeseriesResponse) => response.data);
   }
 
@@ -194,13 +196,14 @@ export class DeploymentApiService {
     const encSpaceId: string = encodeURIComponent(spaceId);
     const encEnvironmentName: string = encodeURIComponent(environmentName);
     const encApplicationId: string = encodeURIComponent(applicationId);
-    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}?podCount=${desiredReplicas}`;
-    return this.http.put(url, '', { headers: this.headers, responseType: 'text' })
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}`;
+    const params: HttpParams = new HttpParams().set('podCount', String(desiredReplicas));
+    return this.http.put(url, '', { headers: this.headers, params, responseType: 'text' })
       .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }
 
-  private httpGet<T>(url: string): Observable<T> {
-    return this.http.get<T>(url, { headers: this.headers })
+  private httpGet<T>(url: string, params: HttpParams = new HttpParams()): Observable<T> {
+    return this.http.get<T>(url, { headers: this.headers, params })
       .catch((err: HttpErrorResponse) => this.handleHttpError(err));
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -5,8 +5,6 @@ import {
   OnDestroy
 } from '@angular/core';
 
-import { HttpResponse } from '@angular/common/http';
-
 import {
   Observable,
   ReplaySubject,
@@ -137,7 +135,7 @@ export class DeploymentsService implements OnDestroy {
 
   scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<string> {
     return this.apiService.scalePods(spaceId, environmentName, applicationId, desiredReplicas)
-      .map((r: HttpResponse<any>) => `Successfully scaled ${applicationId}`)
+      .map(() => `Successfully scaled ${applicationId}`)
       .catch(err => Observable.throw(`Failed to scale ${applicationId}`));
   }
 
@@ -254,7 +252,7 @@ export class DeploymentsService implements OnDestroy {
 
   deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
     return this.apiService.deleteDeployment(spaceId, environmentName, applicationId)
-      .map((r: HttpResponse<any>) => `Deployment has successfully deleted`)
+      .map(() => `Deployment has successfully deleted`)
       .catch(err => Observable.throw(`Failed to delete ${applicationId} in ${spaceId} (${environmentName})`));
   }
 

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -5,7 +5,7 @@ import {
   OnDestroy
 } from '@angular/core';
 
-import { Response } from '@angular/http';
+import { HttpResponse } from '@angular/common/http';
 
 import {
   Observable,
@@ -137,7 +137,7 @@ export class DeploymentsService implements OnDestroy {
 
   scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<string> {
     return this.apiService.scalePods(spaceId, environmentName, applicationId, desiredReplicas)
-      .map((r: Response) => `Successfully scaled ${applicationId}`)
+      .map((r: HttpResponse<any>) => `Successfully scaled ${applicationId}`)
       .catch(err => Observable.throw(`Failed to scale ${applicationId}`));
   }
 
@@ -254,7 +254,7 @@ export class DeploymentsService implements OnDestroy {
 
   deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
     return this.apiService.deleteDeployment(spaceId, environmentName, applicationId)
-      .map((r: Response) => `Deployment has successfully deleted`)
+      .map((r: HttpResponse<any>) => `Deployment has successfully deleted`)
       .catch(err => Observable.throw(`Failed to delete ${applicationId} in ${spaceId} (${environmentName})`));
   }
 


### PR DESCRIPTION
This PR upgrades the DeploymentApiService from the old Angular Http to the newer HttpClient, and does some light refactoring on top.