### PR TITLE
feat(notifications-settings): add internal feature flag for notifications tab

### DIFF
--- a/src/app/profile/settings/settings-routing.module.ts
+++ b/src/app/profile/settings/settings-routing.module.ts
@@ -3,6 +3,8 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { SettingsComponent } from './settings.component';
 
+import { FeatureFlagResolver } from 'ngx-feature-flag';
+
 const routes: Routes = [
   {
     path: '',
@@ -18,7 +20,14 @@ const routes: Routes = [
       },
       {
         path: 'notifications',
-        loadChildren: './notifications/notifications.module#NotificationsModule'
+        loadChildren: './notifications/notifications.module#NotificationsModule',
+        resolve: {
+          featureFlagConfig: FeatureFlagResolver
+        },
+        data: {
+          title: 'Notifications',
+          featureName: 'ProfileSettingsNotifications'
+        }
       },
       {
         path: 'resources',

--- a/src/app/profile/settings/settings-routing.module.ts
+++ b/src/app/profile/settings/settings-routing.module.ts
@@ -3,8 +3,6 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { SettingsComponent } from './settings.component';
 
-import { FeatureFlagResolver } from 'ngx-feature-flag';
-
 const routes: Routes = [
   {
     path: '',
@@ -17,17 +15,6 @@ const routes: Routes = [
       {
         path: 'feature-opt-in',
         loadChildren: './feature-opt-in/feature-opt-in.module#FeatureOptInModule'
-      },
-      {
-        path: 'notifications',
-        loadChildren: './notifications/notifications.module#NotificationsModule',
-        resolve: {
-          featureFlagConfig: FeatureFlagResolver
-        },
-        data: {
-          title: 'Notifications',
-          featureName: 'ProfileSettingsNotifications'
-        }
       },
       {
         path: 'resources',

--- a/src/app/profile/settings/settings.component.html
+++ b/src/app/profile/settings/settings.component.html
@@ -18,14 +18,6 @@
         Resources
       </a>
     </li>
-    <f8-feature-toggle class="nav nav-tabs nav-tabs-pf" featureName="ProfileSettingsNotifications" [userLevel]="user"></f8-feature-toggle>
-    <ng-template #user>
-      <li class="padding-left-15" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
-        <a [routerLink]="['/' + loggedInUserName + '/_settings/notifications']">
-          Notifications
-        </a>
-      </li>
-    </ng-template>
   </ul>
 </div>
 <router-outlet></router-outlet>

--- a/src/app/profile/settings/settings.component.html
+++ b/src/app/profile/settings/settings.component.html
@@ -14,15 +14,18 @@
       </a>
     </li>
     <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
-      <a [routerLink]="['/' + loggedInUserName + '/_settings/notifications']">
-        Notifications
-      </a>
-    </li>
-    <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
       <a [routerLink]="['/' + loggedInUserName + '/_settings/resources']">
         Resources
       </a>
     </li>
+    <f8-feature-toggle class="nav nav-tabs nav-tabs-pf" featureName="ProfileSettingsNotifications" [userLevel]="user"></f8-feature-toggle>
+    <ng-template #user>
+      <li class="padding-left-15" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+        <a [routerLink]="['/' + loggedInUserName + '/_settings/notifications']">
+          Notifications
+        </a>
+      </li>
+    </ng-template>
   </ul>
 </div>
 <router-outlet></router-outlet>

--- a/src/app/profile/settings/settings.module.ts
+++ b/src/app/profile/settings/settings.module.ts
@@ -4,9 +4,12 @@ import { DeploymentApiService } from '../../space/create/deployments/services/de
 import { SettingsRoutingModule } from './settings-routing.module';
 import { SettingsComponent } from './settings.component';
 
+import { FeatureFlagModule } from 'ngx-feature-flag';
+
 @NgModule({
   imports: [
-    SettingsRoutingModule
+    SettingsRoutingModule,
+    FeatureFlagModule
   ],
   declarations: [ SettingsComponent ],
   providers: [ DeploymentApiService ]

--- a/src/app/profile/settings/settings.module.ts
+++ b/src/app/profile/settings/settings.module.ts
@@ -4,12 +4,9 @@ import { DeploymentApiService } from '../../space/create/deployments/services/de
 import { SettingsRoutingModule } from './settings-routing.module';
 import { SettingsComponent } from './settings.component';
 
-import { FeatureFlagModule } from 'ngx-feature-flag';
-
 @NgModule({
   imports: [
-    SettingsRoutingModule,
-    FeatureFlagModule
+    SettingsRoutingModule
   ],
   declarations: [ SettingsComponent ],
   providers: [ DeploymentApiService ]


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4235
Fixes https://github.com/fabric8-services/fabric8-auth/issues/619

- Adds feature flag with `internal` level to notifications tab under settings section.