### PR TITLE
Deployments RxJS syntax upgrade

### DIFF
--- a/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.spec.ts
@@ -10,10 +10,8 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import {
-  BehaviorSubject,
-  Observable
-} from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 import { Contexts } from 'ngx-fabric8-wit';
 import { createMock } from 'testing/mock';
@@ -53,7 +51,7 @@ describe('DeploymentCardContainer', () => {
       providers: [
         {
           provide: Contexts, useValue: {
-            current: Observable.of({
+            current: of({
               path: 'mock-path',
               user: {
                 attributes: {
@@ -75,7 +73,7 @@ describe('DeploymentCardContainer', () => {
     },
     (component: DeploymentCardContainerComponent) => {
       component.spaceId = 'space';
-      component.environments = Observable.of(environments);
+      component.environments = of(environments);
       component.applications = ['app'];
     });
 

--- a/src/app/space/create/deployments/apps/deployment-card-container.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card-container.component.ts
@@ -5,6 +5,8 @@ import {
 
 import { Contexts } from 'ngx-fabric8-wit';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators/map';
+import { mergeMap } from 'rxjs/operators/mergeMap';
 
 import { DeploymentsService } from '../services/deployments.service';
 
@@ -29,12 +31,12 @@ export class DeploymentCardContainerComponent {
   ) {}
 
   ngOnInit(): void {
-    this.spacePath = this.contexts.current.map(c => c.path);
-    this.username = this.contexts.current.map(c => c.user.attributes.username);
-    this.hasDeployments = this.environments.flatMap(
+    this.spacePath = this.contexts.current.pipe(map(c => c.path));
+    this.username = this.contexts.current.pipe(map(c => c.user.attributes.username));
+    this.hasDeployments = this.environments.pipe(mergeMap(
       (environments: string[]): Observable<boolean> =>
         this.deploymentsService.hasDeployments(this.spaceId, environments)
-    );
+    ));
     this.applications.forEach(app => {
       this.collapsed[app] = true;
     });

--- a/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.spec.ts
@@ -19,14 +19,15 @@ import {
   BsDropdownModule,
   BsDropdownToggleDirective
 } from 'ngx-bootstrap/dropdown';
-import { ModalDirective, ModalModule } from 'ngx-bootstrap/modal';
+import { ModalModule } from 'ngx-bootstrap/modal';
 
 import 'patternfly/dist/js/patternfly-settings.js';
 import {
   BehaviorSubject,
-  Observable,
   Subject
 } from 'rxjs';
+import { of } from 'rxjs/observable/of';
+
 import { createMock } from 'testing/mock';
 import {
   initContext,
@@ -76,13 +77,13 @@ describe('DeploymentCardComponent', () => {
         provide: DeploymentsService, useFactory: (): jasmine.SpyObj<DeploymentsService> => {
           const svc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
 
-          svc.getVersion.and.returnValue(Observable.of('1.2.3'));
-          svc.getDeploymentCpuStat.and.returnValue(Observable.of([{ used: 1, quota: 2, timestamp: 1 }] as CpuStat[]));
-          svc.getDeploymentMemoryStat.and.returnValue(Observable.of([{ used: 3, quota: 4, units: 'GB', timestamp: 1 }] as MemoryStat[]));
-          svc.getAppUrl.and.returnValue(Observable.of('mockAppUrl'));
-          svc.getConsoleUrl.and.returnValue(Observable.of('mockConsoleUrl'));
-          svc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
-          svc.deleteDeployment.and.returnValue(Observable.of('mockDeletedMessage'));
+          svc.getVersion.and.returnValue(of('1.2.3'));
+          svc.getDeploymentCpuStat.and.returnValue(of([{ used: 1, quota: 2, timestamp: 1 }] as CpuStat[]));
+          svc.getDeploymentMemoryStat.and.returnValue(of([{ used: 3, quota: 4, units: 'GB', timestamp: 1 }] as MemoryStat[]));
+          svc.getAppUrl.and.returnValue(of('mockAppUrl'));
+          svc.getConsoleUrl.and.returnValue(of('mockConsoleUrl'));
+          svc.getLogsUrl.and.returnValue(of('mockLogsUrl'));
+          svc.deleteDeployment.and.returnValue(of('mockDeletedMessage'));
           svc.isApplicationDeployedInEnvironment.and.returnValue(new BehaviorSubject<boolean>(true));
           svc.deleteDeployment.and.returnValue(new Subject<string>());
 
@@ -205,7 +206,7 @@ describe('DeploymentCardComponent', () => {
       }));
 
       it('should not display appUrl if none available', fakeAsync(function(this: Context) {
-        this.testedDirective.appUrl = Observable.of('');
+        this.testedDirective.appUrl = of('');
 
         this.fixture.detectChanges();
 

--- a/src/app/space/create/deployments/apps/deployment-card.component.ts
+++ b/src/app/space/create/deployments/apps/deployment-card.component.ts
@@ -10,7 +10,12 @@ import {
 
 import { debounce } from 'lodash';
 import { NotificationType } from 'ngx-base';
-import { Observable, Subscription } from 'rxjs';
+import {
+  Observable,
+  Subscription
+} from 'rxjs';
+import { finalize } from 'rxjs/operators/finalize';
+import { first } from 'rxjs/operators/first';
 
 import { NotificationsService } from '../../../../shared/notifications.service';
 import {
@@ -169,24 +174,24 @@ export class DeploymentCardComponent implements OnDestroy, OnInit {
         this.spaceId,
         this.environment,
         this.applicationId
-        )
-        .first()
-        .finally(() => this.deleting = false)
-        .subscribe(
-          (success: string) => {
-            this.notifications.message({
-              type: NotificationType.SUCCESS,
-              message: success
-            });
-            this.active = false;
-          },
-          (error: any) => {
-            this.notifications.message({
-              type: NotificationType.WARNING,
-              message: error
-            });
-          }
-        )
+      ).pipe(
+        first(),
+        finalize(() => this.deleting = false)
+      ).subscribe(
+        (success: string) => {
+          this.notifications.message({
+            type: NotificationType.SUCCESS,
+            message: success
+          });
+          this.active = false;
+        },
+        (error: any) => {
+          this.notifications.message({
+            type: NotificationType.WARNING,
+            message: error
+          });
+        }
+      )
     );
     this.lockAndDelete();
   }

--- a/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployment-details.component.spec.ts
@@ -11,9 +11,10 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
 import 'patternfly/dist/js/patternfly-settings.js';
 import {
   BehaviorSubject,
-  Observable,
   Subject
 } from 'rxjs';
+import { of } from 'rxjs/observable/of';
+
 import { createMock } from 'testing/mock';
 import {
   initContext,
@@ -137,13 +138,13 @@ describe('DeploymentDetailsComponent', () => {
       {
         provide: DeploymentsService, useFactory: (): jasmine.SpyObj<DeploymentsService> => {
           const svc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
-          svc.getVersion.and.returnValue(Observable.of('1.2.3'));
+          svc.getVersion.and.returnValue(of('1.2.3'));
           svc.getDeploymentCpuStat.and.returnValue(new BehaviorSubject([{ used: 1, quota: 2, timestamp: 1 }] as CpuStat[]));
           svc.getDeploymentMemoryStat.and.returnValue(new BehaviorSubject([{ used: 3, quota: 4, units: 'GB', timestamp: 1 }] as MemoryStat[]));
-          svc.getAppUrl.and.returnValue(Observable.of('mockAppUrl'));
-          svc.getConsoleUrl.and.returnValue(Observable.of('mockConsoleUrl'));
-          svc.getLogsUrl.and.returnValue(Observable.of('mockLogsUrl'));
-          svc.deleteDeployment.and.returnValue(Observable.of('mockDeletedMessage'));
+          svc.getAppUrl.and.returnValue(of('mockAppUrl'));
+          svc.getConsoleUrl.and.returnValue(of('mockConsoleUrl'));
+          svc.getLogsUrl.and.returnValue(of('mockLogsUrl'));
+          svc.deleteDeployment.and.returnValue(of('mockDeletedMessage'));
           svc.getDeploymentNetworkStat.and.returnValue(
             new BehaviorSubject([{
               sent: new ScaledNetStat(1 * Math.pow(1024, 2), 1),
@@ -162,8 +163,8 @@ describe('DeploymentDetailsComponent', () => {
         provide: DeploymentStatusService, useFactory: (): jasmine.SpyObj<DeploymentStatusService> => {
           const svc: jasmine.SpyObj<DeploymentStatusService> = createMock(DeploymentStatusService);
           svc.getDeploymentAggregateStatus.and.returnValue(new BehaviorSubject<Status>({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' }));
-          svc.getDeploymentCpuStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
-          svc.getDeploymentMemoryStatus.and.returnValue(Observable.of({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' }));
+          svc.getDeploymentCpuStatus.and.returnValue(of({ type: StatusType.OK, message: '' }));
+          svc.getDeploymentMemoryStatus.and.returnValue(of({ type: StatusType.WARN, message: 'Memory usage is nearing capacity.' }));
           return svc;
         }
       },

--- a/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.spec.ts
@@ -9,6 +9,8 @@ import { By } from '@angular/platform-browser';
 
 import { Broadcaster } from 'ngx-base';
 import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
+
 import {
   initContext,
   TestContext
@@ -37,8 +39,8 @@ describe('DeploymentsAppsComponent', () => {
 
   const environments: string[] = ['envId1', 'envId2'];
   const applications: string[] = ['first', 'second'];
-  const mockEnvironments: Observable<string[]> = Observable.of(environments);
-  const mockApplications: Observable<string[]> = Observable.of(applications);
+  const mockEnvironments: Observable<string[]> = of(environments);
+  const mockApplications: Observable<string[]> = of(applications);
 
   initContext(DeploymentsAppsComponent, HostComponent,
     {
@@ -49,8 +51,8 @@ describe('DeploymentsAppsComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     },
     (component: DeploymentsAppsComponent) => {
-      component.spaceId = Observable.of('spaceId');
-      component.spaceName = Observable.of('spaceName');
+      component.spaceId = of('spaceId');
+      component.spaceName = of('spaceName');
       component.environments = mockEnvironments;
       component.applications = mockApplications;
     });

--- a/src/app/space/create/deployments/apps/deployments-apps.component.ts
+++ b/src/app/space/create/deployments/apps/deployments-apps.component.ts
@@ -15,6 +15,9 @@ import {
   Observable,
   Subscription
 } from 'rxjs';
+import { forkJoin } from 'rxjs/observable/forkJoin';
+import { first } from 'rxjs/operators/first';
+import { map } from 'rxjs/operators/map';
 
 import { DeploymentsToolbarComponent } from '../deployments-toolbar/deployments-toolbar.component';
 
@@ -44,7 +47,10 @@ export class DeploymentsAppsComponent implements OnInit, OnDestroy {
   constructor(private broadcaster: Broadcaster) {}
 
   ngOnInit(): void {
-    this.hasLoaded = Observable.forkJoin(this.applications.first(), this.environments.first()).map(() => true);
+    this.hasLoaded = forkJoin(
+      this.applications.pipe(first()),
+      this.environments.pipe(first())
+    ).pipe(map(() => true));
     this.subscriptions.push(
       this.applications.subscribe((applications: string[]) => {
         this.applicationsList = applications;

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -7,9 +7,11 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import {
-  Observable,
   Subject
 } from 'rxjs';
+import { of } from 'rxjs/observable/of';
+import { _throw } from 'rxjs/observable/throw';
+
 import { createMock } from 'testing/mock';
 import {
   initContext,
@@ -53,10 +55,10 @@ describe('DeploymentsDonutComponent', () => {
           provide: DeploymentsService, useFactory: (): jasmine.SpyObj<DeploymentsService> => {
             const svc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
             svc.scalePods.and.returnValue(
-              Observable.of('scalePods')
+              of('scalePods')
             );
             svc.getPods.and.returnValue(
-              Observable.of({ pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]], total: 2 })
+              of({ pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]], total: 2 })
             );
             svc.getEnvironmentCpuStat.and.returnValue(new Subject<CpuStat>());
             svc.getEnvironmentMemoryStat.and.returnValue(new Subject<MemoryStat>());
@@ -208,7 +210,7 @@ describe('DeploymentsDonutComponent', () => {
   describe('error handling', () => {
     it('should notify if scaling pods has an error', function(this: Context) {
       const mockSvc: jasmine.SpyObj<DeploymentsService> = TestBed.get(DeploymentsService);
-      mockSvc.scalePods.and.returnValue(Observable.throw('scalePods error'));
+      mockSvc.scalePods.and.returnValue(_throw('scalePods error'));
 
       this.testedDirective.scaleUp();
       this.detectChanges();

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -11,6 +11,8 @@ import {
   Observable,
   Subscription
 } from 'rxjs';
+import { combineLatest } from 'rxjs/observable/combineLatest';
+import { first } from 'rxjs/operators/first';
 
 import { PodPhase } from '../models/pod-phase';
 
@@ -74,7 +76,7 @@ export class DeploymentsDonutComponent implements OnInit {
     );
 
     this.subscriptions.push(
-      Observable.combineLatest(
+      combineLatest(
         this.deploymentsService.getEnvironmentCpuStat(this.spaceId, this.environment),
         this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment)
       ).subscribe((stats: Stat[]): void => {
@@ -111,7 +113,7 @@ export class DeploymentsDonutComponent implements OnInit {
     this.subscriptions.push(
       this.deploymentsService.scalePods(
         this.spaceId, this.environment, this.applicationId, this.desiredReplicas
-      ).first().subscribe(
+      ).pipe(first()).subscribe(
         success => {
           this.scaleRequestPending = false;
         },

--- a/src/app/space/create/deployments/deployments.component.spec.ts
+++ b/src/app/space/create/deployments/deployments.component.spec.ts
@@ -10,6 +10,7 @@ import {
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { Spaces } from 'ngx-fabric8-wit';
 import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 import { createMock } from 'testing/mock';
 import {
@@ -32,8 +33,8 @@ describe('DeploymentsComponent', () => {
 
   beforeEach(async(function(this: Context): void {
     this.service = createMock(DeploymentsService);
-    this.service.getApplications.and.returnValue(Observable.of(['foo-app', 'bar-app']));
-    this.service.getEnvironments.and.returnValue(Observable.of(['stage', 'prod']));
+    this.service.getApplications.and.returnValue(of(['foo-app', 'bar-app']));
+    this.service.getEnvironments.and.returnValue(of(['stage', 'prod']));
     this.service.ngOnDestroy.and.callThrough();
     TestBed.overrideProvider(DeploymentsService, { useValue: this.service });
   }));
@@ -43,7 +44,7 @@ describe('DeploymentsComponent', () => {
     providers: [
       {
         provide: Spaces, useValue: (
-          { current: Observable.of({ id: 'fake-spaceId' }) }
+          { current: of({ id: 'fake-spaceId' }) }
         )
       }
     ],

--- a/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/deployments-resource-usage.component.spec.ts
@@ -6,7 +6,7 @@ import {
 import { By } from '@angular/platform-browser';
 
 import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 import { initContext, TestContext } from 'testing/test-context';
 
 import { DeploymentsResourceUsageComponent } from './deployments-resource-usage.component';
@@ -36,8 +36,8 @@ describe('DeploymentsResourceUsageComponent', () => {
       declarations: [FakeResourceCardComponent]
     },
     (component: DeploymentsResourceUsageComponent) => {
-      component.environments = Observable.of(mockEnvironmentData);
-      component.spaceId = Observable.of('spaceId');
+      component.environments = of(mockEnvironmentData);
+      component.spaceId = of('spaceId');
     }
   );
 

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -14,6 +14,7 @@ import {
 import { createMock } from 'testing/mock';
 
 import { Observable } from 'rxjs';
+import { of } from 'rxjs/observable/of';
 
 import { MemoryUnit } from '../models/memory-unit';
 import { Stat } from '../models/stat';
@@ -51,18 +52,18 @@ describe('ResourceCardComponent', () => {
         {
           provide: DeploymentsService, useFactory: (): jasmine.SpyObj<DeploymentsService> => {
             const svc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
-            svc.getApplications.and.returnValue(Observable.of(['foo-app', 'bar-app']));
-            svc.getEnvironments.and.returnValue(Observable.of(['stage', 'prod']));
-            svc.getEnvironmentCpuStat.and.returnValue(Observable.of({ used: 1, quota: 2 }));
-            svc.getEnvironmentMemoryStat.and.returnValue(Observable.of({ used: 3, quota: 4, units: 'GB' as MemoryUnit  }));
+            svc.getApplications.and.returnValue(of(['foo-app', 'bar-app']));
+            svc.getEnvironments.and.returnValue(of(['stage', 'prod']));
+            svc.getEnvironmentCpuStat.and.returnValue(of({ used: 1, quota: 2 }));
+            svc.getEnvironmentMemoryStat.and.returnValue(of({ used: 3, quota: 4, units: 'GB' as MemoryUnit  }));
             return svc;
           }
         },
         {
           provide: DeploymentStatusService, useFactory: (): jasmine.SpyObj<DeploymentStatusService> => {
             const svc: jasmine.SpyObj<DeploymentStatusService> = createMock(DeploymentStatusService);
-            svc.getEnvironmentCpuStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
-            svc.getEnvironmentMemoryStatus.and.returnValue(Observable.of({ type: StatusType.OK, message: '' }));
+            svc.getEnvironmentCpuStatus.and.returnValue(of({ type: StatusType.OK, message: '' }));
+            svc.getEnvironmentMemoryStatus.and.returnValue(of({ type: StatusType.OK, message: '' }));
             return svc;
           }
         }

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core';
 
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators/map';
 
 import { MemoryStat } from '../models/memory-stat';
 import { DeploymentStatusService } from '../services/deployment-status.service';
@@ -29,8 +30,9 @@ export class ResourceCardComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.spaceId && this.environment) {
-      this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment)
-        .map((stat: MemoryStat) => stat.units);
+      this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment).pipe(
+        map((stat: MemoryStat) => stat.units)
+      );
     }
   }
 }

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.spec.ts
@@ -5,6 +5,9 @@ import {
   Observable,
   Subject
 } from 'rxjs';
+import { empty } from 'rxjs/observable/empty';
+import { of } from 'rxjs/observable/of';
+
 import { initContext, TestContext } from 'testing/test-context';
 
 import { Stat } from '../models/stat';
@@ -26,8 +29,8 @@ describe('UtilizationBarComponent', () => {
     initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
-      component.stat = Observable.of({ used: 1, quota: 4 } as Stat);
-      component.status = Observable.of({ type: StatusType.OK, message: '' });
+      component.stat = of({ used: 1, quota: 4 } as Stat);
+      component.status = of({ type: StatusType.OK, message: '' });
     });
 
     it('should have proper stat fields set', function(this: Context) {
@@ -64,8 +67,8 @@ describe('UtilizationBarComponent', () => {
     initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
-      component.stat = Observable.of({ used: 3, quota: 4 } as Stat);
-      component.status = Observable.of({ type: StatusType.WARN, message: '' });
+      component.stat = of({ used: 3, quota: 4 } as Stat);
+      component.status = of({ type: StatusType.WARN, message: '' });
     });
 
     it('should have proper stat fields set', function(this: Context) {
@@ -102,8 +105,8 @@ describe('UtilizationBarComponent', () => {
     initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
-      component.stat = Observable.of({ used: 2, quota: 0 } as Stat);
-      component.status = Observable.of({ type: StatusType.ERR, message: '' });
+      component.stat = of({ used: 2, quota: 0 } as Stat);
+      component.status = of({ type: StatusType.ERR, message: '' });
     });
 
     it('should have a properly set title', function(this: Context) {
@@ -124,7 +127,7 @@ describe('UtilizationBarComponent', () => {
     initContext(UtilizationBarComponent, HostComponent, {}, (component: UtilizationBarComponent) => {
       component.resourceTitle = 'someTitle';
       component.resourceUnit = 'someUnit';
-      component.stat = Observable.empty();
+      component.stat = empty();
       component.status = status;
     });
 

--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -6,6 +6,8 @@ import {
 import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
+import { first } from 'rxjs/operators/first';
+
 import { createMock } from 'testing/mock';
 
 import { Logger } from 'ngx-base';
@@ -86,9 +88,9 @@ describe('DeploymentApiService', () => {
           }
         ] as EnvironmentStat[]
       };
-      this.service.getEnvironments('foo spaceId')
-        .first()
-        .subscribe((envs: EnvironmentStat[]): void => {
+      this.service.getEnvironments('foo spaceId').pipe(
+        first()
+      ).subscribe((envs: EnvironmentStat[]): void => {
           expect(envs).toEqual(httpResponse.data);
           this.controller.verify();
           done();
@@ -101,9 +103,9 @@ describe('DeploymentApiService', () => {
     });
 
     it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.getEnvironments('foo spaceId')
-        .first()
-        .subscribe(
+      this.service.getEnvironments('foo spaceId').pipe(
+        first()
+      ).subscribe(
           () => done.fail('should throw error'),
           () => {
             expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
@@ -143,9 +145,9 @@ describe('DeploymentApiService', () => {
           }
         }
       } as ApplicationsResponse;
-      this.service.getApplications('foo spaceId')
-        .first()
-        .subscribe((apps: Application[]): void => {
+      this.service.getApplications('foo spaceId').pipe(
+        first()
+      ).subscribe((apps: Application[]): void => {
           expect(apps).toEqual(httpResponse.data.attributes.applications);
           this.controller.verify();
           done();
@@ -158,9 +160,9 @@ describe('DeploymentApiService', () => {
     });
 
     it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.getApplications('foo spaceId')
-        .first()
-        .subscribe(
+      this.service.getApplications('foo spaceId').pipe(
+        first()
+      ).subscribe(
           () => done.fail('should throw error'),
           () => {
             expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
@@ -199,9 +201,9 @@ describe('DeploymentApiService', () => {
           end: 2
         }
       } as MultiTimeseriesResponse;
-      this.service.getTimeseriesData('foo spaceId', 'stage env', 'foo appId', 1, 2)
-        .first()
-        .subscribe((data: MultiTimeseriesData): void => {
+      this.service.getTimeseriesData('foo spaceId', 'stage env', 'foo appId', 1, 2).pipe(
+        first()
+      ).subscribe((data: MultiTimeseriesData): void => {
           expect(data).toEqual(httpResponse.data);
           this.controller.verify();
           done();
@@ -214,9 +216,9 @@ describe('DeploymentApiService', () => {
     });
 
     it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.getTimeseriesData('foo spaceId', 'stage env', 'foo appId', 1, 2)
-        .first()
-        .subscribe(
+      this.service.getTimeseriesData('foo spaceId', 'stage env', 'foo appId', 1, 2).pipe(
+        first()
+      ).subscribe(
           () => done.fail('should throw error'),
           () => {
             expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
@@ -251,9 +253,9 @@ describe('DeploymentApiService', () => {
           }
         }
       } as TimeseriesResponse;
-      this.service.getLatestTimeseriesData('foo spaceId', 'stage env', 'foo appId')
-        .first()
-        .subscribe((data: TimeseriesData): void => {
+      this.service.getLatestTimeseriesData('foo spaceId', 'stage env', 'foo appId').pipe(
+        first()
+      ).subscribe((data: TimeseriesData): void => {
           expect(data).toEqual(httpResponse.data.attributes);
           this.controller.verify();
           done();
@@ -266,9 +268,9 @@ describe('DeploymentApiService', () => {
     });
 
     it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.getLatestTimeseriesData('foo spaceId', 'stage env', 'foo appId')
-        .first()
-        .subscribe(
+      this.service.getLatestTimeseriesData('foo spaceId', 'stage env', 'foo appId').pipe(
+        first()
+      ).subscribe(
           () => done.fail('should throw error'),
           () => {
             expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
@@ -285,9 +287,9 @@ describe('DeploymentApiService', () => {
 
   describe('#deleteDeployment', () => {
     it('should return response', function(this: TestContext, done: DoneFn): void {
-      this.service.deleteDeployment('foo spaceId', 'stage env', 'foo appId')
-        .first()
-        .subscribe((): void => {
+      this.service.deleteDeployment('foo spaceId', 'stage env', 'foo appId').pipe(
+        first()
+      ).subscribe((): void => {
           this.controller.verify();
           done();
         });
@@ -299,9 +301,9 @@ describe('DeploymentApiService', () => {
     });
 
     it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.deleteDeployment('foo spaceId', 'stage env', 'foo appId')
-        .first()
-        .subscribe(
+      this.service.deleteDeployment('foo spaceId', 'stage env', 'foo appId').pipe(
+        first()
+      ).subscribe(
           () => done.fail('should throw error'),
           () => {
             expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
@@ -318,9 +320,9 @@ describe('DeploymentApiService', () => {
 
   describe('#scalePods', () => {
     it('should return response', function(this: TestContext, done: DoneFn): void {
-      this.service.scalePods('foo spaceId', 'stage env', 'foo appId', 5)
-        .first()
-        .subscribe((): void => {
+      this.service.scalePods('foo spaceId', 'stage env', 'foo appId', 5).pipe(
+        first()
+      ).subscribe((): void => {
           this.controller.verify();
           done();
         });
@@ -332,9 +334,9 @@ describe('DeploymentApiService', () => {
     });
 
     it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.scalePods('foo spaceId', 'stage env', 'foo appId', 5)
-        .first()
-        .subscribe(
+      this.service.scalePods('foo spaceId', 'stage env', 'foo appId', 5).pipe(
+        first()
+      ).subscribe(
           () => done.fail('should throw error'),
           () => {
             expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -8,6 +8,12 @@ import {
   Subject,
   VirtualTimeScheduler
 } from 'rxjs';
+import { empty } from 'rxjs/observable/empty';
+import { of } from 'rxjs/observable/of';
+import { _throw } from 'rxjs/observable/throw';
+import { timer } from 'rxjs/observable/timer';
+import { first } from 'rxjs/operators/first';
+import { takeUntil } from 'rxjs/operators/takeUntil';
 import { VirtualAction } from 'rxjs/scheduler/VirtualTimeScheduler';
 
 import {
@@ -89,7 +95,7 @@ describe('DeploymentsService', () => {
 
   describe('#getApplications', () => {
     it('should publish faked application names', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello'
@@ -115,7 +121,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return empty array if no applications', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([]));
+      this.apiService.getApplications.and.returnValue(of([]));
       this.service.getApplications('foo-spaceId')
         .subscribe((applications: string[]): void => {
           expect(applications).toEqual([]);
@@ -125,7 +131,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return singleton array result', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([{
+      this.apiService.getApplications.and.returnValue(of([{
         attributes: { name: 'vertx-hello' }
       }]));
       this.service.getApplications('foo-spaceId')
@@ -137,7 +143,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return empty array for null applications response', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of(null));
+      this.apiService.getApplications.and.returnValue(of(null));
       this.service.getApplications('foo-spaceId')
         .subscribe((applications: string[]): void => {
           expect(applications).toEqual([]);
@@ -149,7 +155,7 @@ describe('DeploymentsService', () => {
 
   describe('#getEnvironments', () => {
     it('should sort environments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(Observable.of([
+      this.apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'run'
@@ -169,7 +175,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should only emit on change', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(Observable.of([
+      this.apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'run'
@@ -181,9 +187,9 @@ describe('DeploymentsService', () => {
         }
       ]));
       let callCount: number = 0;
-      this.service.getEnvironments('foo-spaceId')
-        .takeUntil(Observable.timer(1000))
-        .subscribe(
+      this.service.getEnvironments('foo-spaceId').pipe(
+        takeUntil(timer(1000))
+      ).subscribe(
           (environments: string[]): void => {
             expect(environments).toEqual(['stage', 'run']);
             callCount++;
@@ -199,7 +205,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return singleton array result', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(Observable.of([
+      this.apiService.getEnvironments.and.returnValue(of([
         { attributes: { name: 'stage' } }
       ]));
       this.service.getEnvironments('foo-spaceId')
@@ -211,7 +217,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return empty array if no environments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(Observable.of([]));
+      this.apiService.getEnvironments.and.returnValue(of([]));
       this.service.getEnvironments('foo-spaceId')
         .subscribe((environments: string[]): void => {
           expect(environments).toEqual([]);
@@ -221,7 +227,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return empty array for null environments response', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(Observable.of(null));
+      this.apiService.getEnvironments.and.returnValue(of(null));
       this.service.getEnvironments('foo-spaceId')
         .subscribe((environments: string[]): void => {
           expect(environments).toEqual([]);
@@ -233,7 +239,7 @@ describe('DeploymentsService', () => {
 
   describe('#isApplicationDeployedInEnvironment', () => {
     it('should be true for included deployments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -256,7 +262,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be true if included in multiple deployments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -284,7 +290,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false for excluded deployments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -307,7 +313,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if excluded in multiple deployments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -335,7 +341,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if no deployments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -352,7 +358,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if deployments is null', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -371,7 +377,7 @@ describe('DeploymentsService', () => {
 
   describe('#isDeployedInEnvironment', () => {
     it('should be true for included environments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -393,7 +399,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be true if included in multiple applications and environments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -438,7 +444,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false for excluded environments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -473,7 +479,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if no environments are deployed', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -496,7 +502,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if no applications exist', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([]));
+      this.apiService.getApplications.and.returnValue(of([]));
       this.service.isDeployedInEnvironment('foo-spaceId', 'stage')
         .subscribe((deployed: boolean): void => {
           expect(deployed).toEqual(false);
@@ -506,7 +512,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if applications are null', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of(null));
+      this.apiService.getApplications.and.returnValue(of(null));
       this.service.isDeployedInEnvironment('foo-spaceId', 'stage')
         .subscribe((deployed: boolean): void => {
           expect(deployed).toEqual(false);
@@ -516,7 +522,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should be false if deployments is null', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -535,7 +541,7 @@ describe('DeploymentsService', () => {
 
   describe('#getVersion', () => {
     it('should return 1.0.2', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -561,7 +567,7 @@ describe('DeploymentsService', () => {
 
   describe('#scalePods', () => {
     it('should return success message on success', function(this: TestContext, done: DoneFn): void {
-      this.apiService.scalePods.and.returnValue(Observable.of({}));
+      this.apiService.scalePods.and.returnValue(of({}));
       this.service.scalePods('foo-spaceId', 'stage', 'vertx-hello', 2)
         .subscribe(
           (msg: string) => {
@@ -575,7 +581,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return failure message on error', function(this: TestContext, done: DoneFn): void {
-      this.apiService.scalePods.and.returnValue(Observable.throw('fail'));
+      this.apiService.scalePods.and.returnValue(_throw('fail'));
       this.service.scalePods('foo-spaceId', 'stage', 'vertx-hello', 2)
         .subscribe(
           (msg: string) => {
@@ -591,7 +597,7 @@ describe('DeploymentsService', () => {
 
   describe('#getPods', () => {
     it('should return pods for an existing deployment', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -645,7 +651,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return pods when there are multiple deployments', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -692,7 +698,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should return pods array', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'vertx-hello',
@@ -734,7 +740,7 @@ describe('DeploymentsService', () => {
 
   describe('#getDeploymentCpuStat', () => {
     it('should combine timeseries and quota data', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -754,7 +760,7 @@ describe('DeploymentsService', () => {
         start: 1,
         end: 8
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -768,7 +774,7 @@ describe('DeploymentsService', () => {
           time: 12, value: 12
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -788,9 +794,9 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app', 3)
-        .first()
-        .subscribe((stats: CpuStat[]) => {
+      this.service.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        first()
+      ).subscribe((stats: CpuStat[]) => {
           expect(stats).toEqual([
             { used: 1, quota: 3, timestamp: 1 },
             { used: 2, quota: 3, timestamp: 2 },
@@ -803,7 +809,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should round usage data points', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 0.0001, time: 1 },
           { value: 0.00001, time: 2 }
@@ -823,7 +829,7 @@ describe('DeploymentsService', () => {
         start: 1,
         end: 8
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 0.00015
         },
@@ -837,7 +843,7 @@ describe('DeploymentsService', () => {
           time: 12, value: 12
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -857,9 +863,9 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app', 3)
-        .first()
-        .subscribe((stats: CpuStat[]) => {
+      this.service.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        first()
+      ).subscribe((stats: CpuStat[]) => {
           expect(stats).toEqual([
             { used: 0.0001, quota: 3, timestamp: 1 },
             { used: 0, quota: 3, timestamp: 2 },
@@ -874,7 +880,7 @@ describe('DeploymentsService', () => {
 
   describe('#getDeploymentMemoryStat', () => {
     it('should combine timeseries and quota data', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -894,7 +900,7 @@ describe('DeploymentsService', () => {
         start: 1,
         end: 8
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -908,7 +914,7 @@ describe('DeploymentsService', () => {
           time: 12, value: 12
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -928,9 +934,9 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentMemoryStat('foo-space', 'foo-env', 'foo-app', 3)
-        .first()
-        .subscribe((stats: MemoryStat[]) => {
+      this.service.getDeploymentMemoryStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        first()
+      ).subscribe((stats: MemoryStat[]) => {
           expect(stats).toEqual([
             new ScaledMemoryStat(3, 3, 3),
             new ScaledMemoryStat(4, 3, 4),
@@ -943,7 +949,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should scale results to the sample with greatest unit', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 0, time: 0 },
           { value: 0, time: 1 }
@@ -963,7 +969,7 @@ describe('DeploymentsService', () => {
         start: 0,
         end: 1
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 0, value: 0
         },
@@ -977,7 +983,7 @@ describe('DeploymentsService', () => {
           time: 2, value: 110 * Math.pow(1024, 2)
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -997,9 +1003,9 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentMemoryStat('foo-space', 'foo-env', 'foo-app', 3)
-        .first()
-        .subscribe((stats: MemoryStat[]) => {
+      this.service.getDeploymentMemoryStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        first()
+      ).subscribe((stats: MemoryStat[]) => {
           expect(stats).toEqual([
             jasmine.objectContaining({
               used: 0.8,
@@ -1026,7 +1032,7 @@ describe('DeploymentsService', () => {
 
   describe('#getDeploymentNetworkStat', () => {
     it('should return scaled timeseries data', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -1046,7 +1052,7 @@ describe('DeploymentsService', () => {
         start: 1,
         end: 8
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -1060,7 +1066,7 @@ describe('DeploymentsService', () => {
           time: 12, value: 12
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1076,9 +1082,9 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentNetworkStat('foo-space', 'foo-env', 'foo-app', 3)
-        .first()
-        .subscribe((stats: NetworkStat[]) => {
+      this.service.getDeploymentNetworkStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        first()
+      ).subscribe((stats: NetworkStat[]) => {
           expect(stats).toEqual([
             { sent: new ScaledNetStat(7, 7), received: new ScaledNetStat(5, 5) },
             { sent: new ScaledNetStat(8, 8), received: new ScaledNetStat(6, 6) },
@@ -1091,7 +1097,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should scale results to the sample with greatest unit', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 0, time: 0 },
           { value: 0, time: 1 }
@@ -1111,7 +1117,7 @@ describe('DeploymentsService', () => {
         start: 0,
         end: 1
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 0, value: 0
         },
@@ -1125,7 +1131,7 @@ describe('DeploymentsService', () => {
           time: 0, value: 0
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1145,9 +1151,9 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentNetworkStat('foo-space', 'foo-env', 'foo-app', 3)
-        .first()
-        .subscribe((stats: NetworkStat[]) => {
+      this.service.getDeploymentNetworkStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        first()
+      ).subscribe((stats: NetworkStat[]) => {
           expect(stats).toEqual([
             {
               sent: jasmine.objectContaining({ used: 0.5, units: MemoryUnit.GB }),
@@ -1171,7 +1177,7 @@ describe('DeploymentsService', () => {
 
   describe('#getTimeseriesData', () => {
     it('should complete without errors if the deployment disappears', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -1191,7 +1197,7 @@ describe('DeploymentsService', () => {
         start: 1,
         end: 8
       }));
-      this.apiService.getLatestTimeseriesData.and.returnValue(Observable.of({
+      this.apiService.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -1205,7 +1211,7 @@ describe('DeploymentsService', () => {
           time: 12, value: 12
         }
       }));
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1224,11 +1230,11 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.service.getDeploymentNetworkStat('foo-space', 'foo-env', 'foo-app', 3)
-        .takeUntil(Observable.timer(1000))
-        .subscribe(
+      this.service.getDeploymentNetworkStat('foo-space', 'foo-env', 'foo-app', 3).pipe(
+        takeUntil(timer(1000))
+      ).subscribe(
           (stat: NetworkStat[]): void => {
-            this.apiService.getApplications.and.returnValue(Observable.of([
+            this.apiService.getApplications.and.returnValue(of([
               {
                 attributes: {
                   name: 'foo-app',
@@ -1236,12 +1242,12 @@ describe('DeploymentsService', () => {
                 }
               }
             ]));
-            this.apiService.getLatestTimeseriesData.and.returnValue(Observable.throw('Generic error message'));
+            this.apiService.getLatestTimeseriesData.and.returnValue(_throw('Generic error message'));
             this.timer.next();
           },
           err => {
             done.fail(err.message || err);
-            return Observable.empty();
+            return empty();
           },
           () => {
             expect(this.logger.error).not.toHaveBeenCalled();
@@ -1256,7 +1262,7 @@ describe('DeploymentsService', () => {
 
   describe('#getEnvironmentCpuStat', () => {
     it('should return a "used" value of 8 and a "quota" value of 10', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(Observable.of([
+      this.apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -1281,7 +1287,7 @@ describe('DeploymentsService', () => {
   describe('#getEnvironmentMemoryStat', () => {
     it('should return a "used" value of 512 and a "quota" value of 1024 with units in "MB"', function(this: TestContext, done: DoneFn): void {
       const GB: number = Math.pow(1024, 3);
-      this.apiService.getEnvironments.and.returnValue(Observable.of([
+      this.apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -1306,7 +1312,7 @@ describe('DeploymentsService', () => {
 
   describe('#deleteDeployment', () => {
     it('should delete a deployment with the correct URL', function(this: TestContext, done: DoneFn): void {
-      this.apiService.deleteDeployment.and.returnValue(Observable.of('OK'));
+      this.apiService.deleteDeployment.and.returnValue(of('OK'));
       expect(this.apiService.deleteDeployment).not.toHaveBeenCalled();
       this.service.deleteDeployment('spaceId', 'envId', 'appId')
         .subscribe(
@@ -1327,7 +1333,7 @@ describe('DeploymentsService', () => {
       const spaceId: string = 'someSpaceId';
       const environmentId: string = 'someStage';
       const appId: string = 'someAppName';
-      this.apiService.deleteDeployment.and.returnValue(Observable.throw('FAIL'));
+      this.apiService.deleteDeployment.and.returnValue(_throw('FAIL'));
       expect(this.apiService.deleteDeployment).not.toHaveBeenCalled();
       this.service.deleteDeployment(spaceId, environmentId, appId)
         .subscribe(
@@ -1347,7 +1353,7 @@ describe('DeploymentsService', () => {
 
   describe('application links', () => {
     it('should provide logs URL', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1373,7 +1379,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should provide console URL', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1399,7 +1405,7 @@ describe('DeploymentsService', () => {
     });
 
     it('should provide application URL', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getApplications.and.returnValue(Observable.of([
+      this.apiService.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1431,7 +1437,7 @@ describe('DeploymentsService', () => {
 
     it('should return true if there are deployed applications', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app-1',
@@ -1477,7 +1483,7 @@ describe('DeploymentsService', () => {
 
     it('should return true if there are is at least one deployed application', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app-1',
@@ -1507,7 +1513,7 @@ describe('DeploymentsService', () => {
 
     it('should return false if there are no deployed applications', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app-1',
@@ -1541,11 +1547,11 @@ describe('DeploymentsService', () => {
       const vs = new VirtualTimeScheduler(VirtualAction);
 
       apiSvc.getApplications.and.returnValue(
-        Observable.throw(error, vs)
+        _throw(error, vs)
       );
 
       const svc: DeploymentsService = TestBed.get(DeploymentsService);
-      svc.getApplications('spaceId').first().subscribe(
+      svc.getApplications('spaceId').pipe(first()).subscribe(
         () => fail('should not emit'),
         () => fail('should not emit'),
         () => fail('should not emit')
@@ -1614,11 +1620,11 @@ describe('DeploymentsService', () => {
       const vs = new VirtualTimeScheduler(VirtualAction);
 
       apiSvc.getEnvironments.and.returnValue(
-        Observable.throw(error, vs)
+        _throw(error, vs)
       );
 
       const svc: DeploymentsService = TestBed.get(DeploymentsService);
-      svc.getEnvironments('spaceId').first().subscribe(
+      svc.getEnvironments('spaceId').pipe(first()).subscribe(
         () => fail('should not emit'),
         () => fail('should not emit'),
         () => fail('should not emit')
@@ -1679,7 +1685,7 @@ describe('DeploymentsService', () => {
   describe('getDeploymentCpuStat', () => {
     function setupErrorTests() {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1700,7 +1706,7 @@ describe('DeploymentsService', () => {
         }
       ]));
 
-      apiSvc.getTimeseriesData.and.returnValue(Observable.of({
+      apiSvc.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -1721,7 +1727,7 @@ describe('DeploymentsService', () => {
         end: 8
       }));
 
-      apiSvc.getLatestTimeseriesData.and.returnValue(Observable.of({
+      apiSvc.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -1748,12 +1754,12 @@ describe('DeploymentsService', () => {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
 
       apiSvc.getTimeseriesData.and.returnValue(
-        Observable.throw(error)
+        _throw(error)
       );
 
       const svc: DeploymentsService = TestBed.get(DeploymentsService);
 
-      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe(
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').pipe(first()).subscribe(
         () => fail('should not emit'),
         () => fail('should not emit'),
         () => fail('should not emit')
@@ -1779,12 +1785,12 @@ describe('DeploymentsService', () => {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
 
       apiSvc.getLatestTimeseriesData.and.returnValue(
-        Observable.throw(error)
+        _throw(error)
       );
 
       const svc: DeploymentsService = TestBed.get(DeploymentsService);
 
-      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe(
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').pipe(first()).subscribe(
         () => fail('should not emit'),
         () => fail('should not emit'),
         () => fail('should not emit')
@@ -1807,12 +1813,12 @@ describe('DeploymentsService', () => {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = TestBed.get(DeploymentApiService);
 
       apiSvc.getApplications.and.returnValue(
-        Observable.throw(error)
+        _throw(error)
       );
 
       const svc: DeploymentsService = TestBed.get(DeploymentsService);
 
-      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe(
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').pipe(first()).subscribe(
         () => fail('should not emit'),
         () => fail('should not emit'),
         () => fail('should not emit')
@@ -1854,7 +1860,7 @@ describe('DeploymentsService', () => {
 
     it('should return data', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1874,7 +1880,7 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      apiSvc.getTimeseriesData.and.returnValue(Observable.of({
+      apiSvc.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -1894,7 +1900,7 @@ describe('DeploymentsService', () => {
         start: 1,
         end: 8
       }));
-      apiSvc.getLatestTimeseriesData.and.returnValue(Observable.of({
+      apiSvc.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -1910,7 +1916,7 @@ describe('DeploymentsService', () => {
       }));
 
       const svc: DeploymentsService = this.service;
-      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe((stats: CpuStat[]): void => {
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').pipe(first()).subscribe((stats: CpuStat[]): void => {
         expect(stats).toEqual([
           { used: 1, quota: 3, timestamp: 1 },
           { used: 2, quota: 3, timestamp: 2 },
@@ -1924,7 +1930,7 @@ describe('DeploymentsService', () => {
 
     it('should return nothing when application is not deployed in environment', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1952,12 +1958,12 @@ describe('DeploymentsService', () => {
       this.timer.next();
       this.timer.next();
 
-      Observable.timer(500).first().subscribe(() => done());
+      timer(500).pipe(first()).subscribe(() => done());
     });
 
     it('should return nothing when application has no pods', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -1985,12 +1991,12 @@ describe('DeploymentsService', () => {
       this.timer.next();
       this.timer.next();
 
-      Observable.timer(500).first().subscribe(() => done());
+      timer(500).pipe(first()).subscribe(() => done());
     });
 
     it('should emit updates when deployment reappears', function(this: TestContext, done: DoneFn): void {
       const apiSvc: jasmine.SpyObj<DeploymentApiService> = this.apiService;
-      apiSvc.getApplications.and.returnValue(Observable.of([
+      apiSvc.getApplications.and.returnValue(of([
         {
           attributes: {
             name: 'foo-app',
@@ -2010,7 +2016,7 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      apiSvc.getLatestTimeseriesData.and.returnValue(Observable.of({
+      apiSvc.getLatestTimeseriesData.and.returnValue(of({
         cores: {
           time: 9, value: 9
         },
@@ -2024,7 +2030,7 @@ describe('DeploymentsService', () => {
           time: 12, value: 12
         }
       }));
-      apiSvc.getTimeseriesData.and.returnValue(Observable.of({
+      apiSvc.getTimeseriesData.and.returnValue(of({
         cores: [
           { value: 1, time: 1 },
           { value: 2, time: 2 }
@@ -2048,7 +2054,7 @@ describe('DeploymentsService', () => {
       let delayPassed: boolean = false;
 
       const svc: DeploymentsService = this.service;
-      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').first().subscribe((stats: CpuStat[]): void => {
+      svc.getDeploymentCpuStat('foo-space', 'foo-env', 'foo-app').pipe(first()).subscribe((stats: CpuStat[]): void => {
         if (!delayPassed) {
           done.fail('should not have emitted before delay passed');
         }
@@ -2062,10 +2068,10 @@ describe('DeploymentsService', () => {
       this.timer.next();
       this.timer.next();
 
-      Observable.timer(500).first().subscribe(() => {
+      timer(500).pipe(first()).subscribe(() => {
         delayPassed = true;
 
-        apiSvc.getApplications.and.returnValue(Observable.of([
+        apiSvc.getApplications.and.returnValue(of([
           {
             attributes: {
               name: 'foo-app',

--- a/src/app/space/create/deployments/services/deployments.service.ts
+++ b/src/app/space/create/deployments/services/deployments.service.ts
@@ -11,6 +11,20 @@ import {
   Subject,
   Subscription
 } from 'rxjs';
+import { combineLatest } from 'rxjs/observable/combineLatest';
+import { empty } from 'rxjs/observable/empty';
+import { from } from 'rxjs/observable/from';
+import { _throw } from 'rxjs/observable/throw';
+import { bufferCount } from 'rxjs/operators/bufferCount';
+import { catchError } from 'rxjs/operators/catchError';
+import { concatMap } from 'rxjs/operators/concatMap';
+import { distinctUntilChanged } from 'rxjs/operators/distinctUntilChanged';
+import { filter } from 'rxjs/operators/filter';
+import { finalize } from 'rxjs/operators/finalize';
+import { map } from 'rxjs/operators/map';
+import { mergeMap } from 'rxjs/operators/mergeMap';
+import { pairwise } from 'rxjs/operators/pairwise';
+import { startWith } from 'rxjs/operators/startWith';
 
 import {
   Notification,
@@ -74,7 +88,7 @@ export class DeploymentsService implements OnDestroy {
     private readonly notifications: NotificationsService,
     @Inject(TIMER_TOKEN) private readonly pollTimer: Observable<void>,
     @Inject(TIMESERIES_SAMPLES_TOKEN) private readonly timeseriesSamples: number,
-    @Inject(POLL_RATE_TOKEN) private readonly pollRate: number
+    @Inject(POLL_RATE_TOKEN) pollRate: number
   ) {
     this.frontLoadWindowWidth = timeseriesSamples * pollRate;
   }
@@ -86,63 +100,71 @@ export class DeploymentsService implements OnDestroy {
   }
 
   getApplications(spaceId: string): Observable<string[]> {
-    return this.getApplicationsResponse(spaceId)
-      .map((apps: Application[]) => apps || [])
-      .map((apps: Application[]) => apps.map((app: Application) => app.attributes.name))
-      .distinctUntilChanged(deepEqual);
+    return this.getApplicationsResponse(spaceId).pipe(
+      map((apps: Application[]) => apps || []),
+      map((apps: Application[]) => apps.map((app: Application) => app.attributes.name)),
+      distinctUntilChanged(deepEqual)
+    );
   }
 
   getEnvironments(spaceId: string): Observable<string[]> {
-    return this.getEnvironmentsResponse(spaceId)
-      .map((envs: EnvironmentStat[]) => envs || [])
-      .map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => env.attributes))
-      .map((envs: EnvironmentAttributes[]) => envs.map((env: EnvironmentAttributes) => env.name))
-      .map((envs: string[]): string[] => envs.sort((a: string, b: string): number => b.localeCompare(a)))
-      .distinctUntilChanged(deepEqual);
+    return this.getEnvironmentsResponse(spaceId).pipe(
+      map((envs: EnvironmentStat[]) => envs || []),
+      map((envs: EnvironmentStat[]) => envs.map((env: EnvironmentStat) => env.attributes)),
+      map((envs: EnvironmentAttributes[]) => envs.map((env: EnvironmentAttributes) => env.name)),
+      map((envs: string[]): string[] => envs.sort((a: string, b: string): number => b.localeCompare(a))),
+      distinctUntilChanged(deepEqual)
+    );
   }
 
   isApplicationDeployedInEnvironment(spaceId: string, environmentName: string, applicationId: string):
     Observable<boolean> {
-    return this.getApplication(spaceId, applicationId)
-      .map((app: Application) => app.attributes.deployments)
-      .map((deployments: Deployment[]) => deployments || [])
-      .map((deployments: Deployment[]) => includes(deployments.map((d: Deployment) => d.attributes.name), environmentName))
-      .distinctUntilChanged();
+    return this.getApplication(spaceId, applicationId).pipe(
+      map((app: Application) => app.attributes.deployments),
+      map((deployments: Deployment[]) => deployments || []),
+      map((deployments: Deployment[]) => includes(deployments.map((d: Deployment) => d.attributes.name), environmentName)),
+      distinctUntilChanged()
+    );
   }
 
   isDeployedInEnvironment(spaceId: string, environmentName: string):
     Observable<boolean> {
-    return this.getApplicationsResponse(spaceId)
-      .map((apps: Application[]) => apps || [])
-      .map((apps: Application[]) => apps.map((app: Application) => app.attributes.deployments || []))
-      .map((deployments: Deployment[][]) => deployments.map((pipeline: Deployment[]) => pipeline.map((deployment: Deployment) => deployment.attributes.name)))
-      .map((pipeEnvNames: string[][]) => flatten(pipeEnvNames))
-      .map((envNames: string[]) => includes(envNames, environmentName))
-      .distinctUntilChanged();
+    return this.getApplicationsResponse(spaceId).pipe(
+      map((apps: Application[]) => apps || []),
+      map((apps: Application[]) => apps.map((app: Application) => app.attributes.deployments || [])),
+      map((deployments: Deployment[][]) => deployments.map((pipeline: Deployment[]) => pipeline.map((deployment: Deployment) => deployment.attributes.name))),
+      map((pipeEnvNames: string[][]) => flatten(pipeEnvNames)),
+      map((envNames: string[]) => includes(envNames, environmentName)),
+      distinctUntilChanged()
+    );
   }
 
   hasDeployments(spaceId: string, environments: string[]): Observable<boolean> {
-    return Observable.combineLatest(
+    return combineLatest(
       environments.map(environment => this.isDeployedInEnvironment(spaceId, environment))
-    ).map((deployed: boolean[]): boolean => deployed.some(b => b));
+    ).pipe(
+      map((deployed: boolean[]): boolean => deployed.some(b => b))
+    );
   }
 
   getVersion(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
-    return this.getDeployment(spaceId, environmentName, applicationId)
-      .map((deployment: Deployment) => deployment.attributes.version)
-      .distinctUntilChanged();
+    return this.getDeployment(spaceId, environmentName, applicationId).pipe(
+      map((deployment: Deployment) => deployment.attributes.version),
+      distinctUntilChanged()
+    );
   }
 
   scalePods(spaceId: string, environmentName: string, applicationId: string, desiredReplicas: number): Observable<string> {
-    return this.apiService.scalePods(spaceId, environmentName, applicationId, desiredReplicas)
-      .map(() => `Successfully scaled ${applicationId}`)
-      .catch(err => Observable.throw(`Failed to scale ${applicationId}`));
+    return this.apiService.scalePods(spaceId, environmentName, applicationId, desiredReplicas).pipe(
+      map(() => `Successfully scaled ${applicationId}`),
+      catchError(() => _throw(`Failed to scale ${applicationId}`))
+    );
   }
 
   getPods(spaceId: string, environmentName: string, applicationId: string): Observable<Pods> {
-    return this.getDeployment(spaceId, environmentName, applicationId)
-      .map((deployment: Deployment) => deployment.attributes)
-      .map((attrs: DeploymentAttributes) => {
+    return this.getDeployment(spaceId, environmentName, applicationId).pipe(
+      map((deployment: Deployment) => deployment.attributes),
+      map((attrs: DeploymentAttributes) => {
         const pods = attrs.pods
           .sort((a: [string, string], b: [string, string]): number =>
             a[0].localeCompare(b[0])
@@ -154,26 +176,30 @@ export class DeploymentsService implements OnDestroy {
           total: attrs.pod_total,
           pods: pods
         } as Pods;
-      })
-      .distinctUntilChanged(deepEqual);
+      }),
+      distinctUntilChanged(deepEqual)
+    );
   }
 
   getPodsQuota(spaceId: string, environmentName: string, applicationId: string): Observable<PodsQuota> {
-    return this.getDeployment(spaceId, environmentName, applicationId)
-      .map((deployment: Deployment) => deployment.attributes)
-      .filter((attrs: DeploymentAttributes) => attrs && has(attrs, 'pods_quota'))
-      .map((attrs: DeploymentAttributes) => attrs.pods_quota)
-      .distinctUntilChanged(deepEqual);
+    return this.getDeployment(spaceId, environmentName, applicationId).pipe(
+      map((deployment: Deployment) => deployment.attributes),
+      filter((attrs: DeploymentAttributes) => attrs && has(attrs, 'pods_quota')),
+      map((attrs: DeploymentAttributes) => attrs.pods_quota),
+      distinctUntilChanged(deepEqual)
+    );
   }
 
   getDeploymentCpuStat(spaceId: string, environmentName: string, applicationId: string, maxSamples: number = this.timeseriesSamples): Observable<CpuStat[]> {
-    const series = this.getTimeseriesData(spaceId, environmentName, applicationId, maxSamples)
-      .filter((t: TimeseriesData[]) => t && t.some((el: TimeseriesData) => has(el, 'cores')))
-      .map((t: TimeseriesData[]) => t.map((s: TimeseriesData) => s.cores));
-    const quota = this.getPodsQuota(spaceId, environmentName, applicationId)
-      .map((podsQuota: PodsQuota) => podsQuota.cpucores)
-      .distinctUntilChanged();
-    return Observable.combineLatest(series, quota, (series: CoresSeries[], quota: number) =>
+    const series = this.getTimeseriesData(spaceId, environmentName, applicationId, maxSamples).pipe(
+      filter((t: TimeseriesData[]) => t && t.some((el: TimeseriesData) => has(el, 'cores'))),
+      map((t: TimeseriesData[]) => t.map((s: TimeseriesData) => s.cores))
+    );
+    const quota = this.getPodsQuota(spaceId, environmentName, applicationId).pipe(
+      map((podsQuota: PodsQuota) => podsQuota.cpucores),
+      distinctUntilChanged()
+    );
+    return combineLatest(series, quota, (series: CoresSeries[], quota: number) =>
       series.map((s: CoresSeries) =>
         ({ used: round(s.value, 4), quota: quota, timestamp: s.time } as CpuStat)
       )
@@ -181,13 +207,15 @@ export class DeploymentsService implements OnDestroy {
   }
 
   getDeploymentMemoryStat(spaceId: string, environmentName: string, applicationId: string, maxSamples: number = this.timeseriesSamples): Observable<MemoryStat[]> {
-    const series = this.getTimeseriesData(spaceId, environmentName, applicationId, maxSamples)
-      .filter((t: TimeseriesData[]) => t && t.some((el: TimeseriesData) => has(el, 'memory')))
-      .map((t: TimeseriesData[]) => t.map((s: TimeseriesData) => s.memory));
-    const quota = this.getPodsQuota(spaceId, environmentName, applicationId)
-      .map((podsQuota: PodsQuota) => podsQuota.memory)
-      .distinctUntilChanged();
-    return Observable.combineLatest(series, quota, (memSeries: MemorySeries[], quota: number) => {
+    const series = this.getTimeseriesData(spaceId, environmentName, applicationId, maxSamples).pipe(
+      filter((t: TimeseriesData[]) => t && t.some((el: TimeseriesData) => has(el, 'memory'))),
+      map((t: TimeseriesData[]) => t.map((s: TimeseriesData) => s.memory))
+    );
+    const quota = this.getPodsQuota(spaceId, environmentName, applicationId).pipe(
+      map((podsQuota: PodsQuota) => podsQuota.memory),
+      distinctUntilChanged()
+    );
+    return combineLatest(series, quota, (memSeries: MemorySeries[], quota: number) => {
       const rawStats: ScaledMemoryStat[] = memSeries
         .map((s: MemorySeries) => new ScaledMemoryStat(s.value, quota, s.time));
       const greatestOrdinal: number = rawStats
@@ -201,16 +229,16 @@ export class DeploymentsService implements OnDestroy {
   }
 
   getDeploymentNetworkStat(spaceId: string, environmentName: string, applicationId: string, maxSamples: number = this.timeseriesSamples): Observable<NetworkStat[]> {
-    return this.getTimeseriesData(spaceId, environmentName, applicationId, maxSamples)
-      .filter((t: TimeseriesData[]) => t && t.some((el: TimeseriesData) => has(el, 'net_tx')) && t.some((el: TimeseriesData) => has(el, 'net_rx')))
-      .map((t: TimeseriesData[]) =>
+    return this.getTimeseriesData(spaceId, environmentName, applicationId, maxSamples).pipe(
+      filter((t: TimeseriesData[]) => t && t.some((el: TimeseriesData) => has(el, 'net_tx')) && t.some((el: TimeseriesData) => has(el, 'net_rx'))),
+      map((t: TimeseriesData[]) =>
         t.map((s: TimeseriesData) =>
         ({
           sent: new ScaledNetStat(s.net_tx.value, s.net_tx.time),
           received: new ScaledNetStat(s.net_rx.value, s.net_rx.time)
         }))
-      )
-      .map((stats: NetworkStat[]): NetworkStat[] => {
+      ),
+      map((stats: NetworkStat[]): NetworkStat[] => {
         const greatestOrdinal: number = stats
           .map((stat: NetworkStat): [MemoryUnit, MemoryUnit] => [stat.sent.units, stat.received.units])
           .map((units: [MemoryUnit, MemoryUnit]): number => Math.max(ordinal(units[0]), ordinal(units[1])))
@@ -222,51 +250,60 @@ export class DeploymentsService implements OnDestroy {
             sent: ScaledNetStat.from(stat.sent, greatestUnit),
             received: ScaledNetStat.from(stat.received, greatestUnit)
           }));
-      });
+      })
+    );
   }
 
   getEnvironmentCpuStat(spaceId: string, environmentName: string): Observable<CpuStat> {
-    return this.getEnvironment(spaceId, environmentName)
-      .map((env: EnvironmentStat) => env.attributes.quota.cpucores);
+    return this.getEnvironment(spaceId, environmentName).pipe(
+      map((env: EnvironmentStat) => env.attributes.quota.cpucores)
+    );
   }
 
   getEnvironmentMemoryStat(spaceId: string, environmentName: string): Observable<MemoryStat> {
-    return this.getEnvironment(spaceId, environmentName)
-      .map((env: EnvironmentStat) => new ScaledMemoryStat(env.attributes.quota.memory.used, env.attributes.quota.memory.quota));
+    return this.getEnvironment(spaceId, environmentName).pipe(
+      map((env: EnvironmentStat) => new ScaledMemoryStat(env.attributes.quota.memory.used, env.attributes.quota.memory.quota))
+    );
   }
 
   getLogsUrl(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
-    return this.getDeployment(spaceId, environmentName, applicationId)
-      .map((deployment: Deployment) => deployment.links.logs);
+    return this.getDeployment(spaceId, environmentName, applicationId).pipe(
+      map((deployment: Deployment) => deployment.links.logs)
+    );
   }
 
   getConsoleUrl(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
-    return this.getDeployment(spaceId, environmentName, applicationId)
-      .map((deployment: Deployment) => deployment.links.console);
+    return this.getDeployment(spaceId, environmentName, applicationId).pipe(
+      map((deployment: Deployment) => deployment.links.console)
+    );
   }
 
   getAppUrl(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
-    return this.getDeployment(spaceId, environmentName, applicationId)
-      .map((deployment: Deployment) => deployment.links.application);
+    return this.getDeployment(spaceId, environmentName, applicationId).pipe(
+      map((deployment: Deployment) => deployment.links.application)
+    );
   }
 
   deleteDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<string> {
-    return this.apiService.deleteDeployment(spaceId, environmentName, applicationId)
-      .map(() => `Deployment has successfully deleted`)
-      .catch(err => Observable.throw(`Failed to delete ${applicationId} in ${spaceId} (${environmentName})`));
+    return this.apiService.deleteDeployment(spaceId, environmentName, applicationId).pipe(
+      map(() => `Deployment has successfully deleted`),
+      catchError(() => _throw(`Failed to delete ${applicationId} in ${spaceId} (${environmentName})`))
+    );
   }
 
   private getApplicationsResponse(spaceId: string): Observable<Application[]> {
     if (!this.appsObservables.has(spaceId)) {
       const subject = new ReplaySubject<Application[]>(1);
-      const observable = this.pollTimer
-        .concatMap(() =>
-          this.apiService.getApplications(spaceId)
-            .catch((err: Response) => {
-              let header: string = 'Cannot get applications';
+      const observable = this.pollTimer.pipe(
+        concatMap(() =>
+          this.apiService.getApplications(spaceId).pipe(
+            catchError((err: Response) => {
+              const header: string = 'Cannot get applications';
               return this.handleHttpError(header, err);
             })
-        );
+          )
+        )
+      );
       this.serviceSubscriptions.push(observable.subscribe(subject));
       this.appsObservables.set(spaceId, subject);
     }
@@ -275,29 +312,33 @@ export class DeploymentsService implements OnDestroy {
 
   private getApplication(spaceId: string, applicationId: string): Observable<Application> {
     // does not emit if there are no applications matching the specified name
-    return this.getApplicationsResponse(spaceId)
-      .flatMap((apps: Application[]) => apps || [])
-      .filter((app: Application) => app.attributes.name === applicationId);
+    return this.getApplicationsResponse(spaceId).pipe(
+      mergeMap((apps: Application[]) => apps || []),
+      filter((app: Application) => app.attributes.name === applicationId)
+    );
   }
 
   private getDeployment(spaceId: string, environmentName: string, applicationId: string): Observable<Deployment> {
     // does not emit if there are no applications or environments matching the specified names
-    return this.getApplication(spaceId, applicationId)
-      .flatMap((app: Application) => app.attributes.deployments || [])
-      .filter((deployment: Deployment) => deployment.attributes.name === environmentName);
+    return this.getApplication(spaceId, applicationId).pipe(
+      mergeMap((app: Application) => app.attributes.deployments || []),
+      filter((deployment: Deployment) => deployment.attributes.name === environmentName)
+    );
   }
 
   private getEnvironmentsResponse(spaceId: string): Observable<EnvironmentStat[]> {
     if (!this.envsObservables.has(spaceId)) {
       const subject = new ReplaySubject<EnvironmentStat[]>(1);
-      const observable = this.pollTimer
-        .concatMap(() =>
-          this.apiService.getEnvironments(spaceId)
-            .catch((err: Response) => {
-              let header: string = 'Cannot get environments';
+      const observable = this.pollTimer.pipe(
+        concatMap(() =>
+          this.apiService.getEnvironments(spaceId).pipe(
+            catchError((err: Response) => {
+              const header: string = 'Cannot get environments';
               return this.handleHttpError(header, err);
             })
-        );
+          )
+        )
+      );
       this.serviceSubscriptions.push(observable.subscribe(subject));
       this.envsObservables.set(spaceId, subject);
     }
@@ -306,9 +347,10 @@ export class DeploymentsService implements OnDestroy {
 
   private getEnvironment(spaceId: string, environmentName: string): Observable<EnvironmentStat> {
     // does not emit if there are no environments matching the specified name
-    return this.getEnvironmentsResponse(spaceId)
-      .flatMap((envs: EnvironmentStat[]) => envs || [])
-      .filter((env: EnvironmentStat) => env.attributes.name === environmentName);
+    return this.getEnvironmentsResponse(spaceId).pipe(
+      mergeMap((envs: EnvironmentStat[]) => envs || []),
+      filter((env: EnvironmentStat) => env.attributes.name === environmentName)
+    );
   }
 
   private getTimeseriesData(spaceId: string, environmentName: string, applicationId: string, maxSamples: number): Observable<TimeseriesData[]> {
@@ -317,64 +359,68 @@ export class DeploymentsService implements OnDestroy {
       const subject = new ReplaySubject<TimeseriesData[]>(this.timeseriesSamples);
 
       const now = +Date.now();
-      const seriesData = this.getStreamingTimeseriesData(spaceId, environmentName, applicationId, now - this.frontLoadWindowWidth, now)
-        .finally(() => {
+      const seriesData = this.getStreamingTimeseriesData(spaceId, environmentName, applicationId, now - this.frontLoadWindowWidth, now).pipe(
+        finalize(() => {
           this.timeseriesSubjects.delete(key);
-        })
-        .bufferCount(this.timeseriesSamples, 1);
+        }),
+        bufferCount(this.timeseriesSamples, 1)
+      );
 
       this.serviceSubscriptions.push(seriesData.subscribe(subject));
       this.timeseriesSubjects.set(key, subject);
     }
-    return this.timeseriesSubjects.get(key)
-      .map((data: TimeseriesData[]) => {
+    return this.timeseriesSubjects.get(key).pipe(
+      map((data: TimeseriesData[]) => {
         if (maxSamples >= data.length) {
           return data;
         }
         return data.slice(data.length - maxSamples);
-      });
+      })
+    );
   }
 
   private getStreamingTimeseriesData(spaceId: string, environmentName: string, applicationId: string, startTime: number, endTime: number): Observable<TimeseriesData> {
-    return Observable.combineLatest(
+    return combineLatest(
       this.isApplicationDeployedInEnvironment(spaceId, environmentName, applicationId),
-      this.getPods(spaceId, environmentName, applicationId).map((p: Pods): number => p.total),
-      this.pollTimer.startWith(null)
-    )
-      .startWith([false, 0, null])
-      .pairwise()
-      .concatMap((status: [[boolean, number, void], [boolean, number, void]]): Observable<TimeseriesData> => {
-        const prev: [boolean, number, void] = status[0];
-        const curr: [boolean, number, void] = status[1];
+      this.getPods(spaceId, environmentName, applicationId).pipe(map((p: Pods): number => p.total)),
+      this.pollTimer.pipe(startWith(null))
+    ).pipe(
+      startWith([false, 0, null]),
+      pairwise(),
+      concatMap((status: [(number | boolean)[], (number | boolean)[]]): Observable<TimeseriesData> => {
+        const prev: (number | boolean)[] = status[0];
+        const curr: (number | boolean)[] = status[1];
 
         const isDeployed: boolean = curr[0] && curr[1] > 0;
         const wasDeployed: boolean = prev[0] && prev[1] > 0;
 
         if (!isDeployed) {
-          return Observable.empty();
+          return empty();
         }
 
         if (!wasDeployed) {
           return this.getInitialTimeseriesData(spaceId, environmentName, applicationId, startTime, endTime);
         } else {
-          return this.apiService.getLatestTimeseriesData(spaceId, environmentName, applicationId)
-            .catch((err: Response) => {
-              let header: string = 'Cannot get latest application statistics';
+          return this.apiService.getLatestTimeseriesData(spaceId, environmentName, applicationId).pipe(
+            catchError((err: Response) => {
+              const header: string = 'Cannot get latest application statistics';
               return this.handleHttpError(header, err);
-            })
-            .filter((t: TimeseriesData) => !!t && !isEmpty(t));
+            }),
+            filter((t: TimeseriesData) => !!t && !isEmpty(t))
+          );
         }
-      });
+      })
+    );
   }
 
   private getInitialTimeseriesData(spaceId: string, environmentName: string,  applicationId: string, startTime: number, endTime: number): Observable<TimeseriesData> {
-    return this.apiService.getTimeseriesData(spaceId, environmentName, applicationId, startTime, endTime)
-      .catch((err: Response) => {
+    return this.apiService.getTimeseriesData(spaceId, environmentName, applicationId, startTime, endTime).pipe(
+      catchError((err: Response) => {
         let header: string = 'Cannot get initial application statistics';
         return this.handleHttpError(header, err);
-      })
-      .filter((t: MultiTimeseriesData) => !!t && !isEmpty(t))
-      .concatMap((t: MultiTimeseriesData) => {
+      }),
+      filter((t: MultiTimeseriesData) => !!t && !isEmpty(t)),
+      concatMap((t: MultiTimeseriesData) => {
         const results: TimeseriesData[] = [];
         const numSamples = t.cores.length;
         for (let i = 0; i < numSamples; i++) {
@@ -397,8 +443,9 @@ export class DeploymentsService implements OnDestroy {
             }
           });
         }
-        return Observable.from(results);
-      });
+        return from(results);
+      })
+    );
   }
 
   private handleHttpError(header: string, response: Response): Observable<any> {
@@ -424,6 +471,6 @@ export class DeploymentsService implements OnDestroy {
       header: header,
       message: message
     } as Notification);
-    return Observable.empty();
+    return empty();
   }
 }


### PR DESCRIPTION
These commits make Deployments-area code use the new RxJS `pipe` syntax and Observable factories such as `Observable.of() -> of()`, updating imports as needed.

https://openshift.io/openshiftio/Openshift_io/plan/detail/579