### PR TITLE
Upgrade.compile.test

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -14,7 +14,7 @@ var fs = require('fs');
  * Webpack Plugins
  */
 const autoprefixer = require('autoprefixer');
-const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
+//const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
 const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
@@ -26,9 +26,7 @@ const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
 const ProvidePlugin = require('webpack/lib/ProvidePlugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
-const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
-// const TsConfigPathsPlugin = require('awesome-typescript-loader');
 
 /*
  * Webpack Constants
@@ -122,7 +120,7 @@ module.exports = function (options) {
             '@ngtools/webpack'
           ] : [
               '@angularclass/hmr-loader?pretty=' + !isProd + '&prod=' + isProd,
-              'awesome-typescript-loader',
+              'ts-loader',
               'angular2-template-loader',
               'angular2-router-loader'
             ],
@@ -378,7 +376,7 @@ module.exports = function (options) {
        *
        * See: https://github.com/s-panferov/awesome-typescript-loader#forkchecker-boolean-defaultfalse
        */
-      new CheckerPlugin(),
+      //new CheckerPlugin(),
 
 
       /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,6 +1621,16 @@
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
+      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -3835,8 +3845,8 @@
       "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.4",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.11",
         "meow": "4.0.1",
         "split2": "2.2.0",
@@ -9040,16 +9050,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
-      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsontoxml": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz",
@@ -11519,6 +11519,7 @@
       "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.4",
         "abbrev": "1.1.1",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
@@ -11558,7 +11559,6 @@
         "init-package-json": "1.10.3",
         "is-cidr": "2.0.6",
         "json-parse-better-errors": "1.0.2",
-        "JSONStream": "1.3.4",
         "lazy-property": "1.0.0",
         "libcipm": "2.0.2",
         "libnpmhook": "4.0.1",
@@ -11639,6 +11639,15 @@
         "write-file-atomic": "2.3.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
+        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
@@ -12813,15 +12822,6 @@
           "version": "1.3.1",
           "bundled": true,
           "dev": true
-        },
-        "JSONStream": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
         },
         "jsprim": {
           "version": "1.4.1",
@@ -14182,14 +14182,6 @@
           "bundled": true,
           "dev": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
@@ -14217,6 +14209,14 @@
                 "ansi-regex": "3.0.0"
               }
             }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
           }
         },
         "stringify-package": {
@@ -18483,14 +18483,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -18517,6 +18509,14 @@
       "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
       "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "stringify-entities": {
       "version": "1.3.2",

--- a/src/a-runtime-console/kubernetes/service/kubernetes.restangular.ts
+++ b/src/a-runtime-console/kubernetes/service/kubernetes.restangular.ts
@@ -1,5 +1,5 @@
 import { InjectionToken, NgModule } from '@angular/core';
-import { OAuthService } from 'angular2-oauth2/oauth-service';
+import { OAuthService } from 'angular-oauth2-oidc';
 import { Restangular } from 'ngx-restangular';
 import { LoginService } from '../../shared/login.service';
 import { OnLogin } from '../../shared/onlogin.service';

--- a/src/a-runtime-console/kubernetes/store/oauth-config-store.spec.ts
+++ b/src/a-runtime-console/kubernetes/store/oauth-config-store.spec.ts
@@ -9,7 +9,8 @@ import {
   User,
   UserService
 } from 'ngx-login-client';
-import { BehaviorSubject,
+import {
+  BehaviorSubject, ConnectableObservable,
   Observable,
   ReplaySubject,
   Subscription,
@@ -67,7 +68,7 @@ describe('OauthConfigStore', () => {
   describe('success state', () => {
     beforeEach(() => {
       mockUserService = createMock(UserService);
-      mockUserService.loggedInUser = new BehaviorSubject(user).pipe(multicast(() => new ReplaySubject(1)));
+      mockUserService.loggedInUser = new BehaviorSubject(user).pipe<User>(multicast(() => new ReplaySubject(1))) as ConnectableObservable<User>;
 
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
@@ -129,7 +130,7 @@ describe('OauthConfigStore', () => {
   describe('user service empty', () => {
     beforeEach(() => {
       mockUserService = createMock(UserService);
-      mockUserService.loggedInUser = new BehaviorSubject({} as User).pipe(multicast(() => new ReplaySubject(1)));
+      mockUserService.loggedInUser = new BehaviorSubject({} as User).pipe<User>(multicast(() => new ReplaySubject(1))) as ConnectableObservable<User>;
 
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
@@ -195,7 +196,7 @@ describe('OauthConfigStore', () => {
       scheduler = new VirtualTimeScheduler(VirtualAction);
 
       mockUserService = createMock(UserService);
-      mockUserService.loggedInUser = observableThrowError({error : 'error'}, scheduler).pipe(multicast(() => new ReplaySubject(1)));
+      mockUserService.loggedInUser = observableThrowError({error : 'error'}, scheduler).pipe<User>(multicast(() => new ReplaySubject(1))) as ConnectableObservable<User>;
 
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
@@ -249,7 +250,7 @@ describe('OauthConfigStore', () => {
   describe('config request error', () => {
     beforeEach(() => {
       mockUserService = createMock(UserService);
-      mockUserService.loggedInUser = new BehaviorSubject(user).pipe(multicast(() => new ReplaySubject(1)));
+      mockUserService.loggedInUser = new BehaviorSubject(user).pipe<User>(multicast(() => new ReplaySubject(1))) as ConnectableObservable<User>;
 
       TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],

--- a/src/a-runtime-console/kubernetes/support/abstract-watch.component.ts
+++ b/src/a-runtime-console/kubernetes/support/abstract-watch.component.ts
@@ -263,7 +263,7 @@ export class CachingSubject<T> extends Subject<T> {
   }
 
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     if (this._hasValue) {
       subscriber.next(this._value);
     }

--- a/src/app/base/config.store.ts
+++ b/src/app/base/config.store.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import {ConnectableObservable, Observable} from 'rxjs';
 import { map, publishReplay } from 'rxjs/operators';
 import { ValWrapper } from './val-wrapper';
 
@@ -30,7 +30,7 @@ export class ConfigStore {
             loading: false
           } as ValWrapper<T>;
         }),
-        publishReplay(1));
+        publishReplay(1)) as ConnectableObservable<ValWrapper<T>>;
       this._cache.set(name, res);
       res.connect();
       return res;

--- a/src/app/base/config.store.ts
+++ b/src/app/base/config.store.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import {ConnectableObservable, Observable} from 'rxjs';
+import { ConnectableObservable, Observable } from 'rxjs';
 import { map, publishReplay } from 'rxjs/operators';
 import { ValWrapper } from './val-wrapper';
 

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.ts
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.ts
@@ -7,6 +7,7 @@ import {
   BuildConfigs
 } from '../../../a-runtime-console/index';
 import { PipelinesService } from '../../shared/runtime-console/pipelines.service';
+import {ConnectableObservable} from "rxjs";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -44,7 +45,7 @@ export class AnalyticalReportWidgetComponent implements OnInit {
 
   ngOnInit() {
     let bcs = this.pipelinesService.current.pipe(
-      publish());
+      publish()) as ConnectableObservable<BuildConfig[]>;
     this.buildConfigs = bcs;
 
     this.buildConfigs.subscribe((data) => {

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.ts
@@ -42,7 +42,7 @@ export class CreateWorkItemWidgetComponent implements OnInit {
       tap(workItems => workItems.forEach(workItem => this.workItemService.resolveAreaForWorkItem(workItem))),
       // MUST DO creator after area due to bug in planner
       tap(workItems => workItems.forEach(workItem => this.workItemService.resolveCreator(workItem))),
-      publishReplay(1));
+      publishReplay(1)) as ConnectableObservable<WorkItem[]>;
     this._myWorkItems.connect();
     this.myWorkItemsCount = this._myWorkItems.pipe(map(workItems => workItems.length));
   }

--- a/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Notification, Notifications, NotificationType } from 'ngx-base';
-import { Space, Spaces } from 'ngx-fabric8-wit';
-import { RelationalData, SpaceAttributes, SpaceLink, SpaceRelationships } from 'ngx-fabric8-wit/src/app/models/space';
-import { Team } from 'ngx-fabric8-wit/src/app/models/team';
+import { Space, Spaces, Team } from 'ngx-fabric8-wit';
+import { RelationalData, SpaceAttributes, SpaceLink, SpaceRelationships } from 'ngx-fabric8-wit';
 import { forkJoin as observableForkJoin, of as observableOf } from 'rxjs';
 import { catchError, map, mergeMap, switchMap, tap } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs/Rx';
@@ -24,8 +23,8 @@ export class ExtSpace implements Space {
   name: string;
   path: String;
   privateSpace?: boolean;
-  //teams: Team[];
-  //defaultTeam: Team;
+  teams: Team[];
+  defaultTeam: Team;
   id: string;
   attributes: SpaceAttributes;
   type: string;

--- a/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-workspaces-widget/recent-workspaces-widget.component.ts
@@ -24,8 +24,8 @@ export class ExtSpace implements Space {
   name: string;
   path: String;
   privateSpace?: boolean;
-  teams: Team[];
-  defaultTeam: Team;
+  //teams: Team[];
+  //defaultTeam: Team;
   id: string;
   attributes: SpaceAttributes;
   type: string;

--- a/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
+++ b/src/app/dashboard-widgets/work-item-widget/work-item-widget.component.ts
@@ -104,7 +104,7 @@ export class WorkItemWidgetComponent implements OnInit {
         });
         this.initChartData();
       }),
-      publishReplay(1));
+      publishReplay(1)) as ConnectableObservable<WorkItem[]>;
     this._myWorkItems.connect();
   }
 

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -23,6 +23,7 @@ if ('production' === ENV) {
   used in `ngx-launcher` to broadcast events for telemetry */
   _decorateModuleRef = (modRef: any) => {
     StaticInjector.setInjector(modRef.injector);
+    return modRef;
   };
 
   PROVIDERS = [

--- a/src/app/getting-started/services/getting-started.service.ts
+++ b/src/app/getting-started/services/getting-started.service.ts
@@ -8,7 +8,7 @@ import { cloneDeep } from 'lodash';
 import { Logger } from 'ngx-base';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService, Profile, User, UserService } from 'ngx-login-client';
-import { Observable,  Subscription, throwError as observableThrowError } from 'rxjs';
+import {ConnectableObservable, Observable, Subscription, throwError as observableThrowError} from 'rxjs';
 import { catchError, map, publish } from 'rxjs/operators';
 
 interface ExtUserResponse {
@@ -52,14 +52,14 @@ export class GettingStartedService implements OnDestroy {
   createTransientProfile(): ExtProfile {
     let profile: ExtUser;
 
-    this.userService.loggedInUser.pipe(
+    (this.userService.loggedInUser.pipe(
       map((user: User): void => {
         profile = cloneDeep(user) as ExtUser;
         if (profile.attributes !== undefined) {
           profile.attributes.contextInformation = (user as ExtUser).attributes.contextInformation || {};
         }
       }),
-      publish()).connect();
+      publish()) as ConnectableObservable<User>).connect();
 
     return (profile !== undefined && profile.attributes !== undefined) ? profile.attributes : {} as ExtProfile;
   }

--- a/src/app/getting-started/services/getting-started.service.ts
+++ b/src/app/getting-started/services/getting-started.service.ts
@@ -8,7 +8,7 @@ import { cloneDeep } from 'lodash';
 import { Logger } from 'ngx-base';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService, Profile, User, UserService } from 'ngx-login-client';
-import {ConnectableObservable, Observable, Subscription, throwError as observableThrowError} from 'rxjs';
+import { ConnectableObservable, Observable, Subscription, throwError as observableThrowError } from 'rxjs';
 import { catchError, map, publish } from 'rxjs/operators';
 
 interface ExtUserResponse {

--- a/src/app/home/work-item-widget/work-item-widget.component.ts
+++ b/src/app/home/work-item-widget/work-item-widget.component.ts
@@ -96,7 +96,7 @@ export class WorkItemWidgetComponent implements OnDestroy, OnInit  {
         });
       }),
       tap(() => this.loading = false))
-      .subscribe(workItems => {
+      .subscribe((workItems: WorkItem[]) => {
         this.workItems = workItems;
         this.selectRecentSpace(workItems);
       }));

--- a/src/app/profile/profile.service.ts
+++ b/src/app/profile/profile.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable } from '@angular/core';
 import { cloneDeep } from 'lodash';
 import { Notification, Notifications, NotificationType } from 'ngx-base';
 import { AUTH_API_URL, AuthenticationService, Profile, User, UserService } from 'ngx-login-client';
-import { ConnectableObservable, empty as observableEmpty, Observable } from 'rxjs';
+import { ConnectableObservable, EMPTY, Observable } from 'rxjs';
 import { catchError, map, publishReplay, skipWhile, tap } from 'rxjs/operators';
 
 export class ExtUser extends User {
@@ -50,7 +50,7 @@ export class ProfileService {
         }
       }),
       map(user => user.attributes),
-      publishReplay(1));
+      publishReplay(1)) as ConnectableObservable<ExtProfile> ;
     this._profile.connect();
   }
 
@@ -69,7 +69,7 @@ export class ProfileService {
           type: NotificationType.DANGER
         } as Notification);
         console.log('Error updating user profile', error);
-        return observableEmpty();
+        return EMPTY;
       }));
   }
 

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.spec.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.spec.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2/dist/index';
+import { JwBootstrapSwitchNg2Module } from 'jw-bootstrap-switch-ng2/dist/index';
 import { Notifications, NotificationType } from 'ngx-base';
 import { Feature, FeatureTogglesService } from 'ngx-feature-flag';
 import { UserService } from 'ngx-login-client';
@@ -50,7 +50,7 @@ describe('FeatureOptInComponent', () => {
       CommonModule,
       FormsModule,
       ListModule,
-      JWBootstrapSwitchModule
+      JwBootstrapSwitchNg2Module
     ],
     providers: [
       { provide: GettingStartedService, useFactory: (): jasmine.SpyObj<GettingStartedService> => {

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.ts
@@ -155,12 +155,12 @@ export class FeatureOptInComponent implements OnInit, OnDestroy {
     this.toggleServiceAck.setToggle(event.currentValue);
   }
 
-  featureByLevel(features: Feature[]): any {
+  featureByLevel(features: {} | Feature[]): any {
     let released: Feature[] = [];
     let internal: Feature[] = [];
     let experimental: Feature[] = [];
     let beta: Feature[] = [];
-    for (let feature of features) {
+    for (let feature of features as Feature[]) {
       feature.attributes.name = feature.id.replace('.', ' ');
       switch (feature.attributes['enablement-level']) {
         case 'released': {

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.module.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
+import { JwBootstrapSwitchNg2Module } from 'jw-bootstrap-switch-ng2';
 import { ListModule } from 'patternfly-ng';
 import { FeatureOptInRoutingModule } from './feature-opt-in-routing.module';
 import { FeatureOptInComponent } from './feature-opt-in.component';
@@ -14,7 +14,7 @@ import { FeatureOptInComponent } from './feature-opt-in.component';
     FormsModule,
     FeatureOptInRoutingModule,
     ListModule,
-    JWBootstrapSwitchModule
+    JwBootstrapSwitchNg2Module
   ],
   declarations: [FeatureOptInComponent],
   exports: [FeatureOptInComponent]

--- a/src/app/profile/tenant/tenant.module.ts
+++ b/src/app/profile/tenant/tenant.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
+import { JwBootstrapSwitchNg2Module } from 'jw-bootstrap-switch-ng2';
 import { RemainingCharsCountModule } from 'patternfly-ng/remaining-chars-count';
 import { TenantRoutingModule } from './tenant-routing.module';
 import { TenantComponent } from './tenant.component';
@@ -10,7 +10,7 @@ import { TenantComponent } from './tenant.component';
   imports: [
     CommonModule,
     FormsModule,
-    JWBootstrapSwitchModule,
+    JwBootstrapSwitchNg2Module,
     RemainingCharsCountModule,
     TenantRoutingModule
   ],

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -6,7 +6,6 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import { Response } from '@angular/http';
 import { Router } from '@angular/router';
 import { Notification, Notifications, NotificationType } from 'ngx-base';
 import { Context, Contexts } from 'ngx-fabric8-wit';

--- a/src/app/profile/update/update.module.ts
+++ b/src/app/profile/update/update.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
+import { JwBootstrapSwitchNg2Module } from 'jw-bootstrap-switch-ng2';
 import { RemainingCharsCountModule } from 'patternfly-ng/remaining-chars-count';
 import { OwnerGuard } from '../../shared/owner-guard.service';
 import { SpacesModule } from '../overview/spaces/overview-spaces.module';
@@ -13,7 +13,7 @@ import { UpdateComponent } from './update.component';
   imports: [
     CommonModule,
     FormsModule,
-    JWBootstrapSwitchModule,
+    JwBootstrapSwitchNg2Module,
     RemainingCharsCountModule,
     UpdateRoutingModule,
     SpacesModule,

--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -11,7 +11,18 @@ import {
 } from 'ngx-fabric8-wit';
 import { FeatureTogglesService } from 'ngx-feature-flag';
 import { User, UserService } from 'ngx-login-client';
-import { ConnectableObservable, empty as observableEmpty,  forkJoin, merge ,  Observable ,  of ,  ReplaySubject ,  Scheduler ,  Subject ,  throwError as observableThrowError } from 'rxjs';
+import {
+  asapScheduler,
+  ConnectableObservable,
+  EMPTY,
+  forkJoin,
+  merge,
+  Observable,
+  of,
+  ReplaySubject,
+  Subject,
+  throwError as observableThrowError
+} from 'rxjs';
 import { catchError,
   distinctUntilChanged,
   distinctUntilKeyChanged,
@@ -311,7 +322,7 @@ export class ContextService implements Contexts {
 
   private loadUser(userName: string): Observable<User> {
     if (this.checkForReservedWords(userName)) {
-      return observableThrowError(new Error(`User name ${userName} contains reserved characters.`), Scheduler.asap);
+      return observableThrowError(new Error(`User name ${userName} contains reserved characters.`), asapScheduler);
     }
     return this.userService
       .getUserByUsername(userName)
@@ -349,9 +360,9 @@ export class ContextService implements Contexts {
 
   private loadSpace(userName: string, spaceName: string): Observable<Space> {
     if (this.checkForReservedWords(userName)) {
-      return observableThrowError(new Error(`User name ${userName} contains reserved characters.`), Scheduler.asap);
+      return observableThrowError(new Error(`User name ${userName} contains reserved characters.`), asapScheduler);
     } else if (this.checkForReservedWords(spaceName)) {
-      return observableThrowError(new Error(`Space name ${spaceName} contains reserved characters.`), Scheduler.asap);
+      return observableThrowError(new Error(`Space name ${spaceName} contains reserved characters.`), asapScheduler);
     }
 
     if (userName && spaceName) {
@@ -393,7 +404,7 @@ export class ContextService implements Contexts {
                 .pipe(
                   catchError(err => {
                     console.log('Unable to restore recent context', err);
-                    return observableEmpty<Context>();
+                    return EMPTY;
                   }),
                   map(val => {
                     return this.buildContext({ user: val } as RawContext);

--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -116,7 +116,7 @@ export class ContextService implements Contexts {
             return {} as Context;
           }
         })
-      ).pipe(multicast(() => new ReplaySubject(1)));
+      ).pipe(multicast(() => new ReplaySubject(1))) as ConnectableObservable<Context>;
 
     // Create the recent space list
     this._recent = merge(this._addRecent, this._deleteFromRecent).pipe(
@@ -136,7 +136,7 @@ export class ContextService implements Contexts {
       tap(val => {
         this.saveRecent(val);
       })
-    ).pipe(multicast(() => new ReplaySubject(1)));
+    ).pipe(multicast(() => new ReplaySubject(1))) as ConnectableObservable<Context[]>;
     // Finally, start broadcasting
     this._default.connect();
     this._recent.connect();
@@ -258,7 +258,7 @@ export class ContextService implements Contexts {
       tap(val => {
         this._current.next(val);
       })
-    ).pipe(multicast(() => new Subject()));
+    ).pipe(multicast(() => new Subject())) as ConnectableObservable<Context>;
     res.connect();
     return res;
   }

--- a/src/app/shared/interceptors/cache.interceptor.ts
+++ b/src/app/shared/interceptors/cache.interceptor.ts
@@ -6,8 +6,9 @@ import {
   HttpResponse
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { AsyncSubject, Observable, Scheduler } from 'rxjs';
+import { AsyncSubject, Observable } from 'rxjs';
 import { subscribeOn } from 'rxjs/operators';
+import { async } from 'rxjs/scheduler/async';
 import { RequestCache } from '../request-cache.service';
 
 /**
@@ -36,7 +37,7 @@ export class CacheInterceptor implements HttpInterceptor {
         next.handle(req).subscribe(asyncResponse);
       }
 
-      return asyncResponse.pipe(subscribeOn(Scheduler.async)).subscribe(observer);
+      return asyncResponse.pipe(subscribeOn(async)).subscribe(observer);
     });
   }
 }

--- a/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/space/analyze/analyze-overview/analyze-overview.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Broadcaster } from 'ngx-base';
 import { Context, Contexts, Space } from 'ngx-fabric8-wit';
-import { FeatureTogglesService } from 'ngx-feature-flag';
+import { Feature, FeatureTogglesService } from 'ngx-feature-flag';
 import { AuthenticationService, User, UserService } from 'ngx-login-client';
 import { Subscription } from 'rxjs';
 
@@ -36,7 +36,7 @@ export class AnalyzeOverviewComponent implements OnInit, OnDestroy {
       this.loggedInUser = user;
     }));
 
-    this.subscriptions.push(this.featureTogglesService.getFeature('Analyze.MyWorkItemsCard').subscribe((feature) => {
+    this.subscriptions.push(this.featureTogglesService.getFeature('Analyze.MyWorkItemsCard').subscribe((feature: Feature) => {
       if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
         this._myWorkItemsCard = true;
       }

--- a/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/space/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -2,8 +2,9 @@ import { Component, Input, OnDestroy, OnInit, ViewChild, ViewEncapsulation } fro
 import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { Dialog } from 'ngx-widgets';
-import { Observable, of as observableOf,  Subscription } from 'rxjs';
+import { EMPTY, Observable, of as observableOf, Subscription } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
+import { Che } from '../services/che';
 import { CheService } from '../services/che.service';
 import { Codebase } from '../services/codebase';
 import { CodebasesService } from '../services/codebases.service';
@@ -50,7 +51,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
    */
   createWorkspace(): void {
     this.workspaceBusy = true;
-    this.subscriptions.push(this.cheService.getState().pipe(switchMap(che => {
+    this.subscriptions.push(this.cheService.getState().pipe(switchMap((che: Che, index: number) => {
       if (!che.clusterFull) {
         // create
         return this.workspacesService
@@ -83,7 +84,7 @@ export class CodebasesItemActionsComponent implements OnDestroy, OnInit {
           message: `OpenShift Online cluster is currently out of capacity, workspace cannot be started.`,
           type: NotificationType.DANGER
         } as Notification);
-        return observableOf({});
+        return EMPTY;
       }
     })).subscribe(() => {},
         err => {

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
@@ -1,8 +1,15 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
-import { ConnectableObservable, Observable, of as observableOf, Subscription, timer as observableTimer } from 'rxjs';
+import {
+  ConnectableObservable,
+  EMPTY,
+  Observable,
+  Subscription,
+  timer as observableTimer
+} from 'rxjs';
 import { map, publish, switchMap, take } from 'rxjs/operators';
 import { WindowService } from '../../../../shared/window.service';
+import { Che } from '../services/che';
 import { CheService } from '../services/che.service';
 import { Codebase } from '../services/codebase';
 import { Workspace } from '../services/workspace';
@@ -70,7 +77,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
    */
   createWorkspace(): void {
     this.workspaceBusy = true;
-    this.subscriptions.push(this.cheService.getState().pipe(switchMap(che => {
+    this.subscriptions.push(this.cheService.getState().pipe(switchMap((che: Che, index: number) => {
       if (!che.clusterFull) {
         // create
         return this.workspacesService
@@ -101,7 +108,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
           message: `OpenShift Online cluster is currently out of capacity, workspace cannot be started.`,
           type: NotificationType.DANGER
         } as Notification);
-        return observableOf({});
+        return EMPTY;
       }
     })).subscribe(() => {},
       err => {
@@ -125,7 +132,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
   openWorkspace(): void {
     let workspaceWindow = this.windowService.open('about:blank', '_blank');
     this.workspaceBusy = true;
-    this.subscriptions.push(this.cheService.getState().pipe(switchMap(che => {
+    this.subscriptions.push(this.cheService.getState().pipe(switchMap((che: Che, index: number) => {
       if (!che.clusterFull) {
         // create
         return this.workspacesService.openWorkspace(this.workspaceUrl).pipe(map(workspaceLinks => {
@@ -142,7 +149,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
           message: `OpenShift Online cluster is currently out of capacity, workspace cannot be started.`,
           type: NotificationType.DANGER
         } as Notification);
-        return observableOf({});
+        return EMPTY;
       }
     })).subscribe(() => {},
       err => {

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
-import { Observable, of as observableOf,  Subscription, timer as observableTimer } from 'rxjs';
+import {ConnectableObservable, Observable, of as observableOf, Subscription, timer as observableTimer} from 'rxjs';
 import { map, publish, switchMap, take } from 'rxjs/operators';
 import { WindowService } from '../../../../shared/window.service';
 import { CheService } from '../services/che.service';
@@ -225,7 +225,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
       this.workspacePollSubscription.unsubscribe();
     }
     this.workspacePollTimer = observableTimer(2000, 20000).pipe(take(30));
-    this.workspacePollSubscription = this.workspacePollTimer.pipe(
+    this.workspacePollSubscription = (this.workspacePollTimer.pipe(
       switchMap(() => this.workspacesService.getWorkspaces(this.codebase.id)),
       map(workspaces => {
         if (workspaces != undefined && workspaces.length > 0
@@ -236,8 +236,7 @@ export class CodebasesItemWorkspacesComponent implements OnDestroy, OnInit {
           this.setWorkspaceUrl(name);
         }
       }),
-      publish())
-      .connect();
+      publish()) as ConnectableObservable<number>).connect();
     this.subscriptions.push(this.workspacePollSubscription);
   }
 

--- a/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
+++ b/src/app/space/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Broadcaster, Notification, Notifications, NotificationType } from 'ngx-base';
-import {ConnectableObservable, Observable, of as observableOf, Subscription, timer as observableTimer} from 'rxjs';
+import { ConnectableObservable, Observable, of as observableOf, Subscription, timer as observableTimer } from 'rxjs';
 import { map, publish, switchMap, take } from 'rxjs/operators';
 import { WindowService } from '../../../../shared/window.service';
 import { CheService } from '../services/che.service';

--- a/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2/dist/index';
+import { JwBootstrapSwitchNg2Module } from 'jw-bootstrap-switch-ng2';
 import { Broadcaster, Notifications } from 'ngx-base';
 import { Observable, of as observableOf } from 'rxjs';
 import { CodebasesService } from '../services/codebases.service';
@@ -20,7 +20,7 @@ describe('Codebases Item Component', () => {
     mockCodebasesService = jasmine.createSpy('CodebasesService');
 
     TestBed.configureTestingModule({
-      imports: [FormsModule, JWBootstrapSwitchModule],
+      imports: [FormsModule, JwBootstrapSwitchNg2Module],
       declarations: [CodebasesItemComponent],
       providers: [
         { provide: Notifications, useValue: mockNotifications },

--- a/src/app/space/create/codebases/codebases-item/codebases-item.module.ts
+++ b/src/app/space/create/codebases/codebases-item/codebases-item.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { JWBootstrapSwitchModule } from 'jw-bootstrap-switch-ng2';
+import { JwBootstrapSwitchNg2Module } from 'jw-bootstrap-switch-ng2';
 import { CodebasesItemWorkspacesModule } from '../codebases-item-workspaces/codebases-item-workspaces.module';
 import { CodebasesServicesModule } from '../services/codebases-services.module';
 import { CodebasesItemComponent } from './codebases-item.component';
@@ -12,7 +12,7 @@ import { CodebasesItemComponent } from './codebases-item.component';
     CodebasesItemWorkspacesModule,
     CommonModule,
     FormsModule,
-    JWBootstrapSwitchModule
+    JwBootstrapSwitchNg2Module
   ],
   declarations: [ CodebasesItemComponent ],
   exports: [ CodebasesItemComponent ]

--- a/src/app/space/create/codebases/codebases.component.ts
+++ b/src/app/space/create/codebases/codebases.component.ts
@@ -11,6 +11,7 @@ import { Filter, FilterEvent } from 'patternfly-ng/filter';
 import { ListConfig } from 'patternfly-ng/list';
 import { SortEvent, SortField } from 'patternfly-ng/sort';
 import {
+  ConnectableObservable,
   forkJoin as observableForkJoin,
   Observable,
   of as observableOf,
@@ -257,7 +258,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
       this.chePollSubscription.unsubscribe();
     }
     this.chePollTimer = observableTimer(2000, 20000).pipe(take(30));
-    this.chePollSubscription = this.chePollTimer.pipe(
+    this.chePollSubscription = (this.chePollTimer.pipe(
       switchMap(() => this.cheService.getState()),
       map(che => {
         if (che !== undefined && che.running === true) {
@@ -265,8 +266,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
           this.cheState = che;
         }
       }),
-      publish())
-      .connect();
+      publish()) as ConnectableObservable<any>).connect();
     this.subscriptions.push(this.chePollSubscription);
   }
 


### PR DESCRIPTION
List of fixes:
- TS2322: Type 'Observable<any>' is not assignable to type 'ConnectableObservable<User>'
https://stackoverflow.com/questions/50166366/multicast-operator-with-pipe-in-rxjs-5-5/50166414#50166414
Removed     "angular2-oauth2": “1.3.10” is replaced by "angular-oauth2-oidc": “4.0.3", therefore new import: `import { OAuthService } from angular-oauth2-oidc`;
- TS2415: Class 'CachingSubject<T>' incorrectly extends base class 'Subject<T>'.
  Property '_subscribe' is protected in type 'CachingSubject<T>' but public in type ‘Subject<T>'.
=> remove protected
- TS2339: Property 'connect' does not exist on type ‘Observable<ValWrapper<T>>'. See https://github.com/ReactiveX/rxjs/issues/2972 => fixed it by casting return type of publish: publishReplay(1)) as ConnectableObservable<ValWrapper<T>>
- and some typing issue.

Now running `npm run test:unit` gives:
```
➜  fabric8-ui git:(upgrade.compile.test) ✗ npm run test:unit

> fabric8-ui@0.0.0-development test:unit /Users/corinne/workspace/devtools/fabric8-ui
> karma start


START:
⚠ ｢wdm｣: 
ℹ ｢wdm｣: Compiled with warnings.
14 09 2018 14:05:50.912:INFO [karma]: Karma v3.0.0 server started at http://0.0.0.0:9876/
14 09 2018 14:05:50.914:INFO [launcher]: Launching browser ChromeHeadlessNoSandbox with unlimited concurrency
14 09 2018 14:05:50.939:INFO [launcher]: Starting browser ChromeHeadless
14 09 2018 14:05:52.261:INFO [HeadlessChrome 0.0.0 (Mac OS X 10.13.6)]: Connected on socket bIpiLGpPUKlEJHlgAAAA with id 77384666
HeadlessChrome 0.0.0 (Mac OS X 10.13.6) ERROR
  {
    "message": "An error was thrown in afterAll\nUncaught Error: Module build failed (from ./node_modules/ts-loader/index.js):\nError: Typescript emitted no output for /Users/corinne/workspace/devtools/fabric8-ui/src/a-runtime-console/common/loading/loading.component.spec.ts.\n    at successLoader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:41:15)\n    at Object.loader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:21:12)",
    "str": "An error was thrown in afterAll\nUncaught Error: Module build failed (from ./node_modules/ts-loader/index.js):\nError: Typescript emitted no output for /Users/corinne/workspace/devtools/fabric8-ui/src/a-runtime-console/common/loading/loading.component.spec.ts.\n    at successLoader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:41:15)\n    at Object.loader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:21:12)"
  }
HeadlessChrome 0.0.0 (Mac OS X 10.13.6) ERROR
  {
    "message": "An error was thrown in afterAll\nUncaught Error: Module build failed (from ./node_modules/ts-loader/index.js):\nError: Typescript emitted no output for /Users/corinne/workspace/devtools/fabric8-ui/src/a-runtime-console/common/loading/loading.component.spec.ts.\n    at successLoader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:41:15)\n    at Object.loader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:21:12)",
    "str": "An error was thrown in afterAll\nUncaught Error: Module build failed (from ./node_modules/ts-loader/index.js):\nError: Typescript emitted no output for /Users/corinne/workspace/devtools/fabric8-ui/src/a-runtime-console/common/loading/loading.component.spec.ts.\n    at successLoader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:41:15)\n    at Object.loader (/Users/corinne/workspace/devtools/fabric8-ui/node_modules/ts-loader/dist/index.js:21:12)"
  }
14 09 2018 14:05:55.381:WARN [karma]: Test suite was empty.

Finished in 0.002 secs / 0 secs @ 14:05:55 GMT+0200 (CEST)

SUMMARY:
✔ 0 tests completed

=============================== Coverage summary ===============================
Statements   : 100% ( 0/0 )
Branches     : 100% ( 0/0 )
Functions    : 100% ( 0/0 )
Lines        : 100% ( 0/0 )
================================================================================
```