### PR TITLE
fix(recent-spaces): fix f8-card-body-lg less rules to properly fill r…

### DIFF
--- a/src/assets/stylesheets/shared/_cards.less
+++ b/src/assets/stylesheets/shared/_cards.less
@@ -22,6 +22,10 @@
       .list-view-pf-view { margin-top: -1px; }
       &-lg {
         max-height: 585px;
+        margin-top: 0;
+        overflow-x: hidden;
+        .list-group { padding-bottom: 0; }
+        .list-view-pf-view { margin-top: -1px; }
       }
     }
     &-heading {


### PR DESCRIPTION
…ecent spaces widget

This PR addresses the recent-spaces widget list on the home page. When a `f8-card-body-lg` is used for the widget (as a result of experimental/internal feature toggle), the list has a noticeable gap at the top of the component (see screenshots below). This is because the `&-lg` stylesheet rule is not inheriting the `.list-group` and `.list-view-pf-view` attributes from the main `&-body` tag, which is required for closing the gap [[0]](https://github.com/fabric8-ui/fabric8-ui/blob/master/src/assets/stylesheets/shared/_cards.less#L24).

**Before:**
![before](https://user-images.githubusercontent.com/10425301/43913906-5750e5ae-9bd4-11e8-9bda-caa40de8f632.png)

**After:**
![after](https://user-images.githubusercontent.com/10425301/43913911-5ba2b222-9bd4-11e8-9c18-646e0c42961c.png)

[0] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/assets/stylesheets/shared/_cards.less#L24


