### PR TITLE
"My Spaces" search

### DIFF
--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.html
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.html
@@ -1,0 +1,11 @@
+<div class="space-item" *ngIf="space?.relationalData?.creator?.attributes">
+  <div class="list-pf-title">
+    <a [routerLink]="['/', space?.relationalData?.creator?.attributes?.username, space?.attributes?.name]">
+      {{space?.attributes?.name}}</a>
+    <span class="avatar">
+      <img src="{{space?.relationalData?.creator?.attributes?.imageURL}}">
+      <span class="margin-left-10">{{space?.relationalData?.creator?.attributes?.username}}</span>
+    </span>
+  </div>
+  <div>{{space?.attributes?.description}}</div>
+</div>

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.html
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.html
@@ -3,7 +3,13 @@
     <a [routerLink]="['/', space?.relationalData?.creator?.attributes?.username, space?.attributes?.name]">
       {{space?.attributes?.name}}</a>
     <span class="avatar">
-      <img src="{{space?.relationalData?.creator?.attributes?.imageURL}}">
+      <span *ngIf="space?.relationalData?.creator?.attributes?.imageURL?.length > 0; then userAvatar else defaultAvatar"></span>
+      <ng-template #userAvatar>
+        <img [src]="space.relationalData.creator.attributes.imageURL">
+      </ng-template>
+      <ng-template #defaultAvatar>
+        <img src="../../../../../assets/images/profile-user.png">
+      </ng-template>
       <span class="margin-left-10">{{space?.relationalData?.creator?.attributes?.username}}</span>
     </span>
   </div>

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.html
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.html
@@ -5,10 +5,10 @@
     <span class="avatar">
       <span *ngIf="space?.relationalData?.creator?.attributes?.imageURL?.length > 0; then userAvatar else defaultAvatar"></span>
       <ng-template #userAvatar>
-        <img [src]="space.relationalData.creator.attributes.imageURL">
+        <img user-avatar [src]="space.relationalData.creator.attributes.imageURL">
       </ng-template>
       <ng-template #defaultAvatar>
-        <img src="../../../../../assets/images/profile-user.png">
+        <img default-avatar src="../../../../../assets/images/profile-user.png">
       </ng-template>
       <span class="margin-left-10">{{space?.relationalData?.creator?.attributes?.username}}</span>
     </span>

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.less
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.less
@@ -1,0 +1,19 @@
+@import (reference) '../../../../../assets/stylesheets/shared/osio.less';
+
+.space-item {
+  background-color: @color-pf-white;
+  padding: 20px;
+  border-top: 1px solid;
+  border-top-color: @color-pf-black-300;
+  .avatar {
+    border-left: 1px solid;
+    border-left-color: @color-pf-black-300;
+    margin-left: 10px;
+    padding-left: 10px;
+    img {
+      border-radius: 50%;
+      height: 25px;
+      width: 25px;
+    }
+  }
+}

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.spec.ts
@@ -23,5 +23,4 @@ describe('MySpacesSearchSpacesDialogSpaceItemComponent', () => {
   it('should be instantiable', function(this: TestingContext): void {
     expect(this.testedDirective).toBeDefined();
   });
-
 });

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.spec.ts
@@ -1,10 +1,17 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  DebugElement
+} from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import {
   initContext,
   TestContext
 } from 'testing/test-context';
+
+import { Space } from 'ngx-fabric8-wit';
 
 import { MySpacesSearchSpacesDialogSpaceItemComponent } from './my-spaces-search-spaces-dialog-space-item.component';
 
