### PR TITLE
chore(routing): remove unused removeAction function

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,34 +2,8 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { FeatureFlagResolver } from 'ngx-feature-flag';
 
-import { trimEnd } from 'lodash';
-
-import { LoginComponent } from './login/login.component';
 import { ContextResolver } from './shared/context-resolver.service';
 import { ProfileResolver } from './shared/profile-resolver.service';
-import { SigninComponent } from './signin/signin.component';
-
-
-export function removeAction(url: string) {
-  const nestedOutletRegex: RegExp = (/^(.*\([A-z-]*?)\/{0,2}action:[A-z-]*\)$/);
-  if (url.indexOf('action:') !== -1) {
-    if (nestedOutletRegex.test(url)) {
-      // if the action outlet contains the current page
-      // e.g., /${user}/${space}/create/(pipelines//action:add-codebase)
-      url = url.match(nestedOutletRegex)[1];
-      let i = url.lastIndexOf('(');
-      url = url.substring(0, i) + url.substring(i + 1);
-      if ((url.lastIndexOf('/') + 1) === url.length) {
-       url = url.slice(0, -1); // trim trailing '/' if applicable
-      }
-    } else {
-      // if the outlet is isolated at the end of the url
-      // e.g., /${user}/${space}/create/(action:add-codebase)
-      url = trimEnd(url.replace(/\(action:[a-z-]*\)/, ''), '/');
-    }
-  }
-  return url;
-}
 
 export const routes: Routes = [
 
@@ -61,7 +35,8 @@ export const routes: Routes = [
       title: 'Getting Started'
     }
   },
-  //verify Email
+
+  // Verify Email
   {
     path: '_verifyEmail',
     loadChildren: './profile/email-verification/email-verification.module#EmailVerificationModule',
@@ -69,6 +44,7 @@ export const routes: Routes = [
       title: 'Verify'
     }
   },
+
   // Error Pages
   {
     path: '_error',
@@ -77,6 +53,7 @@ export const routes: Routes = [
       title: 'Error'
     }
   },
+
   // Feature Flag
   {
     path: '_featureflag',
@@ -85,6 +62,7 @@ export const routes: Routes = [
       title: 'Feature Flag'
     }
   },
+
   // Profile
   {
     path: '_profile',

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -142,24 +142,4 @@ describe('HeaderComponent', () => {
     });
   });
 
-  describe('#formatUrl', () => {
-    it('should remove an action outlet from the end of the url', () => {
-      let url: string = 'create/(action:add-codebase)';
-      let result = component.formatUrl(url);
-      expect(result).toEqual('create');
-    });
-
-    it('should remove an action outlet that contains a nested route', () => {
-      let url: string = 'create/(pipelines//action:add-codebase)';
-      let result = component.formatUrl(url);
-      expect(result).toEqual('create/pipelines');
-    });
-
-    it('should remove a query from the url', () => {
-      let url: string = 'space/plan?q=(space:1234567890)&showTree=true';
-      let result = component.formatUrl(url);
-      expect(result).toEqual('space/plan');
-    });
-  });
-
 });

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -18,14 +18,10 @@ import {
 } from 'testing/test-context';
 
 import {
-  Broadcaster,
-  Logger
+  Broadcaster
 } from 'ngx-base';
-import { BsModalService } from 'ngx-bootstrap/modal';
 import { Contexts } from 'ngx-fabric8-wit';
-import { FeatureTogglesService } from 'ngx-feature-flag';
 import {
-  AuthenticationService,
   UserService
 } from 'ngx-login-client';
 
