### PR TITLE
fix(profile): fix init and destroy in tenant component tests

### DIFF
--- a/src/app/profile/tenant/tenant.component.spec.ts
+++ b/src/app/profile/tenant/tenant.component.spec.ts
@@ -21,7 +21,7 @@ describe('TenantComponent', () => {
   let fixture: ComponentFixture<TenantComponent>;
   let component: DebugNode['componentInstance'];
   let mockAuthenticationService: any = jasmine.createSpyObj('AuthenticationService', ['getToken']);
-  let mockGettingStartedService: any = jasmine.createSpyObj('GettingStartedService', ['createTransientProfile', 'update']);
+  let mockGettingStartedService: any = jasmine.createSpyObj('GettingStartedService', ['createTransientProfile', 'update', 'ngOnDestroy']);
   let mockContexts: any = jasmine.createSpy('Contexts');
   let mockNotifications: any = jasmine.createSpyObj('Notifications', ['message']);
   let mockRouter: any = jasmine.createSpyObj('Router', ['navigate']);
@@ -61,6 +61,8 @@ describe('TenantComponent', () => {
     TestBed.overrideProvider(TenantService, { useValue: mockTenantService });
     fixture = TestBed.createComponent(TenantComponent);
     component = fixture.debugElement.componentInstance;
+
+    fixture.detectChanges();
   });
 
   describe('#isUpdateProfileDisabled', () => {


### PR DESCRIPTION
This fixes the tenant component spec to properly init and destroy, so the following no longer occurs.

```
ERROR: 'Error during cleanup of component', TenantComponent [...]
```