### PR TITLE
fix(spaces): add loading widget to profile spaces component

### DIFF
--- a/src/app/profile/overview/spaces/spaces.component.html
+++ b/src/app/profile/overview/spaces/spaces.component.html
@@ -8,7 +8,10 @@
     </div>
   </div>
   <div class="card-pf-body f8-card-body">
-    <div *ngIf="spaces.length === 0; then showBlankState else showSpaces"></div>
+    <fabric8-loading-widget message="Please wait while we load the spaces"
+                            *ngIf="loading"></fabric8-loading-widget>
+    <div *ngIf="spaces.length > 0 && !loading then showSpaces"></div>
+    <div *ngIf="spaces.length === 0 && !loading then showBlankState"></div>
     <ng-template #showBlankState>
       <div class="f8-blank-slate-card">
         <div class="f8-blank-slate-icon">

--- a/src/app/profile/overview/spaces/spaces.component.spec.ts
+++ b/src/app/profile/overview/spaces/spaces.component.spec.ts
@@ -1,13 +1,12 @@
-import { DebugNode, NO_ERRORS_SCHEMA } from '@angular/core';
+import { DebugNode, ErrorHandler, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Broadcaster, Logger } from 'ngx-base';
 import { Contexts, Fabric8WitModule, SpaceService, WIT_API_URL } from 'ngx-fabric8-wit';