@@ -16,11 +23,57 @@ class HostComponent { }
 describe('MySpacesSearchSpacesDialogSpaceItemComponent', () => {
 
   type TestingContext = TestContext<MySpacesSearchSpacesDialogSpaceItemComponent, HostComponent>;
-  initContext(MySpacesSearchSpacesDialogSpaceItemComponent, HostComponent, {
-    imports: [ RouterTestingModule ]
-  });
+  initContext(MySpacesSearchSpacesDialogSpaceItemComponent, HostComponent,
+    {
+      imports: [
+        CommonModule,
+        RouterTestingModule
+      ]
+    },
+    (comp: MySpacesSearchSpacesDialogSpaceItemComponent): void => {
+      comp.space = {
+        attributes: {
+          name: 'foo-space',
+          description: 'some space description'
+        },
+        relationalData: {
+          creator: {
+            attributes: {
+              username: 'foo-user'
+            }
+          }
+        }
+      } as Space;
+    }
+  );
 
   it('should be instantiable', function(this: TestingContext): void {
     expect(this.testedDirective).toBeDefined();
+  });
+
+  describe('invalid (missing) creator avatar URL', () => {
+    it('should load default image', function(this: TestingContext): void {
+      const imgElement: DebugElement = this.tested.query(By.css('img'));
+      // within test harness the src attribute is undefined (rather than set to a specific URL),
+      // probably due to Webpack processing of the component template and image loader
+      expect(imgElement.properties['src']).toBeUndefined();
+      expect(imgElement.attributes['user-avatar']).toBeUndefined();
+      expect(imgElement.attributes['default-avatar']).toBeDefined();
+    });
+  });
+
+  describe('valid creator avatar URL', () => {
+    beforeEach(function(this: TestingContext): void {
+      // would actually be a remote URL, but for testing purposes, we will use a relative path to an existing asset to avoid 404s
+      this.testedDirective.space.relationalData.creator.attributes.imageURL = '../../../../../assets/images/icon-stack-nodejs.png';
+      this.detectChanges();
+    });
+
+    it('should load specified image', function(this: TestingContext): void {
+      const imgElement: DebugElement = this.tested.query(By.css('img'));
+      expect(imgElement.properties['src']).toEqual(this.testedDirective.space.relationalData.creator.attributes.imageURL);
+      expect(imgElement.attributes['user-avatar']).toBeDefined();
+      expect(imgElement.attributes['default-avatar']).toBeUndefined();
+    });
   });
 });

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.spec.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { MySpacesSearchSpacesDialogSpaceItemComponent } from './my-spaces-search-spaces-dialog-space-item.component';
+
+@Component({
+  template: '<my-spaces-search-spaces-dialog-space-item></my-spaces-search-spaces-dialog-space-item>'
+})
+class HostComponent { }
+
+describe('MySpacesSearchSpacesDialogSpaceItemComponent', () => {
+
+  type TestingContext = TestContext<MySpacesSearchSpacesDialogSpaceItemComponent, HostComponent>;
+  initContext(MySpacesSearchSpacesDialogSpaceItemComponent, HostComponent, {
+    imports: [ RouterTestingModule ]
+  });
+
+  it('should be instantiable', function(this: TestingContext): void {
+    expect(this.testedDirective).toBeDefined();
+  });
+
+});

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.component.ts
@@ -1,0 +1,14 @@
+import {
+  Component,
+  Input
+} from '@angular/core';
+import { Space } from 'ngx-fabric8-wit';
+
+@Component({
+  selector: 'my-spaces-search-spaces-dialog-space-item',
+  templateUrl: './my-spaces-search-spaces-dialog-space-item.component.html',
+  styleUrls: ['./my-spaces-search-spaces-dialog-space-item.component.less']
+})
+export class MySpacesSearchSpacesDialogSpaceItemComponent {
+  @Input() space: Space;
+}

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.module.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.module.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { MySpacesSearchSpacesDialogSpaceItemComponent } from './my-spaces-search-spaces-dialog-space-item.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule
+  ],
+  exports: [ MySpacesSearchSpacesDialogSpaceItemComponent ],
+  declarations: [ MySpacesSearchSpacesDialogSpaceItemComponent ]
+})
+export class MySpacesSearchSpacesDialogSpaceItemModule { }

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.html
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.html
@@ -8,7 +8,6 @@
         </button>
       </div>
       <div class="modal-body">
-
         <div class="input-group search-bar">
           <input #searchField type="text" class="form-control" placeholder="Enter Text to Search" [(ngModel)]="searchTerm" (keyup.enter)="search()">
           <div class="input-group-btn">
@@ -19,7 +18,6 @@
         </div>
 
         <div class="results-area">
-
           <ng-container [ngSwitch]="(viewState | async)">
             <ng-container *ngSwitchCase="'INIT'">
               <div class="init-state">
@@ -74,9 +72,7 @@
               </div>
             </ng-container>
           </ng-container><!-- ngSwitch -->
