### PR TITLE
fix(work-item-widget): fix incorrect total of work items

### DIFF
--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.spec.ts
@@ -17,6 +17,7 @@ import {
   initContext,
   TestContext
 } from 'testing/test-context';
+import { WorkItemsData } from '../../shared/workitem-utils';
 
 @Component({
   template: '<fabric8-create-work-item-widget [userOwnsSpace]="userOwnsSpace"></fabric8-create-work-item-widget>'
@@ -58,8 +59,7 @@ describe('CreateWorkItemWidgetComponent', () => {
         provide: WorkItemService, useFactory: () => {
           let workItemServiceMock = jasmine.createSpyObj('WorkItemService', ['buildUserIdMap', 'getWorkItems']);
           workItemServiceMock.buildUserIdMap.and.returnValue(fakeUser);
-          workItemServiceMock.getWorkItems.and.returnValue([] as WorkItem[]);
-
+          workItemServiceMock.getWorkItems.and.returnValue(Observable.of({ workItems: [] }) as Observable<WorkItemsData>);
           return workItemServiceMock;
         }
       },

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.ts
@@ -6,7 +6,7 @@ import { FilterService, WorkItem, WorkItemService } from 'fabric8-planner';
 import { Contexts } from 'ngx-fabric8-wit';
 import { UserService } from 'ngx-login-client';
 
-import { filterOutClosedItems } from '../../shared/workitem-utils';
+import { filterOutClosedItems, WorkItemsData } from '../../shared/workitem-utils';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -37,7 +37,7 @@ export class CreateWorkItemWidgetComponent implements OnInit {
       .map(user => this.filterService.queryBuilder('assignee', this.filterService.equal_notation, user.id))
       .switchMap(filters => this.workItemService
         .getWorkItems(100000, {expression: filters}))
-      .map(val => val.workItems)
+      .map((val: WorkItemsData) => val.workItems)
       .map(workItems => filterOutClosedItems(workItems))
       // Resolve the work item type
       .do(workItems => workItems.forEach(workItem => this.workItemService.resolveType(workItem)))

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.spec.ts
@@ -14,6 +14,7 @@ import { createMock } from 'testing/mock';
 import { MockFeatureToggleComponent } from 'testing/mock-feature-toggle.component';
 import { LoadingWidgetModule } from '../../dashboard-widgets/loading-widget/loading-widget.module';
 import { SpacesService } from '../../shared/spaces.service';
+import { WorkItemsData } from '../../shared/workitem-utils';
 import { WorkItemBarchartModule } from './work-item-barchart/work-item-barchart.module';
 import { WorkItemWidgetComponent } from './work-item-widget.component';
 
@@ -141,7 +142,7 @@ describe('Dashboard: WorkItemWidgetComponent', () => {
             const mockWorkItemService: jasmine.SpyObj<WorkItemService> = createMock(WorkItemService);
             mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
               workItems: workItems
-            }));
+            } as WorkItemsData));
             return mockWorkItemService;
           }
         }
@@ -205,7 +206,7 @@ describe('Dashboard: WorkItemWidgetComponent', () => {
       const mockWorkItemService: jasmine.SpyObj<WorkItemService> = TestBed.get(WorkItemService);
       mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
         workItems: [workItem] // workItem has no system.state attribute
-      }));
+      } as WorkItemsData));
 
       fixture = TestBed.createComponent(WorkItemWidgetComponent);
       component = fixture.debugElement.componentInstance;
@@ -236,7 +237,7 @@ describe('Dashboard: WorkItemWidgetComponent', () => {
 
       mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
         workItems: []
-      }));
+      } as WorkItemsData));
       mockContexts.current.next(mockContext);
       // if WI service returns empty list, counter variables should not increment after reset
       expect(component.myWorkItemsCount).toEqual(0);
@@ -262,7 +263,7 @@ describe('Dashboard: WorkItemWidgetComponent', () => {
 
       mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
         workItems: [workItem1, workItem2, workItem3]
-      }));
+      } as WorkItemsData));
       mockContexts.current.next(mockContext);
       // verify that chartData contains the 3 workItems worth of information
       expect(component.chartData.yData[0]).toEqual([component.LABEL_RESOLVED, 0]);