-import { AuthenticationService, UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs/Observable';
 
+import { createMock } from 'testing/mock';
 import { SpacesComponent } from './spaces.component';
-
 
 describe('SpacesComponent', () => {
   let fixture: ComponentFixture<SpacesComponent>;
@@ -15,10 +14,9 @@ describe('SpacesComponent', () => {
   let mockContexts: any = jasmine.createSpy('Contexts');
   let mockLogger: any = jasmine.createSpyObj('Logger', ['error']);
   let mockSpaceService: any = jasmine.createSpyObj('SpaceService', ['getSpacesByUser', 'getMoreSpacesByUser']);
-  let mockUserService: any = jasmine.createSpy('UserService');
-  let mockAuthenticationService: any = jasmine.createSpyObj('AuthenticationService', ['getGitHubToken', 'getToken']);
   let mockBroadcaster: any = jasmine.createSpyObj('Broadcaster', ['broadcast', 'on']);
   let mockEvent = jasmine.createSpy('Event');
+  let mockErrorHandler: jasmine.SpyObj<ErrorHandler> = createMock(ErrorHandler);
   let mockContext: any;
 
   beforeEach(() => {
@@ -32,7 +30,6 @@ describe('SpacesComponent', () => {
       }
     };
     mockContexts.current = Observable.of(mockContext);
-    mockAuthenticationService.gitHubToken = {};
 
     TestBed.configureTestingModule({
       imports: [
@@ -42,9 +39,8 @@ describe('SpacesComponent', () => {
       providers: [
         { provide: Contexts, useValue: mockContexts },
         { provide: Logger, useValue: mockLogger },
-        { provide: UserService, useValue: mockUserService},
-        { provide: AuthenticationService, useValue: mockAuthenticationService },
         { provide: Broadcaster, useValue: mockBroadcaster },
+        { provide: ErrorHandler, useValue: mockErrorHandler },
         { provide: WIT_API_URL, useValue: 'http://example.com' }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -56,7 +52,6 @@ describe('SpacesComponent', () => {
 
   describe('#ngOnInit', () => {
     it('should simply delegate to initSpaces() with the page size', () => {
-      console.log('compomemt', component);
       component.pageSize = 5;
       spyOn(component, 'initSpaces');
       component.ngOnInit();
@@ -65,6 +60,12 @@ describe('SpacesComponent', () => {
   });
 
   describe('#initSpaces', () => {
+
+    // ensure the component is not left in a loading state
+    afterEach(() => {
+      expect(component.loading).toEqual(false);
+    });
+
     it('should use spaceService.getSpacesByUser to set the initial spaces', () => {
       component.context = mockContext;
       component.spaceService.getSpacesByUser.and.returnValue(Observable.of('mock-spaces'));
@@ -100,9 +101,5 @@ describe('SpacesComponent', () => {
       expect(component.logger.error).toHaveBeenCalledWith('Failed to retrieve list of spaces owned by user');
     });
   });
-
-  // describe('#removeSpace', () => {});
-
-  // describe('#confirmDeleteSpace', () => {});
 
 });

--- a/src/app/profile/overview/spaces/spaces.component.ts
+++ b/src/app/profile/overview/spaces/spaces.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ErrorHandler, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { Broadcaster, Logger } from 'ngx-base';
 import { Context, Contexts } from 'ngx-fabric8-wit';
 import { Space, SpaceService } from 'ngx-fabric8-wit';
-import { AuthenticationService, User, UserService } from 'ngx-login-client';
+import { User } from 'ngx-login-client';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -20,18 +20,18 @@ export class SpacesComponent implements OnDestroy, OnInit  {
   subscriptions: Subscription[] = [];
   // spaceToDelete: Space;
   spaces: Space[] = [];
+  loading: boolean = false;
   private space: string;
 
   constructor(
       private contexts: Contexts,
       private logger: Logger,
       private spaceService: SpaceService,
-      private userService: UserService,
-      private authentication: AuthenticationService,
-      private broadcaster: Broadcaster
+      private broadcaster: Broadcaster,
+      private errorHandler: ErrorHandler
   ) {
     this.space = '';
-    this.subscriptions.push(contexts.current.subscribe(val => this.context = val));
+    this.subscriptions.push(this.contexts.current.subscribe(val => this.context = val));
     this.subscriptions.push(this.broadcaster.on('contextChanged').subscribe(val => {
       this.context = val as Context;
       this.initSpaces({pageSize: this.pageSize});
@@ -51,56 +51,41 @@ export class SpacesComponent implements OnDestroy, OnInit  {
   // Actions
 
   initSpaces(event: any): void {
+    this.loading = true;
     this.pageSize = event.pageSize;
     if (this.context && this.context.user) {
       this.subscriptions.push(this.spaceService
         .getSpacesByUser(this.context.user.attributes.username, this.pageSize)
-        .subscribe(spaces => {
-          this.spaces = spaces;
-        }));
+        .subscribe(
+          (spaces: Space[]): void => {
+            this.spaces = spaces;
+            this.loading = false;
+          },
+          (error: any): void => {
+            this.logger.error(error);
+            this.errorHandler.handleError(error);
+            this.loading = false;
+          }));
     } else {
       this.logger.error('Failed to retrieve list of spaces owned by user');
+      this.loading = false;
     }
   }
 
-  fetchMoreSpaces($event): void {
+  fetchMoreSpaces($event: any): void {
     if (this.context && this.context.user) {
       this.subscriptions.push(this.spaceService.getMoreSpacesByUser()
-        .subscribe(spaces => {
+        .subscribe(
+          (spaces: Space[]): void => {
             this.spaces = this.spaces.concat(spaces);
           },
-          err => {
+          (err: any): void => {
             this.logger.error(err);
           }));
     } else {
       this.logger.error('Failed to retrieve list of spaces owned by user');
     }
   }
-
-  // removeSpace(): void {
-  //   if (this.context && this.context.user && this.spaceToDelete) {
-  //     let space = this.spaceToDelete;
-  //     this.subscriptions.push(this.spaceService.deleteSpace(space)
-  //     .subscribe(spaces => {
-  //           let index = this.spaces.indexOf(space);
-  //       this.spaces.splice(index, 1);
-  //       this.spaceToDelete = undefined;
-  //       this.modalRef.hide();
-  //     },
-  //     err => {
-  //     this.logger.error(err);
-  //     this.spaceToDelete = undefined;
-  //     this.modalRef.hide();
-  //     }));
-  //   } else {
-  //     this.logger.error('Failed to retrieve list of spaces owned by user');
-  //   }
-  // }
-
-  // confirmDeleteSpace(space: Space, deleteSpace: TemplateRef<any>): void {
-  //   this.spaceToDelete = space;
-  //   this.modalRef = this.modalService.show(deleteSpace, { class: 'modal-lg' });
-  // }
 
   showAddSpaceOverlay(): void {
     this.broadcaster.broadcast('showAddSpaceOverlay', true);

--- a/src/app/profile/overview/spaces/spaces.module.ts
+++ b/src/app/profile/overview/spaces/spaces.module.ts
@@ -8,6 +8,7 @@ import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { InfiniteScrollModule, WidgetsModule } from 'ngx-widgets';
 
+import { LoadingWidgetModule } from '../../../dashboard-widgets/loading-widget/loading-widget.module';
 import { SpacesComponent } from './spaces.component';
 
 @NgModule({
@@ -17,6 +18,7 @@ import { SpacesComponent } from './spaces.component';
     Fabric8WitModule,
     FormsModule,
     InfiniteScrollModule,
+    LoadingWidgetModule,
     ModalModule.forRoot(),
     WidgetsModule,
     NgArrayPipesModule


### PR DESCRIPTION
This PR addresses the loading state of the profile spaces component, and it's current lack of the loading widget while retrieving spaces. Currently, an empty state screen appears initially, and then gets updated once the list of spaces returns. This PR uses the loading widget similar to other components in OSIO to display a spinner while the list of spaces is being retrieved.

Before:
![before](https://user-images.githubusercontent.com/10425301/44483902-4f06b400-a61a-11e8-841a-7072159d8c2b.gif)

After:
![after](https://user-images.githubusercontent.com/10425301/44483905-50d07780-a61a-11e8-91bd-99fb9717876d.gif)