@@ -76,9 +72,7 @@ describe('HeaderComponent', () => {
     ],
     declarations: [ MockRoutedComponent ],
     providers: [
-      { provide: FeatureTogglesService, useClass: MockFeatureToggleService },
       { provide: UserService, useValue: { loggedInUser: Observable.never() } },
-      { provide: Logger, useValue: createMock(Logger) },
       { provide: LoginService, useValue: jasmine.createSpyObj('LoginService', ['login']) },
       { provide: Broadcaster, useValue: mockBroadcaster },
       {
@@ -87,9 +81,7 @@ describe('HeaderComponent', () => {
           current: Observable.of({ name: 'current' }),
           recent: Observable.never()
         }
-      },
-      { provide: BsModalService, useValue: createMock(BsModalService) },
-      { provide: AuthenticationService, useValue: createMock(AuthenticationService) }
+      }
     ],
     schemas: [ NO_ERRORS_SCHEMA ]
   });

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -7,8 +7,6 @@ import { Broadcaster, Logger } from 'ngx-base';
 import { Context, Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 
-import { removeAction } from '../../app-routing.module';
-
 import { FeatureTogglesService } from 'ngx-feature-flag';
 import { Navigation } from '../../models/navigation';
 import { LoginService } from '../../shared/login.service';
@@ -162,12 +160,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return (this.router.url.indexOf('applauncher') !== -1);
   }
 
