### PR TITLE
refactor(profile): use rxjs pipe instead of operator chaining

### DIFF
--- a/src/app/profile/cleanup/cleanup.component.spec.ts
+++ b/src/app/profile/cleanup/cleanup.component.spec.ts
@@ -6,11 +6,12 @@ import { Router } from '@angular/router';
 import { Logger } from 'ngx-base';
 import { Contexts, SpaceService, WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService, UserService } from 'ngx-login-client';
-import { Observable } from 'rxjs/Observable';
-
 import { EventService } from '../../shared/event.service';
 import { TenantService } from '../services/tenant.service';
 import { CleanupComponent } from './cleanup.component';
+
+import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 
 describe('CleanupComponent', () => {
@@ -41,7 +42,7 @@ describe('CleanupComponent', () => {
         version: 0
       }
     };
-    mockContexts.current = Observable.of({
+    mockContexts.current = of({
       'user': {
         'attributes': {
           'username': 'mock-username'
@@ -50,7 +51,7 @@ describe('CleanupComponent', () => {
       }
     });
     mockEventService.deleteSpaceSubject = jasmine.createSpyObj('deleteSpaceSubject', ['next']);
-    mockSpaceService.getSpacesByUser.and.returnValue(Observable.of([mockSpace]));
+    mockSpaceService.getSpacesByUser.and.returnValue(of([mockSpace]));
 
     TestBed.configureTestingModule({
       imports: [FormsModule],
@@ -84,9 +85,9 @@ describe('CleanupComponent', () => {
   describe('#confirm', () => {
     it('should show a success message if spaces were erased successfully', () => {
       component.spaces = [mockSpace];
-      component.spaceService.deleteSpace.and.returnValue(Observable.of(mockSpace));
-      component.tenantService.cleanupTenant.and.returnValue(Observable.of('mock-response'));
-      component.tenantService.updateTenant.and.returnValue(Observable.of('mock-response'));
+      component.spaceService.deleteSpace.and.returnValue(of(mockSpace));
+      component.tenantService.cleanupTenant.and.returnValue(of('mock-response'));
+      component.tenantService.updateTenant.and.returnValue(of('mock-response'));
       spyOn(component, 'showSuccessNotification');
       component.confirm();
       expect(mockEventService.deleteSpaceSubject.next).toHaveBeenCalled();
@@ -97,9 +98,9 @@ describe('CleanupComponent', () => {
 
     it('should call deleteSpace with skipCluster set to true', () => {
       component.spaces = [mockSpace];
-      component.spaceService.deleteSpace.and.returnValue(Observable.of(mockSpace));
-      component.tenantService.cleanupTenant.and.returnValue(Observable.of('mock-response'));
-      component.tenantService.updateTenant.and.returnValue(Observable.of('mock-response'));
+      component.spaceService.deleteSpace.and.returnValue(of(mockSpace));
+      component.tenantService.cleanupTenant.and.returnValue(of('mock-response'));
+      component.tenantService.updateTenant.and.returnValue(of('mock-response'));
       spyOn(component, 'showSuccessNotification');
       component.confirm();
       expect(mockEventService.deleteSpaceSubject.next).toHaveBeenCalled();
@@ -113,8 +114,8 @@ describe('CleanupComponent', () => {
     it('should show a notification if a space is unable to be erased', () => {
       component.spaces = [mockSpace];
       component.spaceService.deleteSpace.and.returnValue(Observable.throw('error'));
-      component.tenantService.cleanupTenant.and.returnValue(Observable.of('mock-response'));
-      component.tenantService.updateTenant.and.returnValue(Observable.of('mock-response'));
+      component.tenantService.cleanupTenant.and.returnValue(of('mock-response'));
+      component.tenantService.updateTenant.and.returnValue(of('mock-response'));
       spyOn(component, 'showWarningNotification');
       component.confirm();
       expect(mockSpace['erased']).toBeFalsy();
@@ -133,9 +134,9 @@ describe('CleanupComponent', () => {
 
     it('should show a successful notification if tenant update & reset worked', () => {
       component.spaces = [mockSpace];
-      component.spaceService.deleteSpace.and.returnValue(Observable.of(mockSpace));
-      component.tenantService.cleanupTenant.and.returnValue(Observable.of('mock-response'));
-      component.tenantService.updateTenant.and.returnValue(Observable.of('mock-response'));
+      component.spaceService.deleteSpace.and.returnValue(of(mockSpace));
+      component.tenantService.cleanupTenant.and.returnValue(of('mock-response'));
+      component.tenantService.updateTenant.and.returnValue(of('mock-response'));
       spyOn(component, 'showSuccessNotification');
       component.confirm();
       expect(component.showSuccessNotification).toHaveBeenCalled();
@@ -143,7 +144,7 @@ describe('CleanupComponent', () => {
     });
 
     it('should show a warning notification if tenant update failed', () => {
-      component.tenantService.cleanupTenant.and.returnValue(Observable.of('mock-response'));
+      component.tenantService.cleanupTenant.and.returnValue(of('mock-response'));
       component.tenantService.updateTenant.and.returnValue(Observable.throw('error'));
       spyOn(component, 'showWarningNotification');
       component.confirm();
@@ -152,7 +153,7 @@ describe('CleanupComponent', () => {
     });
 
     it('should show a warning notification if the fork joined observable results in an error', () => {
-      component.tenantService.cleanupTenant.and.returnValue(Observable.of('mock-response'));
+      component.tenantService.cleanupTenant.and.returnValue(of('mock-response'));
       spyOn(Observable, 'forkJoin').and.returnValue(Observable.throw('error'));
       spyOn(component, 'showWarningNotification');
       component.tenantCleanError = true;

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.spec.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { Observable } from 'rxjs';
 
 import { createMock } from 'testing/mock';
 import {
@@ -23,6 +22,9 @@ import { Space, SpaceService } from 'ngx-fabric8-wit';
 import { InfiniteScrollModule } from 'ngx-widgets';
 
 import { MySpacesSearchSpacesDialog, ViewState } from './my-spaces-search-spaces-dialog.component';
+
+import { Observable } from 'rxjs';
+import { first } from 'rxjs/operators';
 
 @Component({
   template: '<my-spaces-search-spaces-dialog></my-spaces-search-spaces-dialog>'
@@ -108,12 +110,12 @@ describe('MySpacesSearchSpacesDialog', () => {
         .subscribe((spaces: Space[]): void => {
           expect(spaces).toEqual([{ name: 'foo-space' } as Space]);
           this.testedDirective.clear();
-          this.testedDirective.spaces
-            .first()
-            .subscribe((spaces: Space[]): void => {
-              expect(spaces).toEqual([]);
-              done();
-            });
+          this.testedDirective.spaces.pipe(
+            first()
+          ).subscribe((spaces: Space[]): void => {
+            expect(spaces).toEqual([]);
+            done();
+          });
         });
     });
 
@@ -123,12 +125,12 @@ describe('MySpacesSearchSpacesDialog', () => {
         .subscribe((count: number): void => {
           expect(count).toEqual(1);
           this.testedDirective.clear();
-          this.testedDirective.totalCount
-            .first()
-            .subscribe((count: number): void => {
-              expect(count).toEqual(0);
-              done();
-            });
+          this.testedDirective.totalCount.pipe(
+            first()
+          ).subscribe((count: number): void => {
+            expect(count).toEqual(0);
+            done();
+          });
         });
     });
 
@@ -138,12 +140,12 @@ describe('MySpacesSearchSpacesDialog', () => {
         .subscribe((state: ViewState): void => {
           expect(state).toEqual(ViewState.SHOW);
           this.testedDirective.clear();
-          this.testedDirective.viewState
-            .first()
-            .subscribe((state: ViewState): void => {
-              expect(state).toEqual(ViewState.INIT);
-              done();
-            });
+          this.testedDirective.viewState.pipe(
+            first()
+          ).subscribe((state: ViewState): void => {
+            expect(state).toEqual(ViewState.INIT);
+            done();
+          });
         });
     });
 
@@ -170,21 +172,21 @@ describe('MySpacesSearchSpacesDialog', () => {
       this.testedDirective.initItems({ pageSize });
       this.testedDirective.search();
       tick();
-      this.testedDirective.spaces
-        .first()
-        .subscribe(() => {
-          expect(spaceService.search).toHaveBeenCalledWith(jasmine.any(String), pageSize);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe(() => {
+        expect(spaceService.search).toHaveBeenCalledWith(jasmine.any(String), pageSize);
+      });
     }));
 
     it('should set view state to LOADING', fakeAsync(function(this: TestingContext): void {
       this.testedDirective.initItems({ pageSize: 10 });
       tick();
-      this.testedDirective.viewState
-        .first()
-        .subscribe((state: ViewState): void => {
-          expect(state).toEqual(ViewState.LOADING);
-        });
+      this.testedDirective.viewState.pipe(
+        first()
+      ).subscribe((state: ViewState): void => {
+        expect(state).toEqual(ViewState.LOADING);
+      });
     }));
   });
 
@@ -222,61 +224,61 @@ describe('MySpacesSearchSpacesDialog', () => {
       tick();
       expect(spaceService.getTotalCount).toHaveBeenCalled();
 
-      this.testedDirective.totalCount
-        .first()
-        .subscribe((count: number): void => {
-          expect(count).toBe(456);
-        });
+      this.testedDirective.totalCount.pipe(
+        first()
+      ).subscribe((count: number): void => {
+        expect(count).toBe(456);
+      });
     }));
 
     it('should set view state to SHOW when results are received', fakeAsync(function(this: TestingContext): void {
-      this.testedDirective.viewState
-        .first()
-        .subscribe((state: ViewState): void => {
-          expect(state).toEqual(ViewState.INIT);
-        });
+      this.testedDirective.viewState.pipe(
+        first()
+      ).subscribe((state: ViewState): void => {
+        expect(state).toEqual(ViewState.INIT);
+      });
       this.testedDirective.search();
       this.testedDirective.initItems({ pageSize: 123 });
       tick();
-      this.testedDirective.viewState
-        .first()
-        .subscribe((state: ViewState): void => {
-          expect(state).toEqual(ViewState.SHOW);
-        });
+      this.testedDirective.viewState.pipe(
+        first()
+      ).subscribe((state: ViewState): void => {
+        expect(state).toEqual(ViewState.SHOW);
+      });
     }));
 
     it('should set view state to EMPTY when no results are received', fakeAsync(function(this: TestingContext): void {
       const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       spaceService.search.and.returnValue(Observable.of([]));
-      this.testedDirective.viewState
-        .first()
-        .subscribe((state: ViewState): void => {
-          expect(state).toEqual(ViewState.INIT);
-        });
+      this.testedDirective.viewState.pipe(
+        first()
+      ).subscribe((state: ViewState): void => {
+        expect(state).toEqual(ViewState.INIT);
+      });
       this.testedDirective.search();
       this.testedDirective.initItems({ pageSize: 123 });
       tick();
-      this.testedDirective.viewState
-        .first()
-        .subscribe((state: ViewState): void => {
-          expect(state).toEqual(ViewState.EMPTY);
-        });
+      this.testedDirective.viewState.pipe(
+        first()
+      ).subscribe((state: ViewState): void => {
+        expect(state).toEqual(ViewState.EMPTY);
+      });
     }));
 
     it('should update spaces with received results', fakeAsync(function(this: TestingContext): void {
-      this.testedDirective.spaces
-        .first()
-        .subscribe((spaces: Space[]): void => {
-          expect(spaces).toEqual([]);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe((spaces: Space[]): void => {
+        expect(spaces).toEqual([]);
+      });
       this.testedDirective.search();
       this.testedDirective.initItems({ pageSize: 123 });
       tick();
-      this.testedDirective.spaces
-        .first()
-        .subscribe((spaces: Space[]): void => {
-          expect(spaces).toEqual([ { name: 'foo-space' } as Space ]);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe((spaces: Space[]): void => {
+        expect(spaces).toEqual([ { name: 'foo-space' } as Space ]);
+      });
     }));
   });
 
@@ -285,34 +287,34 @@ describe('MySpacesSearchSpacesDialog', () => {
       const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       spaceService.getMoreSearchResults.and.returnValue(Observable.of([ { name: 'more-space' } ]));
 
-      this.testedDirective.spaces
-        .first()
-        .subscribe((spaces: Space[]): void => {
-          expect(spaces).toEqual([]);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe((spaces: Space[]): void => {
+        expect(spaces).toEqual([]);
+      });
       this.testedDirective.fetchMoreSpaces();
-      this.testedDirective.spaces
-        .first()
-        .subscribe((spaces: Space[]): void => {
-          expect(spaces).toEqual([ { name: 'more-space' } as Space ]);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe((spaces: Space[]): void => {
+        expect(spaces).toEqual([ { name: 'more-space' } as Space ]);
+      });
     });
 
     it('should silently fail if no more spaces are found', function(this: TestingContext): void {
       const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       spaceService.getMoreSearchResults.and.returnValue(Observable.throw('No more spaces found'));
 
-      this.testedDirective.spaces
-        .first()
-        .subscribe((spaces: Space[]): void => {
-          expect(spaces).toEqual([]);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe((spaces: Space[]): void => {
+        expect(spaces).toEqual([]);
+      });
       this.testedDirective.fetchMoreSpaces();
-      this.testedDirective.spaces
-        .first()
-        .subscribe((spaces: Space[]): void => {
-          expect(spaces).toEqual([]);
-        });
+      this.testedDirective.spaces.pipe(
+        first()
+      ).subscribe((spaces: Space[]): void => {
+        expect(spaces).toEqual([]);
+      });
     });
   });
 });

--- a/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-search-dialog/my-spaces-search-spaces-dialog.component.ts
@@ -8,10 +8,11 @@ import {
 
 import {
   BehaviorSubject,
-  Observable,
   Subject,
   Subscription
 } from 'rxjs';
+import { combineLatest } from 'rxjs/observable/combineLatest';
+import { filter, first, flatMap, map, tap } from 'rxjs/operators';
 
 import { flatten } from 'lodash';
 import { ModalDirective } from 'ngx-bootstrap/modal';
@@ -19,6 +20,7 @@ import {
   Space,
   SpaceService
 } from 'ngx-fabric8-wit';
+
 
 export enum ViewState {
   INIT = 'INIT',
@@ -95,33 +97,33 @@ export class MySpacesSearchSpacesDialog implements OnDestroy, OnInit {
       return;
     }
     this.viewState.next(ViewState.PRESHOW);
-    this.viewState
-      .filter((viewState: ViewState): boolean => viewState === ViewState.LOADING)
-      .first()
-      .flatMap(() => this.spaceService.search(this.searchTerm.trim(), this.pageSize).first())
-      .first()
-      .do(() => (this.searchField.nativeElement as HTMLElement).blur())
-      .do(() => this.spaceService.getTotalCount().first().subscribe((count: number): void => this.totalCount.next(count)))
-      .do((spaces: Space[]) => this.viewState.next(spaces.length === 0 ? ViewState.EMPTY : ViewState.SHOW))
-      .subscribe(
-        (spaces: Space[]): void => this.spaces.next(spaces),
-        (err: any): void => console.error(err)
-      );
+    this.viewState.pipe(
+      filter((viewState: ViewState): boolean => viewState === ViewState.LOADING),
+      first(),
+      flatMap(() => this.spaceService.search(this.searchTerm.trim(), this.pageSize).first()),
+      first(),
+      tap(() => (this.searchField.nativeElement as HTMLElement).blur()),
+      tap(() => this.spaceService.getTotalCount().first().subscribe((count: number): void => this.totalCount.next(count))),
+      tap((spaces: Space[]) => this.viewState.next(spaces.length === 0 ? ViewState.EMPTY : ViewState.SHOW))
+    ).subscribe(
+      (spaces: Space[]): void => this.spaces.next(spaces),
+      (err: any): void => console.error(err)
+    );
   }
 
   fetchMoreSpaces(): void {
-    Observable.combineLatest(
+    combineLatest(
       this.spaces,
       this.spaceService.getMoreSearchResults()
-    )
-      .first()
-      .map(flatten)
-      .subscribe(
-        (spaces: Space[]): void => this.spaces.next(spaces),
-        (err: any): void => {
-          if (err !== 'No more spaces found') {
-            console.error(err);
-          }
-        });
+    ).pipe(
+      first(),
+      map(flatten)
+    ).subscribe(
+      (spaces: Space[]): void => this.spaces.next(spaces),
+      (err: any): void => {
+        if (err !== 'No more spaces found') {
+          console.error(err);
+        }
+    });
   }
 }

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -9,6 +9,7 @@ import { Context, Contexts, Space, SpaceService } from 'ngx-fabric8-wit';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import { Action } from 'patternfly-ng/action';
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { spaceMock } from '../../shared/context.service.mock';
@@ -97,11 +98,11 @@ describe('MySpacesComponent', () => {
     spaceMock2 = cloneDeep(spaceMock);
     spaceMock2.id = '2';
     spaceMock2.attributes.name = 'spaceMock2-name';
-    mockContexts.current = Observable.of(mockContext);
-    mockUserService.loggedInUser = Observable.of(mockUser);
+    mockContexts.current = of(mockContext);
+    mockUserService.loggedInUser = of(mockUser);
     mockGettingStartedService.createTransientProfile.and.returnValue(mockExtProfile);
-    mockGettingStartedService.update.and.returnValue(Observable.of({}));
-    mockSpaceService.getSpacesByUser.and.returnValue(Observable.of([spaceMock1, spaceMock2])); // called by ngOnInit() to initialize allSpaces
+    mockGettingStartedService.update.and.returnValue(of({}));
+    mockSpaceService.getSpacesByUser.and.returnValue(of([spaceMock1, spaceMock2])); // called by ngOnInit() to initialize allSpaces
 
     TestBed.configureTestingModule({
       imports: [FormsModule],
@@ -312,7 +313,7 @@ describe('MySpacesComponent', () => {
 
   describe('#removeSpace', () => {
     it('should delegate to spaceService.deleteSpace for deletion', () => {
-      spyOn(component.spaceService, 'deleteSpace').and.returnValue(Observable.of(spaceMock1));
+      spyOn(component.spaceService, 'deleteSpace').and.returnValue(of(spaceMock1));
       component.modalRef = mockModalRef;
       component.spaceToDelete = spaceMock1;
       component.ngOnInit();
@@ -321,7 +322,7 @@ describe('MySpacesComponent', () => {
     });
 
     it('should remove the selected space out of allSpaces', () => {
-      spyOn(component.spaceService, 'deleteSpace').and.returnValue(Observable.of(spaceMock1));
+      spyOn(component.spaceService, 'deleteSpace').and.returnValue(of(spaceMock1));
       spyOn(component, 'savePins').and.callThrough();
       component.modalRef = mockModalRef;
       component.spaceToDelete = spaceMock1;
@@ -532,7 +533,7 @@ describe('MySpacesComponent', () => {
         }
       };
       component.pageName = 'myspaces';
-      mockGettingStartedService.update.and.returnValue(Observable.of(mockContext.user.attributes));
+      mockGettingStartedService.update.and.returnValue(of(mockContext.user.attributes));
       component.ngOnInit();
       component.savePins();
       expect(mockExtProfile.contextInformation.pins['myspaces']).toEqual([spaceMock1.id]);

--- a/src/app/profile/overview/overview.component.spec.ts
+++ b/src/app/profile/overview/overview.component.spec.ts
@@ -8,7 +8,7 @@ import { Notifications } from 'ngx-base/src/app/notifications/notifications';
 import { Contexts } from 'ngx-fabric8-wit';
 import { SpaceService } from 'ngx-fabric8-wit';
 import { UserService } from 'ngx-login-client';
-import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 import { ContextService } from '../../shared/context.service';
 import { OverviewComponent } from './overview.component';
@@ -63,13 +63,13 @@ describe('OverviewComponent', () => {
   };
 
   beforeEach(() => {
-    mockBroadcaster.on.and.returnValue(Observable.of(mockContext));
-    mockContexts.current = Observable.of(mockContext);
-    mockRouter.events = Observable.of(mockRouterEvent);
+    mockBroadcaster.on.and.returnValue(of(mockContext));
+    mockContexts.current = of(mockContext);
+    mockRouter.events = of(mockRouterEvent);
     mockRouter.createUrlTree.and.returnValue({});
-    mockUserService.loggedInUser = Observable.of(mockContext.user);
-    mockUserService.currentLoggedInUser = Observable.of(mockContext.user);
-    mockSpaceService.getSpacesByUser.and.returnValue(Observable.of([mockSpace]));
+    mockUserService.loggedInUser = of(mockContext.user);
+    mockUserService.currentLoggedInUser = of(mockContext.user);
+    mockSpaceService.getSpacesByUser.and.returnValue(of([mockSpace]));
 
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/profile/overview/spaces/overview-spaces.component.spec.ts
+++ b/src/app/profile/overview/spaces/overview-spaces.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Broadcaster, Logger } from 'ngx-base';
 import { Contexts, Fabric8WitModule, SpaceService, WIT_API_URL } from 'ngx-fabric8-wit';
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 import { createMock } from 'testing/mock';
 import { SpacesComponent } from './overview-spaces.component';
@@ -19,7 +20,7 @@ describe('SpacesComponent', () => {
   let mockContext: any;
 
   beforeEach(() => {
-    mockBroadcaster.on.and.returnValue(Observable.of({}));
+    mockBroadcaster.on.and.returnValue(of({}));
     mockContext = {
       'user': {
         'attributes': {
@@ -28,7 +29,7 @@ describe('SpacesComponent', () => {
         'id': 'mock-user'
       }
     };
-    mockContexts.current = Observable.of(mockContext);
+    mockContexts.current = of(mockContext);
 
     TestBed.configureTestingModule({
       imports: [
@@ -57,7 +58,7 @@ describe('SpacesComponent', () => {
 
     it('should use spaceService.getSpacesByUser to set the initial spaces', () => {
       component.context = mockContext;
-      component.spaceService.getSpacesByUser.and.returnValue(Observable.of('mock-spaces'));
+      component.spaceService.getSpacesByUser.and.returnValue(of('mock-spaces'));
       component.initSpaces();
       expect(component.spaces).toBe('mock-spaces');
     });
@@ -72,7 +73,7 @@ describe('SpacesComponent', () => {
   describe('#fetchMoreSpaces', () => {
     it('should retrieve more spaces and add them to the current list', () => {
       component.context = mockContext;
-      component.spaceService.getMoreSpacesByUser.and.returnValue(Observable.of(['more-spaces']));
+      component.spaceService.getMoreSpacesByUser.and.returnValue(of(['more-spaces']));
       component.fetchMoreSpaces();
       expect(component.spaces).toContain('more-spaces');
     });

--- a/src/app/profile/overview/work-items/work-items.component.spec.ts
+++ b/src/app/profile/overview/work-items/work-items.component.spec.ts
@@ -3,6 +3,7 @@ import { By } from '@angular/platform-browser';
 
 import { List, take } from 'lodash';
 import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 import { FilterService, WorkItemService } from 'fabric8-planner';
 
@@ -65,13 +66,13 @@ describe('WorkItemsComponent', () => {
     providers: [
       { provide: Contexts, useFactory: () => {
           let mockContexts: any = createMock(Contexts);
-          mockContexts.current = Observable.of(mockContext) as Observable<Context>;
+          mockContexts.current = of(mockContext) as Observable<Context>;
           return mockContexts;
         }
       },
       { provide: Spaces, useFactory: () => {
           let mockSpacesService: any = createMock(Spaces);
-          mockSpacesService.recent = Observable.of(mockRecentSpaces) as Observable<Space[]>;
+          mockSpacesService.recent = of(mockRecentSpaces) as Observable<Space[]>;
           return mockSpacesService;
         }
       },
@@ -83,14 +84,14 @@ describe('WorkItemsComponent', () => {
       },
       { provide: SpaceService, useFactory: () => {
           let mockSpaceService: jasmine.SpyObj<SpaceService> = createMock(SpaceService);
-          mockSpaceService.getSpacesByUser.and.returnValue(Observable.of(mockSpaces) as Observable<Space[]>);
+          mockSpaceService.getSpacesByUser.and.returnValue(of(mockSpaces) as Observable<Space[]>);
           return mockSpaceService;
         }
       },
       { provide: WorkItemService, useFactory: () => {
           let mockWorkItemService: jasmine.SpyObj<WorkItemService> = createMock(WorkItemService);
-          mockWorkItemService.getWorkItems.and.returnValue(Observable.of({ workItems: [] }) as Observable<WorkItemsData>);
-          mockWorkItemService.buildUserIdMap.and.returnValue(Observable.of(mockContext.user) as Observable<User>);
+          mockWorkItemService.getWorkItems.and.returnValue(of({ workItems: [] }) as Observable<WorkItemsData>);
+          mockWorkItemService.buildUserIdMap.and.returnValue(of(mockContext.user) as Observable<User>);
           return mockWorkItemService;
         }
       },

--- a/src/app/profile/overview/work-items/work-items.component.ts
+++ b/src/app/profile/overview/work-items/work-items.component.ts
@@ -6,6 +6,7 @@ import { FilterService, WorkItem, WorkItemService } from 'fabric8-planner';
 import { Context, Contexts } from 'ngx-fabric8-wit';
 import { Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
 import { Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ContextService } from '../../../shared/context.service';
 
 import { filterOutClosedItems, WorkItemsData } from '../../../shared/workitem-utils';
@@ -102,10 +103,11 @@ export class WorkItemsComponent implements OnDestroy, OnInit {
     this.subscriptions.push(
       this.workItemService
         .getWorkItems(100000, {expression: filters})
-        .map((val: WorkItemsData) => val.workItems)
-        .map(workItems => filterOutClosedItems(workItems))
+        .pipe(
+          map((val: WorkItemsData) => val.workItems),
+          map(workItems => filterOutClosedItems(workItems))
         // Resolve the work item type, creator and area
-        .subscribe(workItems => {
+        ).subscribe(workItems => {
           this.workItems = workItems;
         })
     );

--- a/src/app/profile/services/tenant.service.ts
+++ b/src/app/profile/services/tenant.service.ts
@@ -5,6 +5,7 @@ import { Logger } from 'ngx-base';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { Observable } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 @Injectable()
 export class TenantService {
@@ -31,9 +32,11 @@ export class TenantService {
     let url = `${this.userUrl}/services`;
     return this.http
       .patch(url, null, { headers: this.headers, observe: 'response', responseType: 'text' })
-      .catch((error: HttpErrorResponse) => {
-        return this.handleError(error);
-      });
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          return this.handleError(error);
+        })
+      );
   }
 
   /**
@@ -44,10 +47,12 @@ export class TenantService {
     let url = `${this.userUrl}/services`;
     return this.http
       .delete(url, { headers: this.headers, responseType: 'text' })
-      .catch((error: HttpErrorResponse) => {
-        return this.handleError(error);
-      })
-      .map(() => null);
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          return this.handleError(error);
+        }),
+        map(() => null)
+      );
   }
 
   // Private

--- a/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
@@ -3,7 +3,8 @@ import { Component } from '@angular/core';
 import { Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { UserService } from 'ngx-login-client';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 import { initContext, TestContext } from '../../../../testing/test-context';
 import { ProviderService } from '../../../shared/account/provider.service';
@@ -36,13 +37,13 @@ describe('Connected Accounts Component', () => {
 
     beforeAll(() => {
       authMock.gitHubToken = Observable.empty();
-      //authMock.openShiftToken = Observable.of('oso-token');
-      authMock.isOpenShiftConnected.and.returnValue(Observable.of(true));
-      contextsMock.current = Observable.of(ctx);
+      //authMock.openShiftToken = of('oso-token');
+      authMock.isOpenShiftConnected.and.returnValue(of(true));
+      contextsMock.current = of(ctx);
       userServiceMock.loggedInUser = Observable.empty();
       userServiceMock.currentLoggedInUser = ctx.user;
       providersMock.getGitHubStatus.and.returnValue(Observable.throw('failure'));
-      providersMock.getOpenShiftStatus.and.returnValue(Observable.of({'username': expectedOsoUser}));
+      providersMock.getOpenShiftStatus.and.returnValue(of({'username': expectedOsoUser}));
     });
 
     initContext(ConnectedAccountsComponent, SampleTestComponent,  {
@@ -72,14 +73,14 @@ describe('Connected Accounts Component', () => {
     let userServiceMock: any = jasmine.createSpy('UserService');
 
     beforeAll(() => {
-      authMock.gitHubToken = Observable.of('gh-test-user');
-      //authMock.openShiftToken = Observable.of('oso-token');
-      authMock.isOpenShiftConnected.and.returnValue(Observable.of(true));
-      contextsMock.current = Observable.of(ctx);
+      authMock.gitHubToken = of('gh-test-user');
+      //authMock.openShiftToken = of('oso-token');
+      authMock.isOpenShiftConnected.and.returnValue(of(true));
+      contextsMock.current = of(ctx);
       userServiceMock.loggedInUser = Observable.empty();
       userServiceMock.currentLoggedInUser = ctx.user;
-      providersMock.getGitHubStatus.and.returnValue(Observable.of({'username': 'username'}));
-      providersMock.getOpenShiftStatus.and.returnValue(Observable.of({'username': expectedOsoUser}));
+      providersMock.getGitHubStatus.and.returnValue(of({'username': 'username'}));
+      providersMock.getOpenShiftStatus.and.returnValue(of({'username': expectedOsoUser}));
     });
 
     initContext(ConnectedAccountsComponent, SampleTestComponent,  {

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.spec.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.spec.ts
@@ -7,7 +7,7 @@ import { Notifications, NotificationType } from 'ngx-base';
 import { Feature, FeatureTogglesService } from 'ngx-feature-flag';
 import { UserService } from 'ngx-login-client';
 import { ListModule } from 'patternfly-ng';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 import { createMock } from 'testing/mock';
 import { initContext, TestContext } from 'testing/test-context';
 import { FeatureAcknowledgementService } from '../../../feature-flag/service/feature-acknowledgement.service';
@@ -41,8 +41,8 @@ describe('FeatureOptInComponent', () => {
         emailVerified: true
       }
     };
-    toggleServiceMock.getAllFeaturesEnabledByLevel.and.returnValue(Observable.of([]));
-    toggleAckServiceMock.getToggle.and.returnValue(Observable.of(true));
+    toggleServiceMock.getAllFeaturesEnabledByLevel.and.returnValue(of([]));
+    toggleAckServiceMock.getToggle.and.returnValue(of(true));
   });
 
   initContext(FeatureOptInComponent, HostComponent, {
@@ -56,12 +56,12 @@ describe('FeatureOptInComponent', () => {
       { provide: GettingStartedService, useFactory: (): jasmine.SpyObj<GettingStartedService> => {
         const mock: jasmine.SpyObj<GettingStartedService> = createMock(GettingStartedService);
         mock.createTransientProfile.and.returnValue({ featureLevel: 'beta' } as ExtProfile);
-        mock.update.and.returnValue(Observable.of({}));
+        mock.update.and.returnValue(of({}));
         return mock;
       }},
       { provide: Notifications, useFactory: (): jasmine.SpyObj<Notifications> => {
         const mock: jasmine.SpyObj<Notifications> = createMock(Notifications);
-        mock.message.and.returnValue(Observable.of({}));
+        mock.message.and.returnValue(of({}));
         return mock;
       }},
       { provide: UserService, useFactory: (): jasmine.SpyObj<UserService> => {
@@ -77,7 +77,7 @@ describe('FeatureOptInComponent', () => {
       }},
       { provide: FeatureTogglesService, useFactory: (): jasmine.SpyObj<FeatureTogglesService> => {
         const mock: jasmine.SpyObj<FeatureTogglesService> = createMock(FeatureTogglesService);
-        mock.getAllFeaturesEnabledByLevel.and.returnValue(Observable.of([]));
+        mock.getAllFeaturesEnabledByLevel.and.returnValue(of([]));
         return mock;
       }},
       { provide: FeatureAcknowledgementService, useFactory: () => toggleAckServiceMock }

--- a/src/app/profile/settings/services/resource.service.ts
+++ b/src/app/profile/settings/services/resource.service.ts
@@ -6,6 +6,7 @@ import { UserService } from 'ngx-login-client';
 import {
   Observable
 } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { ScaledMemoryStat } from '../../../space/create/deployments/models/scaled-memory-stat';
 import { DeploymentApiService, EnvironmentStat } from '../../../space/create/deployments/services/deployment-api.service';
@@ -33,7 +34,9 @@ export class ResourceService {
 
   public getEnvironmentsWithScaleAndIcon(): Observable<UsageSeverityEnvironmentStat[]> {
     let envResponse: Observable<EnvironmentStat[]> = this.apiService.getEnvironments(FAKE_SPACE_ID);
-    return envResponse.map((stats: EnvironmentStat[]) => this.transformAndSortEnvironments(stats));
+    return envResponse.pipe(
+      map((stats: EnvironmentStat[]) => this.transformAndSortEnvironments(stats))
+    );
   }
 
   transformAndSortEnvironments(stats: EnvironmentStat[]): UsageSeverityEnvironmentStat[] {

--- a/src/app/profile/spaces/spaces.component.spec.ts
+++ b/src/app/profile/spaces/spaces.component.spec.ts
@@ -9,6 +9,7 @@ import { FeatureTogglesService } from 'ngx-feature-flag';
 import { AuthenticationService } from 'ngx-login-client';
 import { Subject } from 'rxjs';
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 import { EventService } from '../../shared/event.service';
 import { SpacesComponent } from './spaces.component';
@@ -31,7 +32,7 @@ describe('SpacesComponent', () => {
   let mockEvent = jasmine.createSpy('Event');
 
   mockAuthenticationService.getGitHubToken = {};
-  mockContexts.current = Observable.of({
+  mockContexts.current = of({
     'user': {
       'attributes': {
         'username': 'mock-username'
@@ -68,7 +69,7 @@ describe('SpacesComponent', () => {
 
   describe('#initSpaces', () => {
     it('should use spaceService.getSpacesByUser to set the initial spaces', () => {
-      spyOn(component.spaceService, 'getSpacesByUser').and.returnValue(Observable.of('mock-spaces'));
+      spyOn(component.spaceService, 'getSpacesByUser').and.returnValue(of('mock-spaces'));
       component.initSpaces(mockEvent);
       expect(component._spaces).toBe('mock-spaces');
     });
@@ -82,7 +83,7 @@ describe('SpacesComponent', () => {
 
   describe('#fetchMoreSpaces', () => {
     it('should retrieve more spaces and add them to the current list', () => {
-      spyOn(component.spaceService, 'getMoreSpacesByUser').and.returnValue(Observable.of('more-spaces'));
+      spyOn(component.spaceService, 'getMoreSpacesByUser').and.returnValue(of('more-spaces'));
       component.fetchMoreSpaces(mockEvent);
       expect(component._spaces).toContain('more-spaces');
     });
@@ -103,7 +104,7 @@ describe('SpacesComponent', () => {
   describe('#removeSpace', () => {
     it('should remove the space if the conditions are met', () => {
       let mockSpaces = ['mock-space1', 'mock-space2'];
-      let mockSpacesObservable = Observable.of(mockSpaces);
+      let mockSpacesObservable = of(mockSpaces);
       component.spaceToDelete = 'mock-space1'; // want to remove mock-space1 from _spaces
       component.modalRef = mockModalRef;
 
@@ -151,7 +152,7 @@ describe('SpacesComponent', () => {
   describe('#spaces', () => {
     it('should return the contents of _space', () => {
       let mockSpace = ['mock-space1', 'mock-space2'];
-      spyOn(component.spaceService, 'getSpacesByUser').and.returnValue(Observable.of(mockSpace));
+      spyOn(component.spaceService, 'getSpacesByUser').and.returnValue(of(mockSpace));
       component.initSpaces(mockSpace);
       let result = component.spaces;
       expect(result).toBe(mockSpace);

--- a/src/app/profile/tenant/tenant.component.spec.ts
+++ b/src/app/profile/tenant/tenant.component.spec.ts
@@ -9,6 +9,7 @@ import { Notifications } from 'ngx-base/src/app/notifications/notifications';
 import { Contexts, WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 import { GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { ProviderService } from '../../shared/account/provider.service';
@@ -31,8 +32,8 @@ describe('TenantComponent', () => {
   let mockProviderService: any = jasmine.createSpy('ProviderService');
   let mockGitHubService: any = jasmine.createSpy('GitHubService');
 
-  mockAuthenticationService.gitHubToken = Observable.of('gh-test-user');
-  mockContexts.current = Observable.of({
+  mockAuthenticationService.gitHubToken = of('gh-test-user');
+  mockContexts.current = of({
     'user': {
       'attributes': {
         'username': 'foobar'
@@ -120,8 +121,8 @@ describe('TenantComponent', () => {
         type: NotificationType.SUCCESS
       };
       component.gettingStartedService.createTransientProfile.and.returnValue({});
-      component.gettingStartedService.update.and.returnValue(Observable.of({}));
-      component.tenantService.updateTenant.and.returnValue(Observable.of({}));
+      component.gettingStartedService.update.and.returnValue(of({}));
+      component.tenantService.updateTenant.and.returnValue(of({}));
       component.updateProfile();
       expect(component.notifications.message).toHaveBeenCalledWith(message);
     });
@@ -132,7 +133,7 @@ describe('TenantComponent', () => {
         type: NotificationType.DANGER
       };
       component.gettingStartedService.createTransientProfile.and.returnValue({});
-      component.gettingStartedService.update.and.returnValue(Observable.of({}));
+      component.gettingStartedService.update.and.returnValue(of({}));
       component.tenantService.updateTenant.and.returnValue(Observable.throw('error'));
       component.updateProfile();
       expect(component.notifications.message).toHaveBeenCalledWith(message);

--- a/src/app/profile/update/update.component.spec.ts
+++ b/src/app/profile/update/update.component.spec.ts
@@ -9,6 +9,7 @@ import { Notifications } from 'ngx-base/src/app/notifications/notifications';
 import { Contexts, WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 import { GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { GitHubService } from '../../space/create/codebases/services/github.service';
@@ -33,8 +34,8 @@ describe('UpdateComponent', () => {
   let mockUserService: any = jasmine.createSpy('UserService');
   let mockLogger: any = jasmine.createSpy('Logger');
 
-  mockAuthenticationService.gitHubToken = Observable.of('gh-test-user');
-  mockContexts.current = Observable.of({
+  mockAuthenticationService.gitHubToken = of('gh-test-user');
+  mockContexts.current = of({
     'user': {
       'attributes': {
         'username': 'foobar'
@@ -112,7 +113,7 @@ describe('UpdateComponent', () => {
 
   describe('#linkImageUrl', () => {
     it('should properly link the avatar image if image exists', () => {
-      component.gitHubService.getUser.and.returnValue(Observable.of({
+      component.gitHubService.getUser.and.returnValue(of({
         'avatar_url': 'mock-image'
       }));
       component.linkGithubImageUrl();
@@ -124,7 +125,7 @@ describe('UpdateComponent', () => {
         message: 'No image found',
         type: NotificationType.INFO
       };
-      component.gitHubService.getUser.and.returnValue(Observable.of({}));
+      component.gitHubService.getUser.and.returnValue(of({}));
       component.linkGithubImageUrl();
       expect(component.notifications.message).toHaveBeenCalledWith(message);
     });
@@ -197,7 +198,7 @@ describe('UpdateComponent', () => {
       component.url = 'new-url';
       component.emailPrivate = false;
       component.gettingStartedService.createTransientProfile.and.returnValue(mockUser.attributes);
-      component.gettingStartedService.update.and.returnValue(Observable.of(mockUser));
+      component.gettingStartedService.update.and.returnValue(of(mockUser));
       component.updateProfile();
       expect(component.notifications.message).toHaveBeenCalledWith(message);
     });
@@ -231,7 +232,7 @@ describe('UpdateComponent', () => {
         'message': 'Profile updated!',
         type: NotificationType.SUCCESS
       };
-      component.tenantService.updateTenant.and.returnValue(Observable.of({ status: 200 }));
+      component.tenantService.updateTenant.and.returnValue(of({ status: 200 }));
       component.updateTenant();
       expect(component.updateTenantStatus).toBe(TenantUpdateStatus.Success);
       expect(component.notifications.message).toHaveBeenCalledWith(message);
@@ -242,7 +243,7 @@ describe('UpdateComponent', () => {
         'message': 'Error updating tenant',
         type: NotificationType.DANGER
       };
-      component.tenantService.updateTenant.and.returnValue(Observable.of({ status: 404 }));
+      component.tenantService.updateTenant.and.returnValue(of({ status: 404 }));
       component.updateTenant();
       expect(component.updateTenantStatus).toBe(TenantUpdateStatus.Failure);
       expect(component.notifications.message).toHaveBeenCalledWith(message);


### PR DESCRIPTION
- Use rxjs `pipe()` for chained operators.
- `Observable.of()` -> `of()`