### PR TITLE
fix(SpacesService): reduce number of calls to /api/users regarding recent spaces

### DIFF
--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -213,6 +213,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
             this.savePins();
           }
           this.allSpaces.splice(index, 1);
+          this.broadcaster.broadcast('spaceDeleted', space);
           this.updateSpaces();
           this.spaceToDelete = undefined;
           this.modalRef.hide();

--- a/src/app/profile/spaces/spaces.component.ts
+++ b/src/app/profile/spaces/spaces.component.ts
@@ -92,6 +92,7 @@ export class SpacesComponent implements OnInit {
         .subscribe(spaces => {
           let index = this._spaces.indexOf(space);
           this._spaces.splice(index, 1);
+          this.broadcaster.broadcast('spaceDeleted', space);
           this.spaceToDelete = undefined;
           this.modalRef.hide();
         },

--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -8,14 +8,12 @@ import { ExtProfile, ProfileService } from '../profile/profile.service';
 import { SpacesService } from './spaces.service';
 
 describe('SpacesService', () => {
-
   let mockSpace: Space;
   let mockContext: Context;
   let mockProfile: ExtProfile;
   let mockUser: User;
 
   beforeEach(() => {
-
     mockSpace = {
       name: 'mock-space-name-1',
       path: 'mock-space-path-1' as String,
@@ -133,7 +131,8 @@ describe('SpacesService', () => {
 
   describe('#saveRecent', () => {
     it('should silentSave after a spaceChanged has been broadcasted', () => {
-      const profileService: jasmine.SpyObj<ProfileService> = TestBed.get(ProfileService);
+      const profileService: any = TestBed.get(ProfileService);
+      mockProfile.store.recentSpaces = [mockSpace];
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
       broadcaster.on.and.callFake((key: string): Observable<Space> => {
         if (key === 'spaceChanged') {
@@ -159,6 +158,7 @@ describe('SpacesService', () => {
 
     it('should log an error if silentSave failed', () => {
       const profileService: jasmine.SpyObj<ProfileService> = TestBed.get(ProfileService);
+      mockProfile.store.recentSpaces = [mockSpace];
       profileService.silentSave.and.returnValue(Observable.throw('error'));
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
       broadcaster.on.and.callFake((key: string): Observable<Space> => {
@@ -186,16 +186,14 @@ describe('SpacesService', () => {
 
   describe('#findRecentIndexById', () => {
     it('should return the list index of the space in _recent', () => {
-      mockProfile.store.recentSpaces = [mockSpace];
       const spacesService: SpacesService = TestBed.get(SpacesService);
-      let result: number = spacesService.findRecentIndexById(mockSpace.id);
+      let result: number = spacesService.findRecentIndexById([mockSpace], mockSpace.id);
       expect(result).toEqual(0);
     });
 
     it('should return -1 if the space does not exist in _recent', () => {
-      mockProfile.store.recentSpaces = [mockSpace];
       const spacesService: SpacesService = TestBed.get(SpacesService);
-      let result: number = spacesService.findRecentIndexById('not-a-real-index');
+      let result: number = spacesService.findRecentIndexById([mockSpace], 'not-a-real-index');
       expect(result).toEqual(-1);
     });
   });

--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -106,18 +106,19 @@ describe('SpacesService', () => {
   });
 
   describe('#get recent', () => {
-    it('should return the spaces from the profileService.store', () => {
+    it('should return the spaces from the profileService.store', (done: DoneFn) => {
       mockProfile.store.recentSpaces = [mockSpace];
       const spacesService: SpacesService = TestBed.get(SpacesService);
       let result: Observable<Space[]> = spacesService.recent;
       result.subscribe((r: Space[]) => {
         expect(r).toEqual([mockSpace] as Space[]);
+        done();
       });
     });
   });
 
   describe('#loadRecent', () => {
-    it('should return an empty array if recentSpaces doesn\'t exist on profile.store', () => {
+    it('should return an empty array if recentSpaces doesn\'t exist on profile.store', (done: DoneFn) => {
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
       broadcaster.on.and.returnValue(Observable.never());
       delete mockProfile.store.recentSpaces;
@@ -125,6 +126,7 @@ describe('SpacesService', () => {
       let result: Observable<Space[]> = spacesService.recent;
       result.subscribe((r: Space[]) => {
         expect(r).toEqual([] as Space[]);
+        done();
       });
     });
   });
@@ -227,7 +229,7 @@ describe('SpacesService', () => {
       }
     });
 
-    it('should re-order _recent if updated space already exists in _recent and is not index 0', () => {
+    it('should re-order _recent if updated space already exists in _recent and is not index 0', (done: DoneFn) => {
       const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       let i: number = 0;
       spaceService.getSpaceById.and.callFake(() => {
@@ -254,10 +256,11 @@ describe('SpacesService', () => {
       // mock-space-1 should have been moved to the front of _recent
       spacesService.recent.subscribe(spaces => {
         expect(spaces[0].id).toEqual(mockSpace.id);
+        done();
       });
     });
 
-    it('should not re-order _recent if updated space already exists in _recent and is index 0', () => {
+    it('should not re-order _recent if updated space already exists in _recent and is index 0', (done: DoneFn) => {
       const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       let i: number = 0;
       spaceService.getSpaceById.and.callFake(() => {
@@ -284,10 +287,11 @@ describe('SpacesService', () => {
       // mock-space-0 should stay at the front of _recent
       spacesService.recent.subscribe(spaces => {
         expect(spaces[0].id).toEqual(mockSpaces[0].id);
+        done();
       });
     });
 
-    it('should trim _recent if its length exceeds RECENT_SPACE_LENGTH', () => {
+    it('should trim _recent if its length exceeds RECENT_SPACE_LENGTH', (done: DoneFn) => {
       const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       let i: number = 0;
       spaceService.getSpaceById.and.callFake(() => {
@@ -314,12 +318,13 @@ describe('SpacesService', () => {
       const spacesService: SpacesService = TestBed.get(SpacesService);
       spacesService.recent.subscribe(spaces => {
         expect(spaces.length).toEqual(SpacesService.RECENT_SPACE_LENGTH);
+        done();
       });
     });
   });
 
   describe('#initRecent - spaceDeleted', () => {
-    it('should remove deleted space from _recent', () => {
+    it('should remove deleted space from _recent', (done: DoneFn) => {
       const profileService: jasmine.SpyObj<ProfileService> = TestBed.get(ProfileService);
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
       broadcaster.on.and.callFake((key: string): Observable<Space> => {
@@ -336,13 +341,14 @@ describe('SpacesService', () => {
       mockProfile.store.recentSpaces = [mockSpace];
       const spacesService: SpacesService = TestBed.get(SpacesService);
       let result: Observable<Space[]> = spacesService.recent;
+      expect(profileService.silentSave).toHaveBeenCalledTimes(1);
       result.subscribe((r: Space[]) => {
         expect(r).toEqual([] as Space[]);
+        done();
       });
-      expect(profileService.silentSave).toHaveBeenCalledTimes(1);
     });
 
-    it('should not remove any spaces from _recent if deleted space was not in _recent', () => {
+    it('should not remove any spaces from _recent if deleted space was not in _recent', (done: DoneFn) => {
       const profileService: any = TestBed.get(ProfileService);
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
       const mockSpace2: Space = {
@@ -368,10 +374,11 @@ describe('SpacesService', () => {
       mockProfile.store.recentSpaces = [mockSpace];
       const spacesService: SpacesService = TestBed.get(SpacesService);
       let result: Observable<Space[]> = spacesService.recent;
+      expect(profileService.silentSave).toHaveBeenCalledTimes(0);
       result.subscribe((r: Space[]) => {
         expect(r).toEqual([mockSpace] as Space[]);
+        done();
       });
-      expect(profileService.silentSave).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -213,20 +213,6 @@ describe('SpacesService', () => {
     });
   });
 
-  describe('#findRecentIndexById', () => {
-    it('should return the list index of the space in _recent', () => {
-      const spacesService: SpacesService = TestBed.get(SpacesService);
-      let result: number = spacesService.findRecentIndexById([mockSpace], mockSpace.id);
-      expect(result).toEqual(0);
-    });
-
-    it('should return -1 if the space does not exist in _recent', () => {
-      const spacesService: SpacesService = TestBed.get(SpacesService);
-      let result: number = spacesService.findRecentIndexById([mockSpace], 'not-a-real-index');
-      expect(result).toEqual(-1);
-    });
-  });
-
   describe('#initRecent - spaceChanged', () => {
     let mockSpaces: Space[] = [];
     let mockSpacesObs: Observable<Space>[] = [];

--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { LocalStorageService } from 'angular-2-local-storage';
 import { Broadcaster } from 'ngx-base';
 import { Context, Contexts, Space, SpaceService } from 'ngx-fabric8-wit';
 import { User } from 'ngx-login-client';
@@ -39,7 +38,7 @@ describe('SpacesService', () => {
 
     mockProfile = {
       store: {
-        recentSpaces: [mockSpace]
+        recentSpaces: []
       }
     } as ExtProfile;
 
@@ -57,10 +56,13 @@ describe('SpacesService', () => {
             const mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
             mockBroadcaster.on.and.callFake((key: string): Observable<Space> => {
               if (key === 'spaceChanged') {
-                return Observable.of(mockSpace);
+                return Observable.never();
+              }
+              if (key === 'spaceDeleted') {
+                return Observable.never();
               }
               if (key === 'spaceUpdated') {
-                return Observable.of(mockSpace);
+                return Observable.never();
               }
             });
             return mockBroadcaster;
@@ -70,6 +72,7 @@ describe('SpacesService', () => {
           useFactory: () => {
             const mockProfileService: any = jasmine.createSpyObj('ProfileService', ['silentSave']);
             mockProfileService.current = Observable.of(mockProfile);
+            mockProfileService.silentSave.and.returnValue(Observable.of(mockUser));
             return mockProfileService;
           }
         },
@@ -79,13 +82,6 @@ describe('SpacesService', () => {
             const mockContexts: jasmine.SpyObj<Contexts> = createMock(Contexts);
             mockContexts.current = Observable.of(mockContext) as ConnectableObservable<Context> & jasmine.Spy;
             return mockContexts;
-          }
-        },
-        {
-          provide: LocalStorageService,
-          useFactory: () => {
-            const mockLocalStorageService: jasmine.SpyObj<LocalStorageService> = createMock(LocalStorageService);
-            return mockLocalStorageService;
           }
         },
         {
@@ -102,8 +98,6 @@ describe('SpacesService', () => {
 
   describe('#get current', () => {
     it('should return the space from contexts.current', (done: DoneFn) => {
-      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
-      broadcaster.on.and.returnValue(Observable.never());
       const spacesService: SpacesService = TestBed.get(SpacesService);
       let result: Observable<Space> = spacesService.current;
       result.subscribe((r: Space) => {
@@ -115,8 +109,7 @@ describe('SpacesService', () => {
 
   describe('#get recent', () => {
     it('should return the spaces from the profileService.store', () => {
-      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
-      broadcaster.on.and.returnValue(Observable.never());
+      mockProfile.store.recentSpaces = [mockSpace];
       const spacesService: SpacesService = TestBed.get(SpacesService);
       let result: Observable<Space[]> = spacesService.recent;
       result.subscribe((r: Space[]) => {
@@ -141,8 +134,18 @@ describe('SpacesService', () => {
   describe('#saveRecent', () => {
     it('should silentSave after a spaceChanged has been broadcasted', () => {
       const profileService: jasmine.SpyObj<ProfileService> = TestBed.get(ProfileService);
-      profileService.silentSave.and.returnValue(Observable.of(mockUser));
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return Observable.of(mockSpace);
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.never();
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
       let expectedPatch = {
         store: {
           recentSpaces: [mockSpace.id]
@@ -158,6 +161,17 @@ describe('SpacesService', () => {
       const profileService: jasmine.SpyObj<ProfileService> = TestBed.get(ProfileService);
       profileService.silentSave.and.returnValue(Observable.throw('error'));
       const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return Observable.of(mockSpace);
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.never();
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
       let expectedPatch = {
         store: {
           recentSpaces: [mockSpace.id]
@@ -167,6 +181,199 @@ describe('SpacesService', () => {
       const spacesService: SpacesService = TestBed.get(SpacesService);
       expect(profileService.silentSave).toHaveBeenCalledWith(expectedPatch);
       expect(console.log).toHaveBeenCalledWith('Error saving recent spaces:', 'error');
+    });
+  });
+
+  describe('#findRecentIndexById', () => {
+    it('should return the list index of the space in _recent', () => {
+      mockProfile.store.recentSpaces = [mockSpace];
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      let result: number = spacesService.findRecentIndexById(mockSpace.id);
+      expect(result).toEqual(0);
+    });
+
+    it('should return -1 if the space does not exist in _recent', () => {
+      mockProfile.store.recentSpaces = [mockSpace];
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      let result: number = spacesService.findRecentIndexById('not-a-real-index');
+      expect(result).toEqual(-1);
+    });
+  });
+
+  describe('#initRecent - spaceChanged', () => {
+    let mockSpaces: Space[] = [];
+    let mockSpacesObs: Observable<Space>[] = [];
+    const mockSpace8: Space = {
+      name: 'mock-space-name-8',
+      path: 'mock-space-path-8' as String,
+      id: 'mock-space-id-8',
+      attributes: {
+        name: 'mock-space-name-8',
+        description: 'mock-space-description-8'
+      }
+    } as Space;
+
+    beforeEach(() => {
+      for (let i: number = 0; i < 8; i++) {
+        let space = {
+          name: `mock-space-name-${i}`,
+          path: `mock-space-path-${i}` as String,
+          id: `mock-space-id-${i}`,
+          attributes: {
+            name: `mock-space-name-${i}`,
+            description: `mock-space-description-${i}`
+          }
+        } as Space;
+        mockSpaces[i] = space;
+        mockSpacesObs[i] = Observable.of(space);
+      }
+    });
+
+    it('should re-order _recent if updated space already exists in _recent and is not index 0', () => {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      let i: number = 0;
+      spaceService.getSpaceById.and.callFake(() => {
+        let spaceObs: Observable<Space> = mockSpacesObs[i];
+        i++;
+        return spaceObs;
+      });
+      const profileService: any = TestBed.get(ProfileService);
+      mockProfile.store.recentSpaces = mockSpaces;
+      profileService.current = Observable.of(mockProfile);
+      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return Observable.of(mockSpace);
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.never();
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      // mock-space-1 should have been moved to the front of _recent
+      spacesService.recent.subscribe(spaces => {
+        expect(spaces[0].id).toEqual(mockSpace.id);
+      });
+    });
+
+    it('should not re-order _recent if updated space already exists in _recent and is index 0', () => {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      let i: number = 0;
+      spaceService.getSpaceById.and.callFake(() => {
+        let spaceObs: Observable<Space> = mockSpacesObs[i];
+        i++;
+        return spaceObs;
+      });
+      const profileService: any = TestBed.get(ProfileService);
+      mockProfile.store.recentSpaces = mockSpaces;
+      profileService.current = Observable.of(mockProfile);
+      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return mockSpacesObs[0];
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.never();
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      // mock-space-0 should stay at the front of _recent
+      spacesService.recent.subscribe(spaces => {
+        expect(spaces[0].id).toEqual(mockSpaces[0].id);
+      });
+    });
+
+    it('should trim _recent if its length exceeds RECENT_SPACE_LENGTH', () => {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      let i: number = 0;
+      spaceService.getSpaceById.and.callFake(() => {
+        let spaceObs: Observable<Space> = mockSpacesObs[i];
+        i++;
+        return spaceObs;
+      });
+      // make recentSpaces contain 8 spaces, adding another one will force a .pop()
+      const profileService: any = TestBed.get(ProfileService);
+      mockProfile.store.recentSpaces = mockSpaces;
+      profileService.current = Observable.of(mockProfile);
+      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return Observable.of(mockSpace8);
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.never();
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      spacesService.recent.subscribe(spaces => {
+        expect(spaces.length).toEqual(SpacesService.RECENT_SPACE_LENGTH);
+      });
+    });
+  });
+
+  describe('#initRecent - spaceDeleted', () => {
+    it('should remove deleted space from _recent', () => {
+      const profileService: jasmine.SpyObj<ProfileService> = TestBed.get(ProfileService);
+      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return Observable.never();
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.of(mockSpace);
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
+      mockProfile.store.recentSpaces = [mockSpace];
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      let result: Observable<Space[]> = spacesService.recent;
+      result.subscribe((r: Space[]) => {
+        expect(r).toEqual([] as Space[]);
+      });
+      expect(profileService.silentSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not remove any spaces from _recent if deleted space was not in _recent', () => {
+      const profileService: any = TestBed.get(ProfileService);
+      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      const mockSpace2: Space = {
+        name: 'mock-space-name-2',
+        path: 'mock-space-path-2' as String,
+        id: 'mock-space-id-2',
+        attributes: {
+          name: 'mock-space-name-2',
+          description: 'mock-space-description-2'
+        }
+      } as Space;
+      broadcaster.on.and.callFake((key: string): Observable<Space> => {
+        if (key === 'spaceChanged') {
+          return Observable.never();
+        }
+        if (key === 'spaceDeleted') {
+          return Observable.of(mockSpace2);
+        }
+        if (key === 'spaceUpdated') {
+          return Observable.never();
+        }
+      });
+      mockProfile.store.recentSpaces = [mockSpace];
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      let result: Observable<Space[]> = spacesService.recent;
+      result.subscribe((r: Space[]) => {
+        expect(r).toEqual([mockSpace] as Space[]);
+      });
+      expect(profileService.silentSave).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -50,7 +50,8 @@ describe('SpacesService', () => {
     TestBed.configureTestingModule({
       providers: [
         SpacesService,
-        { provide: Broadcaster,
+        {
+          provide: Broadcaster,
           useFactory: () => {
             const mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
             mockBroadcaster.on.and.callFake((key: string): Observable<Space> => {
@@ -67,7 +68,8 @@ describe('SpacesService', () => {
             return mockBroadcaster;
           }
         },
-        { provide: ProfileService,
+        {
+          provide: ProfileService,
           useFactory: () => {
             const mockProfileService: any = jasmine.createSpyObj('ProfileService', ['silentSave']);
             mockProfileService.current = Observable.of(mockProfile);

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -58,6 +58,15 @@ export class SpacesService implements Spaces {
       // update the profile's store.recentSpaces attribute
       this.saveRecent(this._recent);
     });
+
+    // if a space is deleted, check to see if it should be removed from _recent
+    this.broadcaster.on<Space>('spaceDeleted').subscribe(space => {
+      let index: number = this.findRecentIndexById(space.id);
+      if (index !== -1) {
+        this._recent.splice(index, 1);
+        this.saveRecent(this._recent);
+      }
+    });
   }
 
   get current(): Observable<Space> {

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -32,7 +32,7 @@ export class SpacesService implements Spaces {
 
   private initRecent(): void {
     // load existing recent spaces from profile.store.recentSpaces
-    this.loadRecent().subscribe(spaces => {
+    this.loadRecent().subscribe((spaces: Space[]) => {
       this._recent.next(spaces);
     });
 
@@ -40,7 +40,7 @@ export class SpacesService implements Spaces {
     this.broadcaster.on<Space>('spaceChanged')
       .flatMap((changedSpace: Space) => {
         return this._recent.first().map((recentSpaces: Space[]) => {
-          let index: number = this.findRecentIndexById(recentSpaces, changedSpace.id);
+          let index: number = recentSpaces.findIndex((space: Space) => space.id === changedSpace.id);
           // if changedSpace exists in _recent
           if (index !== -1) {
             // move the space to the front of the list if it is already in _recent
@@ -72,7 +72,7 @@ export class SpacesService implements Spaces {
     this.broadcaster.on<Space>('spaceDeleted')
       .flatMap((deletedSpace: Space) => {
         return this._recent.first().map((recentSpaces: Space[]) => {
-          let index: number = this.findRecentIndexById(recentSpaces, deletedSpace.id);
+          let index: number = recentSpaces.findIndex((space: Space) => space.id === deletedSpace.id);
           if (index !== -1) {
             recentSpaces.splice(index, 1);
             this.recentChanged = true;
@@ -118,13 +118,6 @@ export class SpacesService implements Spaces {
     } as ExtProfile;
     return this.profileService.silentSave(patch)
       .subscribe(() => {}, err => console.log('Error saving recent spaces:', err));
-  }
-
-  /**
-   * Given the id of a space, returns the index of the space in _recent
-   */
-  findRecentIndexById(spaces: Space[], id: string): number {
-    return spaces.findIndex(space => space.id === id);
   }
 
 }

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Broadcaster } from 'ngx-base';
 import { Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { ExtProfile, ProfileService } from '../profile/profile.service';
 
 @Injectable()
@@ -10,7 +10,7 @@ export class SpacesService implements Spaces {
   static readonly RECENT_SPACE_LENGTH = 8;
 
   private _current: Observable<Space>;
-  private _recent: Space[] = [];
+  private _recent: Observable<Space[]>;
 
   constructor(
     private contexts: Contexts,
@@ -31,42 +31,50 @@ export class SpacesService implements Spaces {
 
   private initRecent(): void {
     // load existing recent spaces from profile.store.recentSpaces
-    this.loadRecent().subscribe(spaces => {
-      spaces.forEach(space => {
-        this._recent.push(space);
-      });
-    });
+    this._recent = this.loadRecent();
 
     // update _recent with newly seen space when spaceChanged is emitted
-    this.broadcaster.on<Space>('spaceChanged').subscribe(space => {
-      let index: number = this.findRecentIndexById(space.id);
-      // if changedSpace exists in _recent
-      if (index !== -1) {
-        // move the space to the front of the list if it is already in _recent
-        if (this._recent[0].id !== space.id) {
-          this._recent.splice(index, 1);
-          this._recent.unshift(space);
+    this.broadcaster.on<Space>('spaceChanged')
+      .combineLatest(this._recent)
+      .subscribe((combined: [Space, Space[]]) => {
+        let changedSpace: Space = combined[0];
+        let recentSpaces: Space[] = combined[1];
+        let index: number = this.findRecentIndexById(recentSpaces, changedSpace.id);
+        // if changedSpace exists in _recent
+        if (index !== -1) {
+          // move the space to the front of the list if it is already in _recent
+          if (recentSpaces[0].id !== changedSpace.id) {
+            recentSpaces.splice(index, 1);
+            recentSpaces.unshift(changedSpace);
+          }
+          // otherwise, no operation required; changedSpace is already index 0
+        // if changedSpace is new to the recent spaces
+        } else {
+          recentSpaces.unshift(changedSpace);
+          // trim _recent if required to ensure it is length =< 8
+          if (recentSpaces.length > SpacesService.RECENT_SPACE_LENGTH) {
+            recentSpaces.pop();
+          }
         }
-        // otherwise, no operation required, changedSpace is already index 0
-      } else {
-        this._recent.unshift(space);
-        // trim _recent if required to ensure it's length =< 8
-        if (this._recent.length > SpacesService.RECENT_SPACE_LENGTH) {
-          this._recent.pop();
-        }
+        this._recent = Observable.of(recentSpaces);
+        this.saveRecent(recentSpaces);
       }
-      // update the profile's store.recentSpaces attribute
-      this.saveRecent(this._recent);
-    });
+    );
 
     // if a space is deleted, check to see if it should be removed from _recent
-    this.broadcaster.on<Space>('spaceDeleted').subscribe(space => {
-      let index: number = this.findRecentIndexById(space.id);
-      if (index !== -1) {
-        this._recent.splice(index, 1);
-        this.saveRecent(this._recent);
+    this.broadcaster.on<Space>('spaceDeleted')
+      .combineLatest(this._recent)
+      .subscribe((combined: [Space, Space[]]) => {
+        let deletedSpace: Space = combined[0];
+        let recentSpaces: Space[] = combined[1];
+        let index: number = this.findRecentIndexById(recentSpaces, deletedSpace.id);
+        if (index !== -1) {
+          recentSpaces.splice(index, 1);
+          this._recent = Observable.of(recentSpaces);
+          this.saveRecent(recentSpaces);
+        }
       }
-    });
+    );
   }
 
   get current(): Observable<Space> {
@@ -74,7 +82,7 @@ export class SpacesService implements Spaces {
   }
 
   get recent(): Observable<Space[]> {
-    return Observable.of(this._recent);
+    return this._recent;
   }
 
   private loadRecent(): Observable<Space[]> {
@@ -90,7 +98,7 @@ export class SpacesService implements Spaces {
     });
   }
 
-  private saveRecent(recent: Space[]) {
+  private saveRecent(recent: Space[]): Subscription {
     let patch = {
       store: {
         recentSpaces: recent.map(val => val.id)
@@ -103,9 +111,9 @@ export class SpacesService implements Spaces {
   /**
    * Given the id of a space, returns the index of the space in _recent
    */
-  findRecentIndexById(id: string): number {
-    for (let i: number = 0; i < this._recent.length; i++) {
-      if (this._recent[i].id === id) {
+  findRecentIndexById(spaces: Space[], id: string): number {
+    for (let i: number = 0; i < spaces.length; i++) {
+      if (spaces[i].id === id) {
         return i;
       }
     }

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -72,17 +72,15 @@ export class SpacesService implements Spaces {
     // if a space is deleted, check to see if it should be removed from _recent
     this.broadcaster.on<Space>('spaceDeleted')
       .withLatestFrom(this.recent)
-      .map(([changedSpace, recentSpaces]: [Space, Space[]]): [Space, Space[], number] => {
-        let index: number = recentSpaces.findIndex((space: Space): boolean => space.id === changedSpace.id);
-        return [changedSpace, recentSpaces, index];
+      .map(([deletedSpace, recentSpaces]: [Space, Space[]]): [Space, Space[], number] => {
+        let index: number = recentSpaces.findIndex((space: Space): boolean => space.id === deletedSpace.id);
+        return [deletedSpace, recentSpaces, index];
       })
-      .filter(([changedSpace, recentSpaces, index]: [Space, Space[], number]): boolean => {
+      .filter(([deletedSpace, recentSpaces, index]: [Space, Space[], number]): boolean => {
         return index !== -1;
       })
-      .map(([changedSpace, recentSpaces, index]: [Space, Space[], number]): Space[] => {
-        if (index !== -1) {
-          recentSpaces.splice(index, 1);
-        }
+      .map(([deletedSpace, recentSpaces, index]: [Space, Space[], number]): Space[] => {
+        recentSpaces.splice(index, 1);
         return recentSpaces;
       })
       .subscribe((recentSpaces: Space[]): void => {

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 
-import { LocalStorageService } from 'angular-2-local-storage';
 import { Broadcaster } from 'ngx-base';
 import { Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
 import { Observable, Subject } from 'rxjs';
@@ -13,7 +12,6 @@ import { ExtProfile, ProfileService } from '../profile/profile.service';
 export class SpacesService implements Spaces {
 
   static readonly RECENT_SPACE_LENGTH = 8;
-  private static readonly RECENT_SPACE_KEY = 'recentSpaceIds';
 
   addRecent: Subject<Space> = new Subject<Space>();
   private _current: Observable<Space>;
@@ -21,13 +19,12 @@ export class SpacesService implements Spaces {
 
   constructor(
     private contexts: Contexts,
-    private localStorage: LocalStorageService,
     private spaceService: SpaceService,
     private broadcaster: Broadcaster,
     private profileService: ProfileService
   ) {
     this._current = Observable.merge(
-      contexts.current
+      this.contexts.current
         .map(val => val.space),
       this.broadcaster.on<Space>('spaceUpdated'));
     // Create the recent context list
@@ -99,7 +96,7 @@ export class SpacesService implements Spaces {
       }
     } as ExtProfile;
     return this.profileService.silentSave(patch)
-      .subscribe(profile => { }, err => console.log('Error saving recent spaces:', err));
+      .subscribe(() => {}, err => console.log('Error saving recent spaces:', err));
   }
 
 }

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -47,6 +47,7 @@ export class SpacesService implements Spaces {
           if (recentSpaces[0].id !== changedSpace.id) {
             recentSpaces.splice(index, 1);
             recentSpaces.unshift(changedSpace);
+            this.saveRecent(recentSpaces);
           }
           // otherwise, no operation required; changedSpace is already index 0
         // if changedSpace is new to the recent spaces
@@ -56,8 +57,8 @@ export class SpacesService implements Spaces {
           if (recentSpaces.length > SpacesService.RECENT_SPACE_LENGTH) {
             recentSpaces.pop();
           }
+          this.saveRecent(recentSpaces);
         }
-        this.saveRecent(recentSpaces);
       }
     );
 

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Broadcaster } from 'ngx-base';
 import { Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
-import { Observable, ReplaySubject, Subscription } from 'rxjs';
+import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
 import { ExtProfile, ProfileService } from '../profile/profile.service';
 
 @Injectable()
@@ -10,8 +10,7 @@ export class SpacesService implements Spaces {
   static readonly RECENT_SPACE_LENGTH = 8;
 
   private _current: Observable<Space>;
-  private _recent: ReplaySubject<Space[]> = new ReplaySubject<Space[]>(1);
-  private recentChanged: boolean = false;
+  private _recent: Subject<Space[]>;
 
   constructor(
     private contexts: Contexts,
@@ -19,6 +18,7 @@ export class SpacesService implements Spaces {
     private broadcaster: Broadcaster,
     private profileService: ProfileService
   ) {
+    this._recent = new ReplaySubject<Space[]>(1);
     this.initCurrent();
     this.initRecent();
   }
@@ -32,58 +32,61 @@ export class SpacesService implements Spaces {
 
   private initRecent(): void {
     // load existing recent spaces from profile.store.recentSpaces
-    this.loadRecent().subscribe((spaces: Space[]) => {
+    this.loadRecent().subscribe((spaces: Space[]): void => {
       this._recent.next(spaces);
     });
 
     // update _recent with newly seen space when spaceChanged is emitted
     this.broadcaster.on<Space>('spaceChanged')
-      .flatMap((changedSpace: Space) => {
-        return this._recent.first().map((recentSpaces: Space[]) => {
-          let index: number = recentSpaces.findIndex((space: Space) => space.id === changedSpace.id);
-          // if changedSpace exists in _recent
-          if (index !== -1) {
-            // move the space to the front of the list if it is already in _recent
-            if (recentSpaces[0].id !== changedSpace.id) {
-              recentSpaces.splice(index, 1);
-              recentSpaces.unshift(changedSpace);
-              this.recentChanged = true;
-            }
-            // otherwise, no operation required; changedSpace is already index 0
-          // if changedSpace is new to the recent spaces
-          } else {
-            recentSpaces.unshift(changedSpace);
-            // trim _recent if required to ensure it is length =< 8
-            if (recentSpaces.length > SpacesService.RECENT_SPACE_LENGTH) {
-              recentSpaces.pop();
-            }
-            this.recentChanged = true;
-          }
-          return recentSpaces;
-        });
+      .withLatestFrom(this.recent)
+      .map(([changedSpace, recentSpaces]: [Space, Space[]]): [Space, Space[], number] => {
+        let index: number = recentSpaces.findIndex((space: Space): boolean => space.id === changedSpace.id);
+        return [changedSpace, recentSpaces, index];
       })
-      .subscribe((recentSpaces: Space[]) => {
-        if (this.recentChanged) {
-          this.saveRecent(recentSpaces);
+      .filter(([changedSpace, recentSpaces, index]: [Space, Space[], number]): boolean => {
+        return index !== 0; // continue only if the changed space is new, or requires a move in _recent
+      })
+      .map(([changedSpace, recentSpaces, index]: [Space, Space[], number]): Space[] => {
+        // if changedSpace exists in recentSpaces
+        if (index !== -1) {
+          // move the space to the front of the list if it is already in _recent
+          if (recentSpaces[0].id !== changedSpace.id) {
+            recentSpaces.splice(index, 1);
+            recentSpaces.unshift(changedSpace);
+          }
+          // otherwise, no operation required; changedSpace is already index 0
+        // if changedSpace is new to the recent spaces
+        } else {
+          recentSpaces.unshift(changedSpace);
+          // trim recentSpaces if required to ensure it is length =< 8
+          if (recentSpaces.length > SpacesService.RECENT_SPACE_LENGTH) {
+            recentSpaces.pop();
+          }
         }
+        return recentSpaces;
+      })
+      .subscribe((recentSpaces: Space[]): void => {
+        this.saveRecent(recentSpaces);
       });
 
     // if a space is deleted, check to see if it should be removed from _recent
     this.broadcaster.on<Space>('spaceDeleted')
-      .flatMap((deletedSpace: Space) => {
-        return this._recent.first().map((recentSpaces: Space[]) => {
-          let index: number = recentSpaces.findIndex((space: Space) => space.id === deletedSpace.id);
-          if (index !== -1) {
-            recentSpaces.splice(index, 1);
-            this.recentChanged = true;
-          }
-          return recentSpaces;
-        });
+      .withLatestFrom(this.recent)
+      .map(([changedSpace, recentSpaces]: [Space, Space[]]): [Space, Space[], number] => {
+        let index: number = recentSpaces.findIndex((space: Space): boolean => space.id === changedSpace.id);
+        return [changedSpace, recentSpaces, index];
       })
-      .subscribe((recentSpaces: Space[]) => {
-        if (this.recentChanged) {
-          this.saveRecent(recentSpaces);
+      .filter(([changedSpace, recentSpaces, index]: [Space, Space[], number]): boolean => {
+        return index !== -1;
+      })
+      .map(([changedSpace, recentSpaces, index]: [Space, Space[], number]): Space[] => {
+        if (index !== -1) {
+          recentSpaces.splice(index, 1);
         }
+        return recentSpaces;
+      })
+      .subscribe((recentSpaces: Space[]): void => {
+        this.saveRecent(recentSpaces);
       });
   }
 
@@ -96,10 +99,10 @@ export class SpacesService implements Spaces {
   }
 
   private loadRecent(): Observable<Space[]> {
-    return this.profileService.current.switchMap(profile => {
+    return this.profileService.current.switchMap((profile: ExtProfile): Observable<Space[]> => {
       if (profile.store.recentSpaces) {
         return Observable.forkJoin((profile.store.recentSpaces as string[])
-          .map(id => {
+          .map((id: string): Observable<Space> => {
             return this.spaceService.getSpaceById(id);
           }));
       } else {
@@ -110,14 +113,13 @@ export class SpacesService implements Spaces {
 
   private saveRecent(recent: Space[]): Subscription {
     this._recent.next(recent);
-    this.recentChanged = false;
     let patch = {
       store: {
-        recentSpaces: recent.map(val => val.id)
+        recentSpaces: recent.map((val: Space): string => val.id)
       }
     } as ExtProfile;
     return this.profileService.silentSave(patch)
-      .subscribe(() => {}, err => console.log('Error saving recent spaces:', err));
+      .subscribe((): void => {}, (err: string): void => console.log('Error saving recent spaces:', err));
   }
 
 }

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -65,15 +65,13 @@ export class SpacesService implements Spaces {
       .subscribe((recentSpaces: Space[]) => {
         if (this.recentChanged) {
           this.saveRecent(recentSpaces);
-          this.recentChanged = false;
-          this._recent.next(recentSpaces);
         }
       });
 
     // if a space is deleted, check to see if it should be removed from _recent
     this.broadcaster.on<Space>('spaceDeleted')
       .flatMap((deletedSpace: Space) => {
-        return this._recent.map((recentSpaces: Space[]) => {
+        return this._recent.first().map((recentSpaces: Space[]) => {
           let index: number = this.findRecentIndexById(recentSpaces, deletedSpace.id);
           if (index !== -1) {
             recentSpaces.splice(index, 1);
@@ -85,8 +83,6 @@ export class SpacesService implements Spaces {
       .subscribe((recentSpaces: Space[]) => {
         if (this.recentChanged) {
           this.saveRecent(recentSpaces);
-          this.recentChanged = false;
-          this._recent.next(recentSpaces);
         }
       });
   }
@@ -113,6 +109,8 @@ export class SpacesService implements Spaces {
   }
 
   private saveRecent(recent: Space[]): Subscription {
+    this._recent.next(recent);
+    this.recentChanged = false;
     let patch = {
       store: {
         recentSpaces: recent.map(val => val.id)
@@ -126,12 +124,7 @@ export class SpacesService implements Spaces {
    * Given the id of a space, returns the index of the space in _recent
    */
   findRecentIndexById(spaces: Space[], id: string): number {
-    for (let i: number = 0; i < spaces.length; i++) {
-      if (spaces[i].id === id) {
-        return i;
-      }
-    }
-    return -1;
+    return spaces.findIndex(space => space.id === id);
   }
 
 }

--- a/src/app/space/add-app-overlay/add-app-overlay.component.spec.ts
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 
-import { Broadcaster, Logger, Notification, Notifications, NotificationType } from 'ngx-base';
+import { Broadcaster, Logger, Notifications } from 'ngx-base';
 import { PopoverConfig, PopoverModule } from 'ngx-bootstrap/popover';
 import { Context, ProcessTemplate, Space, SpaceService } from 'ngx-fabric8-wit';
 import { DependencyCheckService } from 'ngx-launcher';
@@ -39,7 +39,6 @@ describe('AddAppOverlayComponent', () => {
   let component: AddAppOverlayComponent;
   let fixture: ComponentFixture<AddAppOverlayComponent>;
 
-  let mockBroadcaster: any = jasmine.createSpyObj('Broadcaster', ['broadcast']);
   let mockRouter: any = jasmine.createSpyObj('Router', ['navigate']);
   let mockSpaceTemplateService: any = {
     getSpaceTemplates: () => {
@@ -50,10 +49,9 @@ describe('AddAppOverlayComponent', () => {
   let mockNotifications: any = jasmine.createSpyObj('Notifications', ['message']);
   let mockUserService: any = jasmine.createSpyObj('UserService', ['getUser']);
   let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
-  let mockSpacesService: any = jasmine.createSpyObj('SpacesService', ['addRecent']);
+  let mockSpacesService: any = jasmine.createSpy('SpacesService');
   let mockLogger: any = jasmine.createSpyObj('Logger', ['error']);
   let mockErrorHandler: any = jasmine.createSpyObj('ErrorHandler', ['handleError']);
-  let mockSubject: any = jasmine.createSpy('Subject');
   let mockDependencyCheckService: any = {
     getDependencyCheck(): Observable<any> {
       return Observable.of({
@@ -157,11 +155,6 @@ describe('AddAppOverlayComponent', () => {
     id: 'template-03',
     type: 'spacetemplates'
   }] as ProcessTemplate[];
-
-  let mockMessage: Notification = {
-    message: `Failed to create "${mockSpace.name}"`,
-    type: NotificationType.DANGER
-  };
 
   class mockContextService {
     get current(): Observable<Context> { return Observable.of(mockContext); }

--- a/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.spec.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 
-import { Broadcaster, Logger, Notification, Notifications, NotificationType } from 'ngx-base';
+import { Broadcaster, Logger, Notifications } from 'ngx-base';
 import { ProcessTemplate, Space, SpaceService } from 'ngx-fabric8-wit';
 import { Profile, User, UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs/Observable';
@@ -31,11 +31,10 @@ describe('AddSpaceOverlayComponent', () => {
   let mockNotifications: any = jasmine.createSpyObj('Notifications', ['message']);
   let mockUserService: any = jasmine.createSpy('UserService');
   let mockSpaceNamespaceService: any = jasmine.createSpy('SpaceNamespaceService');
-  let mockSpacesService: any = jasmine.createSpyObj('SpacesService', ['addRecent']);
+  let mockSpacesService: any = jasmine.createSpy('SpacesService');
   let mockContextService: any = jasmine.createSpy('ContextService');
   let mockLogger: any = jasmine.createSpyObj('Logger', ['error']);
   let mockErrorHandler: any = jasmine.createSpyObj('ErrorHandler', ['handleError']);
-  let mockSubject: any = jasmine.createSpy('Subject');
   let mockElementRef: any = jasmine.createSpyObj('ElementRef', ['nativeElement']);
 
   let mockProfile: Profile = {
@@ -111,17 +110,10 @@ describe('AddSpaceOverlayComponent', () => {
     type: 'spacetemplates'
   }] as ProcessTemplate[];
 
-  let mockMessage: Notification = {
-    message: `Failed to create "${mockSpace.name}"`,
-    type: NotificationType.DANGER
-  };
-
   beforeEach(() => {
     mockElementRef.nativeElement.value = {};
     mockSpaceNamespaceService.updateConfigMap = {};
     mockSpaceService.create.and.returnValue(Observable.of(mockSpace));
-    mockSpacesService.addRecent.and.returnValue(mockSubject);
-    mockSpacesService.addRecent.next = {};
     mockUserService.currentLoggedInUser = mockUser;
 
     TestBed.configureTestingModule({

--- a/src/app/space/add-space-overlay/add-space-overlay.component.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.ts
@@ -113,9 +113,6 @@ export class AddSpaceOverlayComponent implements OnInit {
     this.space.relationships['owned-by'].data.id = this.userService.currentLoggedInUser.id;
 
     this.subscriptions.push(this.spaceService.create(this.space)
-      .do(createdSpace => {
-        this.spacesService.addRecent.next(createdSpace);
-      })
       .switchMap(createdSpace => {
         return this.spaceNamespaceService
           .updateConfigMap(Observable.of(createdSpace))


### PR DESCRIPTION
Note: the last commit (regarding tests) in this PR will need to be refactored when https://github.com/fabric8-ui/fabric8-ui/pull/3201 is merged

This PR addresses OSIO defect #157 [0], in which the updating of 'recent space' causes a large number of PATCH calls to /api/users. Note that refactoring the SpacesService isn't enough to remove all the redundant calls, it appears that the ContextService is operating in a similar fashion and is responsible for most of the PATCH calls.

Currently, the _recent variable is a merge of the broadcaster 'spaceChanged' and addRecent (which gets updated for each space returned from `loadRecent()`) [1]. The problem lies with the `scan()` [2], which gets triggered for each space; loading 8 spaces via `loadRecent()` results in the subsequent block of code being executed 8 times - including `saveRecent()`. As a result, the user can expect to make `${_recent.length}` PATCH calls every time the service is initialized. In this PR, the 'spaceChanged' logic is separated and handled independently from the initial loading of recent spaces from the profileService, this way `saveRecent()` should be called only if 'spaceChanged' or 'spaceDeleted' is broadcasted.

Additionally, there is no code for removing deleted spaces from the list of recent spaces; the ContextService has such functionality by subscribing to the events service, but SpacesService currently does not. This could be seen as problematic and has been reported as a bug a handful of times [3]. In this PR, a message ('spaceDeleted') is broadcasted when a space is deleted, and causes the SpacesService to determine if that space is in the list of recent spaces, and if so, remove it [4].

I've included tests that cover all lines/functions/statements to try and capture the behaviour of the service.

Let me know what you think about this implementation, and if there is anything I've missed or should be on the look out for. Thanks!

**Screenshots**

**Before:**
/api/users requests from the chrome inspect network tab:
![old-home](https://user-images.githubusercontent.com/10425301/43344630-74849dbc-91b8-11e8-8df1-229f3a641711.png)

console warning every time a save occurs:
![old-space](https://user-images.githubusercontent.com/10425301/43344634-776a70ec-91b8-11e8-826b-671c7040767e.png)

**After:**
/api/users requests from the chrome inspect network tab:
![after-home](https://user-images.githubusercontent.com/10425301/43344637-7b15e49c-91b8-11e8-8138-6d04535c9ad5.png)

console warning every time a save occurs:
![after-space](https://user-images.githubusercontent.com/10425301/43344643-7dd8d2b6-91b8-11e8-9c4b-7047b41bf1a4.png)


[0] https://openshift.io/openshiftio/Openshift_io/plan/detail/157
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/shared/spaces.service.ts#L35
[2] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/shared/spaces.service.ts#L40
[3] https://github.com/openshiftio/openshift.io/issues/2196
[4] https://github.com/aptmac/fabric8-ui/blob/93e89febcb97dcea667ec3a36400294b34dc502c/src/app/shared/spaces.service.ts#L63
