### PR TITLE
fix(cache): fix cache interceptor to return the proper observable

### DIFF
--- a/src/app/shared/interceptors/cache.interceptor.ts
+++ b/src/app/shared/interceptors/cache.interceptor.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@angular/core';
 
 import {
-  HttpHandler, HttpInterceptor,
-  HttpRequest, HttpResponse
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse
 } from '@angular/common/http';
 
 import { AsyncSubject, Observable, Scheduler } from 'rxjs';
@@ -19,7 +22,7 @@ import { RequestCache } from '../request-cache.service';
 export class CacheInterceptor implements HttpInterceptor {
   constructor(private cache: RequestCache) {}
 
-  intercept(req: HttpRequest<any>, next: HttpHandler) {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     // continue if not cachable.
     if (!isCachable(req)) {
       return next.handle(req);


### PR DESCRIPTION
Related to: https://github.com/fabric8-ui/fabric8-ui/pull/3285#issuecomment-420281716

The cache interceptor wasn't returning the correct observable.
Observed the Recent Workspaces widget was stuck on loading even though the network request went through.

I was able to reproduce this in dev environment and with the fix, the widget loaded correctly.

![image](https://user-images.githubusercontent.com/14068621/45369985-37857000-b5b5-11e8-88fe-c817e4751eda.png)