-  formatUrl(url: string) {
-    url = this.stripQueryFromUrl(url);
-    url = removeAction(url);
-    return url;
-  }
-
   private stripQueryFromUrl(url: string) {
     if (url.indexOf('?q=') !== -1) {
       url = url.substring(0, url.indexOf('?q='));
@@ -178,7 +170,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private updateMenus() {
     if (this.context && this.context.type && this.context.type.hasOwnProperty('menus')) {
       let foundPath = false;
-      let url = this.formatUrl(this.router.url);
+      let url = this.stripQueryFromUrl(this.router.url);
       let menus = (this.context.type as MenuedContextType).menus;
       for (let n of menus) {
         // Clear the menu's active state

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -1,13 +1,13 @@
-import { Component, OnDestroy, OnInit, TemplateRef } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Event, NavigationEnd, Params, Router } from '@angular/router';
 
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 
-import { Broadcaster, Logger } from 'ngx-base';
+import { Broadcaster } from 'ngx-base';
 import { Context, Contexts } from 'ngx-fabric8-wit';
-import { AuthenticationService, User, UserService } from 'ngx-login-client';
+import { User, UserService } from 'ngx-login-client';
 
-import { FeatureTogglesService } from 'ngx-feature-flag';
+import { MenuItem } from '../../models/menu-item';
 import { Navigation } from '../../models/navigation';
 import { LoginService } from '../../shared/login.service';
 import { MenuedContextType } from './menued-context-type';
@@ -19,19 +19,18 @@ interface MenuHiddenCallback {
 @Component({
   selector: 'alm-app-header',
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.less'],
-  providers: []
+  styleUrls: ['./header.component.less']
 })
 export class HeaderComponent implements OnInit, OnDestroy {
-  imgLoaded: Boolean = false;
-  isIn = false;   // store state
+  imgLoaded: boolean = false;
+  isIn: boolean = false;   // store state
 
   toggleState() { // click handler
-      let bool = this.isIn;
+      let bool: boolean = this.isIn;
       this.isIn = bool === false ? true : false;
   }
 
-  menuCallbacks = new Map<String, MenuHiddenCallback>([
+  menuCallbacks: Map<String, MenuHiddenCallback> = new Map<String, MenuHiddenCallback>([
     [
       '_settings', function(headerComponent) {
         return headerComponent.checkContextUserEqualsLoggedInUser();
@@ -54,42 +53,37 @@ export class HeaderComponent implements OnInit, OnDestroy {
   loggedInUser: User;
   private _context: Context;
   private _defaultContext: Context;
-  private _loggedInUserSubscription: Subscription;
   private plannerFollowQueryParams: Object = {};
   private eventListeners: any[] = [];
-  private selectedFlow: string;
-  private space: string;
 
   constructor(
     public router: Router,
     public route: ActivatedRoute,
     private userService: UserService,
-    private logger: Logger,
     public loginService: LoginService,
     private broadcaster: Broadcaster,
-    private contexts: Contexts,
-    private authentication: AuthenticationService,
-    private featureTogglesService: FeatureTogglesService
+    private contexts: Contexts
   ) {
-    this.space = '';
-    router.events.subscribe((val) => {
+    router.events.subscribe((val: Event): void => {
       if (val instanceof NavigationEnd) {
         this.broadcaster.broadcast('navigate', { url: val.url } as Navigation);
         this.updateMenus();
       }
     });
-    contexts.current.subscribe(val => {
+    this.contexts.current.subscribe((val: Context): void => {
       this._context = val;
       this.updateMenus();
     });
-    contexts.default.subscribe(val => {
+    this.contexts.default.subscribe((val: Context): void => {
       this._defaultContext = val;
     });
-    contexts.recent.subscribe(val => this.recent = val);
+    this.contexts.recent.subscribe((val: Context[]): void => {
+      this.recent = val;
+    });
 
     // Currently logged in user
     this.userService.loggedInUser.subscribe(
-      val => {
+      (val: User): void => {
         if (val.id) {
           this.loggedInUser = val;
         } else {
@@ -104,13 +98,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
     this.listenToEvents();
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.eventListeners.forEach(e => e.unsubscribe());
   }
 
-  listenToEvents() {
+  listenToEvents(): void {
     this.eventListeners.push(
-      this.route.queryParams.subscribe(params => {
+      this.route.queryParams.subscribe((params: Params): void => {
         this.plannerFollowQueryParams = {};
         if (Object.keys(params).indexOf('iteration') > -1) {
           this.plannerFollowQueryParams['iteration'] = params['iteration'];
@@ -119,18 +113,18 @@ export class HeaderComponent implements OnInit, OnDestroy {
     );
   }
 
-  login() {
+  login(): void {
     this.loginService.redirectUrl = this.router.url;
     this.broadcaster.broadcast('login');
     this.loginService.redirectToAuth();
   }
 
-  logout() {
+  logout(): void {
     this.loginService.logout();
 
   }
 
-  onImgLoad() {
+  onImgLoad(): void {
     this.imgLoaded = true;
   }
 
@@ -167,10 +161,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return url;
   }
 
-  private updateMenus() {
+  private updateMenus(): void {
     if (this.context && this.context.type && this.context.type.hasOwnProperty('menus')) {
-      let foundPath = false;
-      let url = this.stripQueryFromUrl(this.router.url);
+      let foundPath: boolean = false;
+      let url: string = this.stripQueryFromUrl(this.router.url);
       let menus = (this.context.type as MenuedContextType).menus;
       for (let n of menus) {
         // Clear the menu's active state
@@ -181,7 +175,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
         // lets go in reverse order to avoid matching
         // /namespace/space/create instead of /namespace/space/create/pipelines
         // as the 'Create' page matches to the 'Codebases' page
-        let subMenus = (n.menus || []).slice().reverse();
+        let subMenus: MenuItem[] = (n.menus || []).slice().reverse();
         if (subMenus && subMenus.length > 0) {
           for (let o of subMenus) {
             // Clear the menu's active state
@@ -232,8 +226,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   private checkContextUserEqualsLoggedInUser(): Observable<boolean> {
     return Observable.combineLatest(
-      Observable.of(this.context).map(val => val.user.id),
-      this.userService.loggedInUser.map(val => val.id),
+      Observable.of(this.context).map((val: Context) => val.user.id),
+      this.userService.loggedInUser.map((val: User) => val.id),
       (a, b) => (a !== b)
     );
   }


### PR DESCRIPTION
This PR removes a now unused function in the `app-routing.module`, and cleans up (add missing type definitions, remove unused imports) the code in the header component. 

Router actions were previously used when adding codebases to a space, but have been deprecated and later removed [0][1]. The `app-routing.module` exports a function that chops the trailing router action from the URL and is used in a couple of unit tests, but outside of that it is no longer needed. While removing the tests from the `header.component.spec` I figured it would be a good opportunity to clean up a bit of the code, so I added missing type definitions and removed unused imports/variables.

[0] https://github.com/fabric8-ui/fabric8-ui/pull/2980
[1] https://github.com/fabric8-ui/fabric8-ui/pull/2980/commits/f6ad12192e8ab6c62336be2e129325a194199317#diff-e567e49645874cf8ca3f28403f0435cbL10