-
         </div><!-- results-area -->
-
       </div>
     </div>
   </div>

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.html
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.html
@@ -1,0 +1,83 @@
+<div class="modal fade" bsModal #modal="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Find Spaces to Join</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="hide()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+
+        <div class="input-group search-bar">
+          <input #searchField type="text" class="form-control" placeholder="Enter Text to Search" [(ngModel)]="searchTerm" (keyup.enter)="search()">
+          <div class="input-group-btn">
+            <button type="button" class="btn btn-primary" (click)="search()">
+              <span class="pficon pficon-search"></span>
+            </button>
+          </div>
+        </div>
+
+        <div class="results-area">
+
+          <ng-container [ngSwitch]="(viewState | async)">
+            <ng-container *ngSwitchCase="'INIT'">
+              <div class="init-state">
+                <div class="fa-3x pficon pficon-info state-icon"></div>
+                <div class="state-title">Your Search Results Will Appear Here</div>
+                <div class="state-description">Based on your search, the results will be listed here.</div>
+              </div>
+            </ng-container>
+
+            <ng-container *ngSwitchCase="'EMPTY'">
+              <div class="empty-state">
+                <div class="state-title">No Results Found</div>
+                <div class="state-description">No result found for your searched query. Change your search string and try again.</div>
+              </div>
+            </ng-container>
+
+            <ng-container *ngSwitchCase="'LOADING'">
+              <div class="loading-state">
+                <span class="spinner spinner-lg spinner-inline"></span>
+                <span class="spinner-label">Loading your results...</span>
+              </div>
+            </ng-container>
+
+            <ng-container *ngSwitchCase="'PRESHOW'">
+              <div [hidden]="true" class="list-title-bar">
+                <div class="list-pf-content-wrapper">
+                  <div class="list-pf-main-content">
+                    <div class="list-pf-title space-list-title-bar">
+                      <span class="sort-key-label">Name</span>
+                      <span class="result-count-label">{{totalCount | async}} Items</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div [hidden]="true" class="spaces-list" #infiniteScroll almInfiniteScroll [fetchThreshold]="'16'" [eachElementHeightInPx]="'54'" (initItems)="initItems($event)">
+              </div>
+            </ng-container>
+
+            <ng-container *ngSwitchCase="'SHOW'">
+              <div class="list-title-bar">
+                <div class="list-pf-content-wrapper">
+                  <div class="list-pf-main-content">
+                    <div class="list-pf-title space-list-title-bar">
+                      <span class="sort-key-label">Name</span>
+                      <span class="result-count-label">{{totalCount | async}} Items</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="spaces-list" #infiniteScroll almInfiniteScroll [fetchThreshold]="'16'" [eachElementHeightInPx]="'54'" (fetchMore)="fetchMoreSpaces()">
+                <my-spaces-search-spaces-dialog-space-item *ngFor="let space of spaces | async" [space]="space"></my-spaces-search-spaces-dialog-space-item>
+              </div>
+            </ng-container>
+          </ng-container><!-- ngSwitch -->
+
+        </div><!-- results-area -->
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.less
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.less
@@ -1,0 +1,100 @@
+@import (reference) '../../../../assets/stylesheets/shared/osio.less';
+
+.init-state {
+  text-align: center;
+  padding-top: 100px;
+  height: calc(100vh - 280px);
+}
+
+.empty-state {
+  text-align: center;
+  padding-top: 100px;
+  height: calc(100vh - 280px);
+}
+
+.loading-state {
+  text-align: center;
+  padding-top: 100px;
+  height: calc(100vh - 280px);
+  .spinner-label {
+    vertical-align: 40%;
+    padding-left: 8px;
+  }
+}
+
+.state {
+  &-icon {
+    color: @color-pf-black-500;
+  }
+  &-title {
+    color: @color-pf-black-500;
+    font-size: 2em;
+    font-weight: 400;
+  }
+  &-description {
+    font-weight: 400;
+  }
+}
+
+.modal-body {
+  padding: 20px;
+}
+
+.modal-dialog {
+  position: absolute;
+
+  width: auto;
+  height: auto;
+  margin: 0;
+
+  left: 50px;
+  right: 50px;
+
+  top: 100px;
+  bottom: 50px;
+}
+
+.modal-content {
+  height: 100%;
+  min-height: 100%;
+}
+
+.search-bar {
+  margin-left: 160px;
+  margin-right: 160px;
+}
+
+.results-area {
+  background-color: @color-pf-black-200;
+
+  margin-left: -20px;
+  margin-right: -20px;
+  margin-top: 20px;
+
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-bottom: 20px;
+}
+
+.list-title-bar {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.space-list-title-bar {
+  display: inline;
+  padding-left: 20px;
+  padding-right: 20px;
+  .sort-key-label {
+    float: left;
+  }
+  .result-count-label {
+    float: right;
+    padding-right: 1em;
+  }
+}
+
+.spaces-list {
+  overflow-y: scroll;
+  max-height: calc(100vh - 325px);
+}

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.spec.ts
@@ -1,0 +1,319 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  Input
+} from '@angular/core';
+import {
+  async,
+  fakeAsync,
+  tick
+} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { Observable } from 'rxjs';
+
+import { createMock } from 'testing/mock';
+import {
+  initContext,
+  TestContext
+} from 'testing/test-context';
+
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { Space, SpaceService } from 'ngx-fabric8-wit';
+import { InfiniteScrollModule } from 'ngx-widgets';
+
+import { MySpacesSearchSpacesDialog, ViewState } from './my-spaces-search-spaces-dialog.component';
+
+@Component({
+  template: '<my-spaces-search-spaces-dialog></my-spaces-search-spaces-dialog>'
+})
+class HostComponent { }
+
+@Component({
+  template: '',
+  selector: 'my-spaces-search-spaces-dialog-space-item'
+})
+class MockSpaceItem {
+  @Input() space: Space;
+}
+
+describe('MySpacesSearchSpacesDialog', () => {
+
+  type TestingContext = TestContext<MySpacesSearchSpacesDialog, HostComponent>;
+  initContext(MySpacesSearchSpacesDialog, HostComponent, {
+    imports: [
+      CommonModule,
+      FormsModule,
+      InfiniteScrollModule,
+      ModalModule.forRoot()
+    ],
+    declarations: [ MockSpaceItem ],
+    providers: [
+      { provide: SpaceService, useFactory: (): jasmine.SpyObj<SpaceService> => createMock(SpaceService) }
+    ]
+  });
+
+  it('should be instantiable', function(this: TestingContext): void {
+    expect(this.testedDirective).toBeDefined();
+  });
+
+  describe('#init', () => {
+    it('should set spaces list to empty array', function(this: TestingContext, done: DoneFn): void {
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([]);
+          done();
+        });
+    });
+
+    it('should set totalCount to 0', function(this: TestingContext, done: DoneFn): void {
+      this.testedDirective.totalCount
+        .first()
+        .subscribe((count: number): void => {
+          expect(count).toEqual(0);
+          done();
+        });
+    });
+
+    it('should set view state to INIT', function(this: TestingContext, done: DoneFn): void {
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.INIT);
+          done();
+        });
+    });
+
+    it('should set search term to empty', function(this: TestingContext): void {
+      expect(this.testedDirective.searchTerm).toBe('');
+    });
+  });
+
+  describe('#clear', () => {
+    beforeEach(async(function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.search.and.returnValue(Observable.of([
+        { name: 'foo-space' }
+      ]));
+      spaceService.getTotalCount.and.returnValue(Observable.of(1));
+      this.testedDirective.searchTerm = 'mocksearch';
+      this.testedDirective.search();
+      this.testedDirective.initItems({ pageSize: 10 });
+    }));
+
+    it('should reset spaces list to empty array', function(this: TestingContext, done: DoneFn): void {
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([{ name: 'foo-space' } as Space]);
+          this.testedDirective.clear();
+          this.testedDirective.spaces
+            .first()
+            .subscribe((spaces: Space[]): void => {
+              expect(spaces).toEqual([]);
+              done();
+            });
+        });
+    });
+
+    it('should set totalCount to 0', function(this: TestingContext, done: DoneFn): void {
+      this.testedDirective.totalCount
+        .first()
+        .subscribe((count: number): void => {
+          expect(count).toEqual(1);
+          this.testedDirective.clear();
+          this.testedDirective.totalCount
+            .first()
+            .subscribe((count: number): void => {
+              expect(count).toEqual(0);
+              done();
+            });
+        });
+    });
+
+    it('should set view state to INIT', function(this: TestingContext, done: DoneFn): void {
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.SHOW);
+          this.testedDirective.clear();
+          this.testedDirective.viewState
+            .first()
+            .subscribe((state: ViewState): void => {
+              expect(state).toEqual(ViewState.INIT);
+              done();
+            });
+        });
+    });
+
+    it('should reset search term', function(this: TestingContext): void {
+      expect(this.testedDirective.searchTerm).toEqual('mocksearch');
+      this.testedDirective.clear();
+      expect(this.testedDirective.searchTerm).toEqual('');
+    });
+  });
+
+  describe('#initItems', () => {
+    beforeEach(function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.search.and.returnValue(Observable.of([
+        { name: 'foo-space' }
+      ]));
+      spaceService.getTotalCount.and.returnValue(Observable.of(1));
+      this.testedDirective.searchTerm = 'mocksearch';
+    });
+
+    it('should set page size', fakeAsync(function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      const pageSize: number = 123;
+      this.testedDirective.initItems({ pageSize });
+      this.testedDirective.search();
+      tick();
+      this.testedDirective.spaces
+        .first()
+        .subscribe(() => {
+          expect(spaceService.search).toHaveBeenCalledWith(jasmine.any(String), pageSize);
+        });
+    }));
+
+    it('should set view state to LOADING', fakeAsync(function(this: TestingContext): void {
+      this.testedDirective.initItems({ pageSize: 10 });
+      tick();
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.LOADING);
+        });
+    }));
+  });
+
+  describe('#search', () => {
+    beforeEach(function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.search.and.returnValue(Observable.of([
+        { name: 'foo-space' }
+      ]));
+      spaceService.getTotalCount.and.returnValue(Observable.of(456));
+      this.testedDirective.searchTerm = ' mocksearch ';
+    });
+
+    it('should call SpaceService#search with trimmed search term', fakeAsync(function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      expect(spaceService.search).not.toHaveBeenCalled();
+      this.testedDirective.search();
+      const pageSize: number = 123;
+      this.testedDirective.initItems({ pageSize });
+      tick();
+      expect(spaceService.search).toHaveBeenCalledWith('mocksearch', pageSize);
+    }));
+
+    it('should call SpaceService#getTotalCount and update', fakeAsync(function(this: TestingContext): void {
+      this.testedDirective.totalCount
+        .first()
+        .subscribe((count: number): void => {
+          expect(count).toBe(0);
+        });
+
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      expect(spaceService.getTotalCount).not.toHaveBeenCalled();
+      this.testedDirective.search();
+      this.testedDirective.initItems({ pageSize: 123 });
+      tick();
+      expect(spaceService.getTotalCount).toHaveBeenCalled();
+
+      this.testedDirective.totalCount
+        .first()
+        .subscribe((count: number): void => {
+          expect(count).toBe(456);
+        });
+    }));
+
+    it('should set view state to SHOW when results are received', fakeAsync(function(this: TestingContext): void {
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.INIT);
+        });
+      this.testedDirective.search();
+      this.testedDirective.initItems({ pageSize: 123 });
+      tick();
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.SHOW);
+        });
+    }));
+
+    it('should set view state to EMPTY when no results are received', fakeAsync(function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.search.and.returnValue(Observable.of([]));
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.INIT);
+        });
+      this.testedDirective.search();
+      this.testedDirective.initItems({ pageSize: 123 });
+      tick();
+      this.testedDirective.viewState
+        .first()
+        .subscribe((state: ViewState): void => {
+          expect(state).toEqual(ViewState.EMPTY);
+        });
+    }));
+
+    it('should update spaces with received results', fakeAsync(function(this: TestingContext): void {
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([]);
+        });
+      this.testedDirective.search();
+      this.testedDirective.initItems({ pageSize: 123 });
+      tick();
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([ { name: 'foo-space' } as Space ]);
+        });
+    }));
+  });
+
+  describe('#fetchMoreSpaces', () => {
+    it('should append spaces to spaces list', function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.getMoreSearchResults.and.returnValue(Observable.of([ { name: 'more-space' } ]));
+
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([]);
+        });
+      this.testedDirective.fetchMoreSpaces();
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([ { name: 'more-space' } as Space ]);
+        });
+    });
+
+    it('should silently fail if no more spaces are found', function(this: TestingContext): void {
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.getMoreSearchResults.and.returnValue(Observable.throw('No more spaces found'));
+
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([]);
+        });
+      this.testedDirective.fetchMoreSpaces();
+      this.testedDirective.spaces
+        .first()
+        .subscribe((spaces: Space[]): void => {
+          expect(spaces).toEqual([]);
+        });
+    });
+  });
+
+});

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.spec.ts
@@ -315,5 +315,4 @@ describe('MySpacesSearchSpacesDialog', () => {
         });
     });
   });