@@ -281,7 +282,7 @@ describe('Dashboard: WorkItemWidgetComponent', () => {
         workItems: [workItem1, workItem2, workItem3],
         nextLink: 'mock-nextLink',
         totalCount: 5
-      }));
+      } as WorkItemsData));
       expect(component.myWorkItemsCount).toEqual(5);
     });
 

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.spec.ts
@@ -270,6 +270,21 @@ describe('Dashboard: WorkItemWidgetComponent', () => {
       expect(component.chartData.yData[2]).toEqual([component.LABEL_OPEN, 2]);
     });
 
+    it('should use the totalCount value for myWorkItemsCount if it exists', () => {
+      const mockWorkItemService: jasmine.SpyObj<WorkItemService> = TestBed.get(WorkItemService);
+
+      fixture = TestBed.createComponent(WorkItemWidgetComponent);
+      component = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+
+      mockWorkItemService.getWorkItems.and.returnValue(Observable.of({
+        workItems: [workItem1, workItem2, workItem3],
+        nextLink: 'mock-nextLink',
+        totalCount: 5
+      }));
+      expect(component.myWorkItemsCount).toEqual(5);
+    });
+
     it('should increment the work item type counters accordingly', () => {
       let expectedCount: number = workItems.length;
       let expectedOpen: number = 0;

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
@@ -83,9 +83,15 @@ export class WorkItemWidgetComponent implements OnInit {
           100000, {expression: {'space': `${space.id}`}}
         );
       })
