### PR TITLE
fix: getPipelines() returns all pipelines instead of defaulting to maven

### DIFF
--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
@@ -99,4 +99,32 @@ describe('Service: AppLauncherPipelineService', () => {
     });
   });
 
+  it('should return empty pipeline collection when response is empty', (done: DoneFn) => {
+    mockBackend.connections.subscribe((connection) => {
+      connection.mockRespond(new Response(new ResponseOptions({
+        body: JSON.stringify([])
+      })));
+    });
+
+    appLauncherPipelineService.getPipelines().subscribe(response => {
+      let pipelines: Pipeline[] = response;
+      expect(pipelines.length).toBe(0)
+      done();
+    });
+  });
+
+  it('should return empty pipelines collection when no match found for the platform name', (done: DoneFn) => {
+    mockBackend.connections.subscribe((connection) => {
+      connection.mockRespond(new Response(new ResponseOptions({
+        body: JSON.stringify(mockPipelines())
+      })));
+    });
+
+    appLauncherPipelineService.getPipelines('rust').subscribe(response => {
+      let pipelines: Pipeline[] = response;
+      expect(pipelines.length).toBe(0)
+      done();
+    });
+  });
+
 });

--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
@@ -30,7 +30,6 @@ function mockPipelines(): Pipeline[] {
     id: 'maven-releaseandstage',
     platform: 'maven',
     name: 'Release and Stage',
-    description: 'Release and stage to mvn',
     stages: [
       {
         name: 'Build Release',
@@ -47,7 +46,6 @@ function mockPipelines(): Pipeline[] {
       id: 'node-releaseandstage',
       platform: 'node',
       name: 'Release and Stage',
-      description: 'Release and stage - node',
       stages: [
         {
           name: 'Build Release',

--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
@@ -1,12 +1,12 @@
-import {TestBed} from '@angular/core/testing';
-import {HttpModule, Response, ResponseOptions, XHRBackend} from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { HttpModule, Response, ResponseOptions, XHRBackend } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
 
-import {Config, HelperService, Pipeline, TokenProvider} from 'ngx-launcher';
+import { Config, HelperService, Pipeline, TokenProvider } from 'ngx-launcher';
 
-import {FABRIC8_FORGE_API_URL} from '../../../shared/runtime-console/fabric8-ui-forge-api';
-import {NewForgeConfig} from '../shared/new-forge.config';
-import {AppLauncherPipelineService} from './app-launcher-pipeline.service';
+import { FABRIC8_FORGE_API_URL } from '../../../shared/runtime-console/fabric8-ui-forge-api';
+import { NewForgeConfig } from '../shared/new-forge.config';
+import { AppLauncherPipelineService } from './app-launcher-pipeline.service';
 
 
 function initTestBed() {
@@ -108,7 +108,7 @@ describe('Service: AppLauncherPipelineService', () => {
 
     appLauncherPipelineService.getPipelines().subscribe(response => {
       let pipelines: Pipeline[] = response;
-      expect(pipelines.length).toBe(0)
+      expect(pipelines.length).toBe(0);
       done();
     });
   });
@@ -122,7 +122,7 @@ describe('Service: AppLauncherPipelineService', () => {
 
     appLauncherPipelineService.getPipelines('rust').subscribe(response => {
       let pipelines: Pipeline[] = response;
-      expect(pipelines.length).toBe(0)
+      expect(pipelines.length).toBe(0);
       done();
     });
   });

--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
@@ -1,86 +1,101 @@
-import { inject, TestBed } from '@angular/core/testing';
-import {
-  HttpModule,
-  Response,
-  ResponseOptions,
-  XHRBackend
-} from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
+import {TestBed} from '@angular/core/testing';
+import {HttpModule, Response, ResponseOptions, XHRBackend} from '@angular/http';
+import {MockBackend} from '@angular/http/testing';
 
-import {
-    Config,
-    HelperService,
-    Pipeline,
-    TokenProvider
-} from 'ngx-launcher';
+import {Config, HelperService, Pipeline, TokenProvider} from 'ngx-launcher';
 
-import { FABRIC8_FORGE_API_URL } from '../../../shared/runtime-console/fabric8-ui-forge-api';
-import { NewForgeConfig } from '../shared/new-forge.config';
-import { AppLauncherPipelineService } from './app-launcher-pipeline.service';
+import {FABRIC8_FORGE_API_URL} from '../../../shared/runtime-console/fabric8-ui-forge-api';
+import {NewForgeConfig} from '../shared/new-forge.config';
+import {AppLauncherPipelineService} from './app-launcher-pipeline.service';
 
 
 function initTestBed() {
   TestBed.configureTestingModule({
-        imports: [
-            HttpModule
-        ],
-        providers: [
-            AppLauncherPipelineService,
-            HelperService,
-            TokenProvider,
-            { provide: Config, useClass: NewForgeConfig },
-            { provide: FABRIC8_FORGE_API_URL, useValue: 'url-here' },
-            { provide: XHRBackend, useClass: MockBackend }
-        ]
+    imports: [
+      HttpModule
+    ],
+    providers: [
+      AppLauncherPipelineService,
+      HelperService,
+      TokenProvider,
+      {provide: Config, useClass: NewForgeConfig},
+      {provide: FABRIC8_FORGE_API_URL, useValue: 'url-here'},
+      {provide: XHRBackend, useClass: MockBackend}
+    ]
   });
 }
 
-function mockPipeline(): Pipeline[] {
-    return <Pipeline[]> [{
-        id: 'maven-releaseandstage',
-        platform: 'maven',
-        name: 'Release and Stage',
-        stages: [
+function mockPipelines(): Pipeline[] {
+  return <Pipeline[]> [{
+    id: 'maven-releaseandstage',
+    platform: 'maven',
+    name: 'Release and Stage',
+    stages: [
+      {
+        name: 'Build Release',
+        description: 'creates a new version then builds and deploys the project into the maven repository'
+      },
+      {
+        name: 'Rollout to Stage',
+        description: 'stages the new version into the Stage environment'
+      }
+    ],
+    suggested: true
+  },
+    {
+      id: 'node-releaseandstage',
+      platform: 'node',
+      name: 'Release and Stage',
+      stages: [
         {
-            name: 'Build Release',
-            description: 'creates a new version then builds and deploys the project into the maven repository'
+          name: 'Build Release',
+          description: 'creates a new version then builds and deploys the project into the maven repository'
         },
         {
-            name: 'Rollout to Stage',
-            description: 'stages the new version into the Stage environment'
+          name: 'Rollout to Stage',
+          description: 'stages the new version into the Stage environment'
         }
-        ],
-        suggested: true
-    }];
+      ],
+      suggested: false
+    }
+  ];
 }
 
 describe('Service: AppLauncherPipelineService', () => {
-  let helperService: HelperService;
   let appLauncherPipelineService: AppLauncherPipelineService;
+  let mockBackend: MockBackend;
 
   beforeEach(() => {
     initTestBed();
     appLauncherPipelineService = TestBed.get(AppLauncherPipelineService);
+    mockBackend = TestBed.get(XHRBackend);
   });
 
-  it('should return pipelines', () => {
-    inject([AppLauncherPipelineService, XHRBackend], (service, mockBackend) => {
-        mockBackend.connections.subscribe((connection) => {
-            connection.mockRespond(new Response(new ResponseOptions({
-                body: JSON.stringify(mockPipeline)
-            })));
-        });
+  it('should return all pipelines when no platform specified', (done: DoneFn) => {
+    mockBackend.connections.subscribe((connection) => {
+      connection.mockRespond(new Response(new ResponseOptions({
+        body: JSON.stringify(mockPipelines())
+      })));
+    });
 
-        service.getMissions().subscribe(response => {
-            let pipelines: Pipeline[] = response;
-            expect(pipelines.length).toBe(2);
-            expect(pipelines[0].id).toBe('maven-releaseandstage');
-            expect(pipelines[0].name).toBe('Release and Stage');
-            expect(pipelines[0].platform).toBe('maven');
-            expect(pipelines[0].stages).toBeDefined();
-            expect(pipelines[0].stages.length).toBe(2);
-            expect(pipelines[0].suggested).toBe(true);
-        });
+    appLauncherPipelineService.getPipelines().subscribe(response => {
+      expect(response.length).toBe(2);
+      done();
+    });
+  });
+
+  it('should return filtered pipelines based on platform name', (done: DoneFn) => {
+    mockBackend.connections.subscribe((connection) => {
+      connection.mockRespond(new Response(new ResponseOptions({
+        body: JSON.stringify(mockPipelines())
+      })));
+    });
+
+    appLauncherPipelineService.getPipelines('node').subscribe(response => {
+      let pipelines: Pipeline[] = response;
+      expect(pipelines.length).toBe(1);
+      expect(pipelines[0].id).toEqual('node-releaseandstage');
+      done();
     });
   });
 

--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.spec.ts
@@ -30,6 +30,7 @@ function mockPipelines(): Pipeline[] {
     id: 'maven-releaseandstage',
     platform: 'maven',
     name: 'Release and Stage',
+    description: 'Release and stage to mvn',
     stages: [
       {
         name: 'Build Release',
@@ -46,6 +47,7 @@ function mockPipelines(): Pipeline[] {
       id: 'node-releaseandstage',
       platform: 'node',
       name: 'Release and Stage',
+      description: 'Release and stage - node',
       stages: [
         {
           name: 'Build Release',

--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.ts
@@ -44,8 +44,8 @@ export class AppLauncherPipelineService implements PipelineService {
         .map(response => response.json() as Pipeline[])
         .map(pipelines => {
           // needs to filter out associated pipelines from list of pipelines
-          return pipelines.filter(item => {
-            return item.platform === (filterByRuntime || item.platform);
+          return pipelines.filter(({platform}) => {
+            return platform === (filterByRuntime || platform);
           });
         })
         .catch(this.handleError);

--- a/src/app/space/app-launcher/services/app-launcher-pipeline.service.ts
+++ b/src/app/space/app-launcher/services/app-launcher-pipeline.service.ts
@@ -37,7 +37,7 @@ export class AppLauncherPipelineService implements PipelineService {
     }));
   }
 
-  getPipelines(filterByRuntime: string = 'maven'): Observable<Pipeline[]> {
+  getPipelines(filterByRuntime?: string): Observable<Pipeline[]> {
     let runtimeEndPoint: string = this.END_POINT + this.API_BASE;
     return this.options.flatMap((option) => {
       return this.http.get(runtimeEndPoint, option)
@@ -45,7 +45,7 @@ export class AppLauncherPipelineService implements PipelineService {
         .map(pipelines => {
           // needs to filter out associated pipelines from list of pipelines
           return pipelines.filter(item => {
-            return item.platform === filterByRuntime;
+            return item.platform === (filterByRuntime || item.platform);
           });
         })
         .catch(this.handleError);


### PR DESCRIPTION
`appLauncherPipelineService#getPipelines()` had default filter set to `maven` which made it impossible to fetch all pipelines exposed by Launcher Backend API. 

Part of https://github.com/openshiftio/openshift.io/issues/4140