### PR TITLE
[WIP] fix(css): use google cdn for opensans fonts

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -345,7 +345,10 @@ module.exports = function (options) {
               name: '_assets/fonts/[name]' + (isProd ? '.[hash]' : '') + '.[ext]'
             }
           },
-          exclude: path.resolve(__dirname, "../src/assets/images/")
+          exclude: [
+            path.resolve(__dirname, "../src/assets/images/"),
+            /OpenSans.*\.(woff2|woff|ttf|eot|svg)$/
+          ]
         },
         {
           test: /\.(jpg|png|svg|gif|jpeg)$/,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rimraf": "rimraf",
     "semantic-release": "semantic-release pre && npm run build:prod && cp -r .git dist && npm publish dist/ && semantic-release post",
     "server:dev:hmr": "npm run server:dev -- --inline --hot",
-    "server:dev": "webpack-dev-server --config config/webpack.dev.js --progress --profile --watch --content-base src/",
+    "server:dev": "node --max-old-space-size=8192 node_modules/webpack-dev-server/bin/webpack-dev-server.js --config config/webpack.dev.js --progress --profile --watch --content-base src/",
     "server:dev2:hmr": "npm run server:dev2 -- --hot",
     "server:dev2": "node config/devserver.js --keepAliveTimeout 10000",
     "server:prod": "http-server dist --cors",

--- a/src/assets/stylesheets/shared/_patternfly.less
+++ b/src/assets/stylesheets/shared/_patternfly.less
@@ -1,0 +1,28 @@
+/* PatternFly */
+
+// Bootstrap
+@import "bootstrap/less/bootstrap.less";
+// Font Awesome
+@import "font-awesome/less/font-awesome.less";
+
+// Bootstrap overrides
+@import "variables.less";
+@import "mixins.less";
+@import "alerts.less";
+@import "badges.less";
+@import "breadcrumbs.less";
+@import "buttons.less";
+@import "dropdowns.less";
+@import "forms.less";
+@import "labels.less";
+@import "list-group.less";
+@import "modals.less";
+@import "pager.less";
+@import "pagination.less";
+@import "panels.less";
+@import "popovers.less";
+@import "progress-bars.less";
+@import "tables.less";
+@import "tabs.less";
+@import "tooltip.less";
+@import "type.less";

--- a/src/assets/stylesheets/shared/osio.less
+++ b/src/assets/stylesheets/shared/osio.less
@@ -17,8 +17,13 @@
 * OpenShift.io
 */
 
+// OpenSans Fonts from CDN
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i');
+
 // PatternFly References
-@import (reference) '../../../../node_modules/patternfly/dist/less/patternfly.less';
+// Use a subset of patternfly styles, excluding the fonts which comes from CDN above
+// Pattenrfly and Pattenrfly NG additions are provided as minified CSS via vendor.browser.ts
+@import '_patternfly.less';
 
 // margin and padding formulas
 @import '_formulas.less';

--- a/src/vendor.browser.ts
+++ b/src/vendor.browser.ts
@@ -26,7 +26,6 @@ import 'ngx-bootstrap';
 
 // import PatternFly CSS
 /* tslint:disable:ordered-imports */
-import '../node_modules/patternfly/dist/css/patternfly.min.css';
 import '../node_modules/patternfly/dist/css/patternfly-additions.min.css';
 import '../node_modules/patternfly-ng/dist/css/patternfly-ng.min.css';
 


### PR DESCRIPTION
This addresses https://openshift.io/openshiftio/Openshift_io/plan/detail/156

The OpenSans fonts are downloaded from CDN instead of being packaged in our distribution. A local prod build via `npm run build:prod` has a reduction of ~10 MB, from 36 MB to 26 MB on my machine.