-
 });

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.ts
@@ -1,0 +1,128 @@
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+
+import {
+  BehaviorSubject,
+  Observable,
+  Subject,
+  Subscription
+} from 'rxjs';
+
+import { flatten } from 'lodash';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import {
+  Space,
+  SpaceService
+} from 'ngx-fabric8-wit';
+
+export enum ViewState {
+  INIT = 'INIT',
+  EMPTY = 'EMPTY',
+  LOADING = 'LOADING',
+  // PRESHOW dummy state is used to allow an empty infinitescroll component
+  // to be initialized, compute the pagesize, and report that pagesize
+  // back to this component, which can then use it for query requests to
+  // populate the true infinitescroll component in "SHOW" state
+  PRESHOW = 'PRESHOW',
+  SHOW = 'SHOW'
+}
+
+@Component({
+  selector: 'my-spaces-search-spaces-dialog',
+  templateUrl: './my-spaces-search-spaces-dialog.component.html',
+  styleUrls: ['./my-spaces-search-spaces-dialog.component.less']
+})
+export class MySpacesSearchSpacesDialog implements OnDestroy, OnInit {
+
+  @ViewChild('modal') private readonly host: ModalDirective;
+  @ViewChild('searchField') private readonly searchField: ElementRef;
+
+  readonly spaces: Subject<Space[]> = new BehaviorSubject<Space[]>([]);
+  readonly totalCount: Subject<number> = new BehaviorSubject<number>(0);
+  readonly viewState: Subject<ViewState> = new BehaviorSubject<ViewState>(ViewState.INIT);
+  searchTerm: string = '';
+
+  private readonly subscriptions: Subscription[] = [];
+  private pageSize: number = 20;
+
+  constructor(
+    private readonly spaceService: SpaceService
+  ) { }
+
+  ngOnInit(): void {
+    this.subscriptions.push(
+      this.host.onShown.subscribe((): void => (this.searchField.nativeElement as HTMLElement).focus())
+    );
+    this.subscriptions.push(
+      this.host.onHidden.subscribe((): void => this.clear())
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((subscription: Subscription): void => subscription.unsubscribe());
+  }
+
+  show(): void {
+    this.host.show();
+  }
+
+  hide(): void {
+    this.host.hide();
+  }
+
+  clear(): void {
+    this.searchTerm = '';
+    this.viewState.next(ViewState.INIT);
+    this.spaces.next([]);
+    this.totalCount.next(0);
+  }
+
+  initItems(event: { pageSize: number }): void {
+    this.pageSize = event.pageSize;
+    setTimeout(() => this.viewState.next(ViewState.LOADING));
+  }
+
+  search(): void {
+    this.totalCount.next(0);
+    this.spaces.next([]);
+    if (!this.searchTerm.trim()) {
+      this.viewState.next(ViewState.INIT);
+      return;
+    }
+    this.viewState.next(ViewState.PRESHOW);
+    this.viewState
+      .filter((viewState: ViewState): boolean => viewState === ViewState.LOADING)
+      .first()
+      .flatMap(() => this.spaceService.search(this.searchTerm.trim(), this.pageSize).first())
+      .first()
+      .do(() => (this.searchField.nativeElement as HTMLElement).blur())
+      .do(() => this.spaceService.getTotalCount().first().subscribe((count: number): void => this.totalCount.next(count)))
+      .do((spaces: Space[]) => this.viewState.next(spaces.length === 0 ? ViewState.EMPTY : ViewState.SHOW))
+      .subscribe(
+        (spaces: Space[]): void => this.spaces.next(spaces),
+        (err: any): void => console.error(err)
+      );
+  }
+
+  fetchMoreSpaces(): void {
+    Observable.combineLatest(
+      this.spaces,
+      this.spaceService.getMoreSearchResults()
+    )
+      .first()
+      .map(flatten)
+      .subscribe(
+        (spaces: Space[]): void => this.spaces.next(spaces),
+        (err: any): void => {
+          if (err !== 'No more spaces found') {
+            console.error(err);
+          }
+        });
+  }
+
+}

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.ts
@@ -124,5 +124,4 @@ export class MySpacesSearchSpacesDialog implements OnDestroy, OnInit {
           }
         });
   }
