### PR TITLE
fix(SpacesService): add catch to space service getSpaceById that prev…

### DIFF
--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -133,6 +133,22 @@ describe('SpacesService', () => {
         done();
       });
     });
+
+    it('should still return values if spaceService.getSpaceById throws an error', (done: DoneFn) => {
+      const broadcaster: jasmine.SpyObj<Broadcaster> = TestBed.get(Broadcaster);
+      broadcaster.on.and.returnValue(Observable.never());
+
+      const spaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
+      spaceService.getSpaceById.and.returnValue(Observable.throw('error'));
+      mockProfile.store.recentSpaces = [mockSpace];
+
+      const spacesService: SpacesService = TestBed.get(SpacesService);
+      let result: Observable<Space[]> = spacesService.recent;
+      result.subscribe((r: Space[]) => {
+        expect(r).toEqual([] as Space[]);
+        done();
+      });
+    });
   });
 
   describe('#saveRecent', () => {


### PR DESCRIPTION
…ents loadRecent from completing

This PR addresses an issue with the SpacesService, in which the list of recent spaces never populates as a result of an uncaught error in the `loadRecent()` method.

The SpacesService recently went under some refactoring [[0]](https://github.com/fabric8-ui/fabric8-ui/pull/3211), and among the changes was the addition of functionality to try and handle removed spaces [[1]](https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/shared/spaces.service.ts#L73). However, there can be instances where the `patch` request to update the recentspaces on the profile store is made, but not completed [[2]](https://github.com/fabric8-ui/fabric8-ui/pull/3211#discussion_r214985090), and as a result the user can end up in a state where the space they owned was deleted, but the space id was not removed from their profile store. This becomes problematic because the next time `loadRecent()` executes, it will not complete because of the call to the ngx-fabric8-wit space service `getSpaceById()` [[3]](https://github.com/fabric8-ui/ngx-fabric8-wit/blob/master/src/app/spaces/space.service.ts#L180). If the `getSpaceById()` does not exist, then an error is thrown and no space is returned. This becomes problematic because it causes the `forkJoin` to not complete, which populates the recent spaces.

The proposed fix here catches the error of `getSpaceById()` inside of the `forkJoin` and substitutes it with a temporary null value, which is promptly removed.

[0] https://github.com/fabric8-ui/fabric8-ui/pull/3211
[1] https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/shared/spaces.service.ts#L73
[2] https://github.com/fabric8-ui/fabric8-ui/pull/3211#discussion_r214985090
[3] https://github.com/fabric8-ui/ngx-fabric8-wit/blob/master/src/app/spaces/space.service.ts#L180