+      .do((val: { workItems: WorkItem[], nextLink: string, totalCount?: number, included?: WorkItem[], ancestorIDs?: string[]}): void => {
+        if (val.totalCount) {
+          this.myWorkItemsCount = val.totalCount;
+        } else {
+          this.myWorkItemsCount = val.workItems.length;
+        }
+      })
       .map(val => val.workItems)
       .do(workItems => {
-        this.myWorkItemsCount = workItems.length;
         this.loading = false;
         workItems.forEach(workItem => {
           let state = workItem.attributes['system.state'];

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
@@ -10,6 +10,7 @@ import { WorkItemBarchartData } from './work-item-barchart/work-item-barchart-da
 
 import { uniqueId } from 'lodash';
 
+import { WorkItemsData } from '../../shared/workitem-utils';
 import { SpacesService } from './../../shared/spaces.service';
 
 @Component({
@@ -83,7 +84,7 @@ export class WorkItemWidgetComponent implements OnInit {
           100000, {expression: {'space': `${space.id}`}}
         );
       })
-      .do((val: { workItems: WorkItem[], nextLink: string, totalCount?: number, included?: WorkItem[], ancestorIDs?: string[]}): void => {
+      .do((val: WorkItemsData): void => {
         if (val.totalCount) {
           this.myWorkItemsCount = val.totalCount;
         } else {

--- a/src/app/home/work-item-widget/work-item-widget.component.spec.ts
+++ b/src/app/home/work-item-widget/work-item-widget.component.spec.ts
@@ -21,7 +21,9 @@ import {
 } from 'testing/test-context';
 
 import { spaceMock } from '../../shared/context.service.mock';
+import { WorkItemsData } from '../../shared/workitem-utils';
 import { WorkItemWidgetComponent } from './work-item-widget.component';
+
 
 @Component({
   template: '<alm-work-item-widget></alm-work-item-widget>'
@@ -72,9 +74,9 @@ describe('Home: WorkItemWidgetComponent', () => {
 
   let fakeWorkItems: WorkItem[] = [fakeWorkItem1, fakeWorkItem2, fakeWorkItem3, fakeWorkItem4, fakeWorkItem5];
 
-  let fakeWorkItemsObs: Observable<{workItems: WorkItem[]}> = Observable.of({
+  let fakeWorkItemsObs: Observable<WorkItemsData> = Observable.of({
     workItems: fakeWorkItems
-  });
+  } as WorkItemsData);
 
   initContext(WorkItemWidgetComponent, HostComponent, {
     declarations: [ MockFeatureToggleComponent ],

--- a/src/app/home/work-item-widget/work-item-widget.component.ts
+++ b/src/app/home/work-item-widget/work-item-widget.component.ts
@@ -5,7 +5,7 @@ import { Space, Spaces } from 'ngx-fabric8-wit';
 import { User, UserService } from 'ngx-login-client';
 import { Subscription } from 'rxjs';
 
-import { filterOutClosedItems } from '../../shared/workitem-utils';
+import { filterOutClosedItems, WorkItemsData } from '../../shared/workitem-utils';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -85,7 +85,7 @@ export class WorkItemWidgetComponent implements OnDestroy, OnInit  {
       })
       .switchMap(filters => this.workItemService
         .getWorkItems(100000, {expression: filters}))
-      .map(val => val.workItems)
+      .map((val: WorkItemsData) => val.workItems)
       .map(workItems => filterOutClosedItems(workItems))
       // Resolve the work item type
       .do(workItems => workItems.forEach(workItem => this.workItemService.resolveType(workItem)))

--- a/src/app/profile/overview/work-items/work-items.component.spec.ts
+++ b/src/app/profile/overview/work-items/work-items.component.spec.ts
@@ -13,6 +13,7 @@ import { createMock } from 'testing/mock';
 import { initContext, TestContext } from 'testing/test-context';
 import { ContextService } from '../../../shared/context.service';
 
+import { WorkItemsData } from '../../../shared/workitem-utils';
 import { WorkItemsComponent } from './work-items.component';
 
 @Component({
@@ -88,7 +89,7 @@ describe('WorkItemsComponent', () => {
       },
       { provide: WorkItemService, useFactory: () => {
           let mockWorkItemService: jasmine.SpyObj<WorkItemService> = createMock(WorkItemService);
-          mockWorkItemService.getWorkItems.and.returnValue(Observable.of({ workItems: [] }) as Observable<{workItems}>);
+          mockWorkItemService.getWorkItems.and.returnValue(Observable.of({ workItems: [] }) as Observable<WorkItemsData>);
           mockWorkItemService.buildUserIdMap.and.returnValue(Observable.of(mockContext.user) as Observable<User>);
           return mockWorkItemService;
         }

--- a/src/app/profile/overview/work-items/work-items.component.ts
+++ b/src/app/profile/overview/work-items/work-items.component.ts
@@ -8,7 +8,7 @@ import { Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
 import { ContextService } from '../../../shared/context.service';
 
-import { filterOutClosedItems } from '../../../shared/workitem-utils';
+import { filterOutClosedItems, WorkItemsData } from '../../../shared/workitem-utils';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -102,7 +102,7 @@ export class WorkItemsComponent implements OnDestroy, OnInit {
     this.subscriptions.push(
       this.workItemService
         .getWorkItems(100000, {expression: filters})
-        .map(val => val.workItems)
+        .map((val: WorkItemsData) => val.workItems)
         .map(workItems => filterOutClosedItems(workItems))
         // Resolve the work item type, creator and area
         .subscribe(workItems => {

--- a/src/app/shared/workitem-utils.ts
+++ b/src/app/shared/workitem-utils.ts
@@ -1,3 +1,5 @@
+import { WorkItem } from 'fabric8-planner';
+
 export function filterOutClosedItems(items) {
   return items.filter(item => {
     // filter out items which has state closed or done or removed
@@ -7,4 +9,12 @@ export function filterOutClosedItems(items) {
       'done'
     ].indexOf(item.attributes['system.state'].toLowerCase()) === -1;
   });
+}
+
+export class WorkItemsData {
+  workItems: WorkItem[];
+  nextLink: string;
+  totalCount?: number | null;
+  included?: WorkItem[] | null;
+  ancestorIDs?: Array<string>;
 }


### PR DESCRIPTION
This PR addresses https://github.com/openshiftio/openshift.io/issues/4303, where the dashboard work item widget can display an incorrect number of total work items. This occurs because it seems the workitemservice will return at most 500 work items, and the total count is obtained by getting the length of the array of work items. However, the workitemservice also returns an actual number with the total number of work items that we can use here.