-
 }

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.module.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.module.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { InfiniteScrollModule } from 'ngx-widgets';
+
+import { MySpacesSearchSpacesDialogSpaceItemModule } from './my-spaces-search-spaces-dialog-space-item/my-spaces-search-spaces-dialog-space-item.module';
+import { MySpacesSearchSpacesDialog } from './my-spaces-search-spaces-dialog.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    InfiniteScrollModule,
+    ModalModule,
+    MySpacesSearchSpacesDialogSpaceItemModule
+  ],
+  declarations: [ MySpacesSearchSpacesDialog ],
+  exports: [ MySpacesSearchSpacesDialog ]
+})
+export class MySpacesSearchSpacesDialogModule { }

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.html
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.html
@@ -1,11 +1,14 @@
 <div class="toolbar-header">
   <pfng-toolbar class="padding-top-10"
       [config]="toolbarConfig"
-      [viewTemplate]="addSpaceTemplate"
+      [viewTemplate]="toolbarTemplate"
       (onFilterChange)="filterChange($event)"
       (onSortChange)="sortChange($event)">
-    <ng-template #addSpaceTemplate>
-      <span class="with-cursor-pointer" placement="top" tooltip="Create Space"
+    <ng-template #toolbarTemplate>
+      <span class="vertical-separator padding-right-10">
+        <button class="btn btn-default" type="button" tooltip="Search Spaces" placement="top" (click)="searchSpaces($event)">Find a Space to Join</button>
+      </span>
+      <span class="with-cursor-pointer padding-left-10" placement="top" tooltip="Create Space"
             (click)="createSpace($event)">
         <span class="add-space-tooltip">
           <i class="pficon pficon-add-circle-o margin-top-4"></i>

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.less
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.less
@@ -1,5 +1,9 @@
 @import (reference) '../../../../assets/stylesheets/shared/osio.less';
 
