### PR TITLE
fix(pipelines): initialize sort with default value

### DIFF
--- a/src/app/space/create/pipelines/pipelines.component.spec.ts
+++ b/src/app/space/create/pipelines/pipelines.component.spec.ts
@@ -288,16 +288,9 @@ describe('PipelinesComponent', () => {
           space: 'space'
         }
       }]);
+
       this.testedDirective.filterChange({ appliedFilters: [] });
       expect(this.testedDirective.pipelines as any[]).toEqual([
-        {
-          id: 'app2',
-          name: 'app2',
-          gitUrl: 'https://example.com/app2.git',
-          labels: {
-            space: 'space'
-          }
-        },
         {
           id: 'app',
           name: 'app',
@@ -310,6 +303,14 @@ describe('PipelinesComponent', () => {
               buildNumber: 2
             }
           ],
+          labels: {
+            space: 'space'
+          }
+        },
+        {
+          id: 'app2',
+          name: 'app2',
+          gitUrl: 'https://example.com/app2.git',
           labels: {
             space: 'space'
           }

--- a/src/app/space/create/pipelines/pipelines.component.ts
+++ b/src/app/space/create/pipelines/pipelines.component.ts
@@ -45,7 +45,7 @@ export class PipelinesComponent implements OnInit, OnDestroy, AfterViewInit {
   private _filteredPipelines: BuildConfig[] = [];
   private _allPipelines: BuildConfig[] = [];
   private _appliedFilters: Filter[] = [];
-  private _ascending: boolean;
+  private _ascending: boolean = true;
   private _currentSortField: SortField = {
     id: 'application',
     title: 'Application',


### PR DESCRIPTION
This fixes the pipelines page to have a correct initial sort. The sorting code called at the start uses this immediately, but the initial state of the toolbar is ascending, not descending, so it would be in the wrong order.