### PR TITLE
fix(webpack): fix errors with loading css due to extract text plugin

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -79,7 +79,12 @@ module.exports = function (options) {
       'vendor': './src/vendor.browser.ts',
       'polyfills': './src/polyfills.browser.ts',
       // 'main': aotMode ? './src/main.browser.aot.ts' : './src/main.browser.ts'
-      'main': './src/main.browser.ts'
+      'main': [
+        './src/main.browser.ts',
+        // workaround for https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/456
+        'style-loader/lib/addStyles',
+        'css-loader/lib/css-base',
+      ]
     },
 
     /*


### PR DESCRIPTION
After fixing the space-name directive errors, runtime errors related to css were showing up.
Tracked down an issue with extract text plugin and webpack 4. Implemented their fix.

We should probably revisit the extract text plugin but for now this gets us one step closer.