+.vertical-separator {
+  border-right: 1px solid @color-pf-black-300;
+}
+
 .my-spaces-page {
   .toolbar-header {
     padding-left: 20px;

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
@@ -25,6 +25,7 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
   @Input() resultsCount: number = 0;
 
   @Output('onCreateSpace') onCreateSpace = new EventEmitter();
+  @Output('onSearchSpaces') onSearchSpaces = new EventEmitter();
   @Output('onFilterChange') onFilterChange = new EventEmitter();
   @Output('onSortChange') onSortChange = new EventEmitter();
 
@@ -79,6 +80,10 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
 
   createSpace($event: MouseEvent): void {
     this.onCreateSpace.emit($event);
+  }
+
+  searchSpaces($event: MouseEvent): void {
+    this.onSearchSpaces.emit($event);
   }
 
   filterChange($event: FilterEvent): void {

--- a/src/app/profile/my-spaces/my-spaces.component.html
+++ b/src/app/profile/my-spaces/my-spaces.component.html
@@ -1,6 +1,7 @@
 <div class="my-spaces-page">
   <my-spaces-toolbar
     (onCreateSpace)="showAddSpaceOverlay()"
+    (onSearchSpaces)="showSearchSpacesOverlay()"
     (onFilterChange)="filterChange($event)"
     (onSortChange)="sortChange($event)"
     [resultsCount]="resultsCount">
@@ -53,3 +54,5 @@
     <button class="btn btn-danger" (click)="removeSpace()">Remove</button>
   </div>
 </ng-template>
+
+<my-spaces-search-spaces-dialog></my-spaces-search-spaces-dialog>

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -3,6 +3,7 @@ import {
   OnDestroy,
   OnInit,
   TemplateRef,
+  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -22,6 +23,8 @@ import { SortEvent, SortField } from 'patternfly-ng/sort';
 import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { EventService } from '../../shared/event.service';
 
+import { MySpacesSearchSpacesDialog } from './my-spaces-search-dialog/my-spaces-search-spaces-dialog.component';
+
 @Component({
   encapsulation: ViewEncapsulation.None,
   selector: 'alm-my-spaces',
@@ -33,6 +36,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   listConfig: ListConfig;
   resultsCount: number = 0;
 
+  @ViewChild(MySpacesSearchSpacesDialog) private searchSpacesDialog: MySpacesSearchSpacesDialog;
   private _spaces: Space[] = [];
   private appliedFilters: Filter[];
   private allSpaces: Space[] = [];
@@ -259,6 +263,10 @@ export class MySpacesComponent implements OnDestroy, OnInit {
 
   showAddSpaceOverlay() {
     this.broadcaster.broadcast('showAddSpaceOverlay', true);
+  }
+
+  showSearchSpacesOverlay() {
+    this.searchSpacesDialog.show();
   }
 
   // Pinned items

--- a/src/app/profile/my-spaces/my-spaces.module.ts
+++ b/src/app/profile/my-spaces/my-spaces.module.ts
@@ -10,6 +10,7 @@ import { MySpacesItemActionsModule } from './my-spaces-item-actions/my-spaces-it
 import { MySpacesItemHeadingModule } from './my-spaces-item-heading/my-spaces-item-heading.module';
 import { MySpacesItemModule } from './my-spaces-item/my-spaces-item.module';
 import { MySpacesRoutingModule } from './my-spaces-routing.module';
+import { MySpacesSearchSpacesDialogModule } from './my-spaces-search-dialog/my-spaces-search-spaces-dialog.module';
 import { MySpacesToolbarModule } from './my-spaces-toolbar/my-spaces-toolbar.module';
 import { MySpacesComponent }     from './my-spaces.component';
 
@@ -24,7 +25,8 @@ import { MySpacesComponent }     from './my-spaces.component';
     MySpacesItemActionsModule,
     MySpacesItemHeadingModule,
     MySpacesToolbarModule,
-    MySpacesRoutingModule
+    MySpacesRoutingModule,
+    MySpacesSearchSpacesDialogModule
   ],
   declarations: [ MySpacesComponent ]
 })


### PR DESCRIPTION
This PR introduces initial support for a search feature on the My Spaces page, as described in the relevant design issue [0]. A button is added to the My Spaces toolbar which summons a search dialog, containing a simple search term text field and submission button above an infinite scroll results list. Other features described in the design issue, such as search typeahead, the ability to request to join spaces, and the ability to sort the results list, are left implemented for future enhancements, since these will require additional enabling backend support features.

The invision designs for the feature are here: https://redhat.invisionapp.com/share/P7LNZNZUZ9Y#/screens

And this GIF is a quick demo of what the feature looks like as proposed in this PR:

![43343519-836f4d9e-91b4-11e8-9822-7e18ea0acfba](https://user-images.githubusercontent.com/3787464/44547446-239eca80-a6e9-11e8-835a-79b7f77032e7.gif)

Below are some more screenshots illustrating the feature.

Toolbar button added:
![screenshot_2018-08-23_15-03-31](https://user-images.githubusercontent.com/3787464/44546449-f00e7100-a6e5-11e8-9afb-b597b77dca44.png)

Initial state:
![screenshot_2018-08-23_15-03-58](https://user-images.githubusercontent.com/3787464/44546455-f7ce1580-a6e5-11e8-8756-d2630649ca14.png)

Empty state (no results for search):
![screenshot_2018-08-23_15-04-20](https://user-images.githubusercontent.com/3787464/44546458-fe5c8d00-a6e5-11e8-9260-9de84f44c9ae.png)

Results list:
![screenshot_2018-08-23_15-04-42](https://user-images.githubusercontent.com/3787464/44546465-0288aa80-a6e6-11e8-893d-59a34704df5f.png)


[0] https://github.com/openshiftio/openshift.io/issues/3655