### PR TITLE
fix(app-launcher): fix github linking due to extra headers

### DIFF
--- a/src/app/space/app-launcher/services/app-launcher-gitprovider.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-gitprovider.service.spec.ts
@@ -9,8 +9,9 @@ import { NewForgeConfig } from '../shared/new-forge.config';
 import { AppLauncherGitproviderService } from './app-launcher-gitprovider.service';
 
 import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@angular/common/http/testing';
-import { AUTH_API_URL, AuthenticationService } from 'ngx-login-client';
+import { AuthenticationService } from 'ngx-login-client';
 import { createMock } from 'testing/mock';
+import { ProviderService } from '../../../shared/account/provider.service';
 
 
 describe('Service: AppLauncherGitproviderService', () => {
@@ -32,6 +33,7 @@ describe('Service: AppLauncherGitproviderService', () => {
   let repos = ['fabric8-ui', 'fabric-uxd'];
 
   beforeEach(() => {
+    const mockProviderService = jasmine.createSpy('ProviderService');
     const mockAuthenticationService: jasmine.SpyObj<AuthenticationService> = createMock(AuthenticationService);
     mockAuthenticationService.getToken.and.returnValue('mock-token');
     const mockHelperService: jasmine.SpyObj<HelperService> = createMock(HelperService);
@@ -41,11 +43,11 @@ describe('Service: AppLauncherGitproviderService', () => {
       imports: [HttpClientTestingModule],
       providers: [
         AppLauncherGitproviderService,
+        { provide: ProviderService, useValue: mockProviderService },
         { provide: HelperService, useValue: mockHelperService },
         { provide: AuthenticationService, useValue: mockAuthenticationService },
         { provide: Config, useClass: NewForgeConfig},
-        { provide: FABRIC8_FORGE_API_URL, useValue: 'http://example.com' },
-        { provide: AUTH_API_URL, useValue: 'http://auth.example.com' }
+        { provide: FABRIC8_FORGE_API_URL, useValue: 'http://example.com' }
       ]
     });
     service = TestBed.get(AppLauncherGitproviderService);

--- a/src/app/space/app-launcher/services/app-launcher-gitprovider.service.ts
+++ b/src/app/space/app-launcher/services/app-launcher-gitprovider.service.ts
@@ -1,8 +1,10 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { GitHubDetails, GitProviderService, HelperService } from 'ngx-launcher';
-import { AUTH_API_URL, AuthenticationService } from 'ngx-login-client';
+import { AuthenticationService } from 'ngx-login-client';
+
+import { ProviderService } from '../../../shared/account/provider.service';
 
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 
@@ -13,7 +15,6 @@ export class AppLauncherGitproviderService implements GitProviderService {
     private API_BASE: string = 'services/git/';
     private ORIGIN: string = '';
     private PROVIDER: string = 'GitHub';
-    private linkUrl: string;
     private gitHubUserLogin: string;
     private headers: HttpHeaders = new HttpHeaders({
       'Content-Type': 'application/json',
@@ -26,12 +27,11 @@ export class AppLauncherGitproviderService implements GitProviderService {
       private http: HttpClient,
       private auth: AuthenticationService,
       private helperService: HelperService,
-      @Inject(AUTH_API_URL) authApiUrl: string
+      private providerService: ProviderService
     ) {
       if (this.helperService) {
         this.END_POINT = this.helperService.getBackendUrl();
         this.ORIGIN = this.helperService.getOrigin();
-        this.linkUrl = authApiUrl + 'token/link';
       }
       if (this.auth.getToken() != null) {
         this.headers = this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
@@ -39,32 +39,12 @@ export class AppLauncherGitproviderService implements GitProviderService {
     }
 
   /**
-   * Link an Identity Provider account to the user account
-   *
-   * @param provider Identity Provider name to link to the user's account
-   * @param redirect URL to be redirected to after successful account linking
-   */
-  link(provider: string, redirect: string): void {
-    let linkURL = this.linkUrl + '?for=' + provider + '&redirect=' +  encodeURIComponent(redirect) ;
-    this.http
-      .get(linkURL, { headers: this.headers })
-      .map((resp: HttpResponse<any>) => {
-        let redirectInfo = resp as any;
-        this.redirectToAuth(redirectInfo.redirect_location);
-      })
-      .catch((error: HttpErrorResponse) => {
-        return this.handleError(error);
-      })
-      .subscribe();
-  }
-
-  /**
    * Connect GitHub account
    *
    * @param {string} redirectUrl The GitHub redirect URL
    */
   connectGitHubAccount(redirectUrl: string): void {
-    this.link('https://github.com', redirectUrl);
+    this.providerService.link('https://github.com', redirectUrl);
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4333
Fixes https://github.com/fabric8-services/fabric8-auth/issues/653

- Due to extra headers being added in github linking request, the request was failing in CORS preflight request.
- Uses `ProviderService` for linking github account instead of custom implementation.