### PR TITLE
feat(settings): show openshift cluster url in connected account section

### DIFF
--- a/src/app/profile/services/tenant.service.spec.ts
+++ b/src/app/profile/services/tenant.service.spec.ts
@@ -36,6 +36,45 @@ describe('TenantService', () => {
     controller = TestBed.get(HttpTestingController);
   });
 
+  describe('#getTenant', () => {
+    it('should make a HTTP GET request', (done: DoneFn) => {
+      let mockResponse = 'mock-response';
+
+      service.getTenant()
+        .subscribe((resp: any) => {
+            expect(resp).toEqual(mockResponse);
+            controller.verify();
+            done();
+          },
+          (err: string) => {
+            done.fail(err);
+          }
+        );
+
+      const req: TestRequest = controller.expectOne('http://example.com/api/user/services');
+      expect(req.request.method).toEqual('GET');
+      expect(req.request.headers.get('Authorization')).toEqual('Bearer mock-token');
+      req.flush({data: mockResponse});
+    });
+
+    it('should delegate to handleError() if an error occurs', (done: DoneFn) => {
+      service.getTenant()
+        .subscribe(
+          (resp: any) => {
+            done.fail(resp);
+          },
+          () => {
+            // handleError() is private, verify that logger.error() is called with returned error
+            expect(mockLogger.error).toHaveBeenCalled();
+            controller.verify();
+            done();
+          }
+        );
+      const req: TestRequest = controller.expectOne('http://example.com/api/user/services');
+      req.error(new ErrorEvent('Mock HTTP Error'));
+    });
+  });
+
   describe('#updateTenant', () => {
     it('should make a HTTP PATCH request', (done: DoneFn) => {
       let mockResponse = 'mock-response';

--- a/src/app/profile/services/tenant.service.ts
+++ b/src/app/profile/services/tenant.service.ts
@@ -9,7 +9,7 @@ import { catchError, map } from 'rxjs/operators';
 @Injectable()
 export class TenantService {
   private headers: HttpHeaders = new HttpHeaders({ 'Content-Type': 'application/json' });
-  private userUrl: string;
+  private tenantUrl: string;
 
   constructor(
       private http: HttpClient,
@@ -19,7 +19,22 @@ export class TenantService {
     if (this.auth.getToken() != undefined) {
       this.headers = this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
     }
-    this.userUrl = apiUrl + 'user';
+    this.tenantUrl = apiUrl + 'user/services';
+  }
+
+  /**
+   * Get user tenant services
+   * @returns {Observable<any>}
+   */
+  getTenant(): Observable<any> {
+    return this.http
+      .get(this.tenantUrl, { headers: this.headers })
+      .pipe(
+        map((res: any) => res.data),
+        catchError((error: HttpErrorResponse) => {
+          return this.handleError(error);
+        })
+      );
   }
 
   /**
@@ -28,9 +43,8 @@ export class TenantService {
    * @returns {Observable<any>}
    */
   updateTenant(): Observable<any> {
-    let url = `${this.userUrl}/services`;
     return this.http
-      .patch(url, null, { headers: this.headers, observe: 'response', responseType: 'text' })
+      .patch(this.tenantUrl, null, { headers: this.headers, observe: 'response', responseType: 'text' })
       .pipe(
         catchError((error: HttpErrorResponse) => {
           return this.handleError(error);
@@ -43,9 +57,8 @@ export class TenantService {
    * @returns {Observable<any>}
    */
   cleanupTenant(): Observable<any> {
-    let url = `${this.userUrl}/services`;
     return this.http
-      .delete(url, { headers: this.headers, responseType: 'text' })
+      .delete(this.tenantUrl, { headers: this.headers, responseType: 'text' })
       .pipe(
         catchError((error: HttpErrorResponse) => {
           return this.handleError(error);

--- a/src/app/profile/settings/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.component.html
@@ -37,8 +37,8 @@
             </div>
             <div class="account-text-box col-xs-6">
               <span class="account-title">OpenShift Online</span>
-              <a [href]="cluster"
-                [tooltip]="cluster"
+              <a [href]="consoleUrl + 'projects'"
+                [tooltip]="consoleUrl + 'projects'"
                 class="cluster-url"
                 containerClass="cluster-tooltip"
                 placement="bottom"

--- a/src/app/profile/settings/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.component.html
@@ -5,7 +5,7 @@
         <div class="card-pf-heading">
           <div class="row account-content">
             <div class="col-xs-12">
-              <h2 class="card-pf-title">Connected Accounts</h2>
+              <h2 class="card-pf-title">Connected Services</h2>
             </div>
           </div>
         </div>
@@ -35,8 +35,14 @@
             <div class="col-xs-2">
               <img class="icon connected-account-icon" src="../../../../assets/images/openshift_icon.svg">
             </div>
-            <div class="account-text-box col-xs-10">
+            <div class="account-text-box col-xs-6">
               <span class="account-title">OpenShift</span>
+              <a [href]="cluster"
+                [tooltip]="cluster"
+                class="cluster-url"
+                containerClass="cluster-tooltip"
+                placement="bottom"
+                >{{ clusterName }}</a>
               <span class="word-wrap" *ngIf="openShiftLinked; else openShiftErrorName">{{openShiftUserName}}</span>
               <ng-template #openShiftErrorName>
                 <span>{{openShiftError}}</span>

--- a/src/app/profile/settings/connected-accounts/connected-accounts.component.html
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.component.html
@@ -36,7 +36,7 @@
               <img class="icon connected-account-icon" src="../../../../assets/images/openshift_icon.svg">
             </div>
             <div class="account-text-box col-xs-6">
-              <span class="account-title">OpenShift</span>
+              <span class="account-title">OpenShift Online</span>
               <a [href]="cluster"
                 [tooltip]="cluster"
                 class="cluster-url"

--- a/src/app/profile/settings/connected-accounts/connected-accounts.component.less
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.component.less
@@ -32,3 +32,13 @@
 #connected-accounts-gh-icon {
   font-size: 3em;
 }
+
+.cluster-url {
+  display: block;
+}
+
+.cluster-tooltip {
+  .tooltip-inner {
+    max-width: 320px;
+  }
+}

--- a/src/app/profile/settings/connected-accounts/connected-accounts.component.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.component.ts
@@ -25,6 +25,7 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
   userName: string;
   contextUserName: string;
   cluster: string;
+  clusterName: string;
 
   constructor(private contexts: Contexts,
     private auth: AuthenticationService,
@@ -43,6 +44,7 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
         this.openShiftLinked = isConnected;
       }));
       this.cluster = user.attributes.cluster;
+      this.clusterName = this.cluster.split('.')[1];
     }
   }
 

--- a/src/app/profile/settings/connected-accounts/connected-accounts.component.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.component.ts
@@ -3,7 +3,9 @@ import { Context, Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { UserService } from 'ngx-login-client';
 import { Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ProviderService } from '../../../shared/account/provider.service';
+import { TenantService } from '../../services/tenant.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -25,12 +27,16 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
   userName: string;
   contextUserName: string;
   cluster: string;
+  consoleUrl: string;
   clusterName: string;
 
-  constructor(private contexts: Contexts,
+  constructor(
+    private contexts: Contexts,
     private auth: AuthenticationService,
     private userService: UserService,
-    private providerService: ProviderService) {
+    private providerService: ProviderService,
+    private tenantService: TenantService
+  ) {
     this.subscriptions.push(auth.gitHubToken.subscribe(token => {
       this.gitHubLinked = (token !== undefined && token.length !== 0);
     }));
@@ -44,8 +50,16 @@ export class ConnectedAccountsComponent implements OnDestroy, OnInit {
         this.openShiftLinked = isConnected;
       }));
       this.cluster = user.attributes.cluster;
-      this.clusterName = this.cluster.split('.')[1];
     }
+
+    this.subscriptions.push(this.tenantService.getTenant()
+      .pipe(
+        map(data => data.attributes.namespaces[0]['cluster-console-url'])
+      ).subscribe(url => {
+        this.consoleUrl = url;
+        this.clusterName = url.split('.')[1];
+      })
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/app/profile/settings/connected-accounts/connected-accounts.module.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.module.ts
@@ -1,13 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { TooltipModule } from 'ngx-bootstrap';
 import { ConnectedAccountsRoutingModule } from './connected-accounts-routing.module';
 import { ConnectedAccountsComponent } from './connected-accounts.component';
 @NgModule({
   imports: [
     RouterModule,
     CommonModule,
-    ConnectedAccountsRoutingModule
+    ConnectedAccountsRoutingModule,
+    TooltipModule.forRoot()
   ],
   declarations: [ConnectedAccountsComponent],
   exports: [ConnectedAccountsComponent]

--- a/src/app/profile/settings/connected-accounts/connected-accounts.module.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.module.ts
@@ -4,6 +4,8 @@ import { RouterModule } from '@angular/router';
 import { TooltipModule } from 'ngx-bootstrap';
 import { ConnectedAccountsRoutingModule } from './connected-accounts-routing.module';
 import { ConnectedAccountsComponent } from './connected-accounts.component';
+
+import { TenantService } from '../../services/tenant.service';
 @NgModule({
   imports: [
     RouterModule,
@@ -12,6 +14,7 @@ import { ConnectedAccountsComponent } from './connected-accounts.component';
     TooltipModule.forRoot()
   ],
   declarations: [ConnectedAccountsComponent],
+  providers: [TenantService],
   exports: [ConnectedAccountsComponent]
 })
 export class ConnectedAccountsModule { }

--- a/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { cluster } from 'd3';
+import { TooltipModule } from 'ngx-bootstrap';
 import { Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { UserService } from 'ngx-login-client';
@@ -18,7 +20,8 @@ describe('Connected Accounts Component', () => {
   const ctx: any = {
     user: {
       attributes: {
-        username: expectedOsoUser
+        username: expectedOsoUser,
+        cluster: 'http://example.cluster-name.something.com'
       }
     }
   };
@@ -44,7 +47,9 @@ describe('Connected Accounts Component', () => {
     });
 
     const testContext = initContext(ConnectedAccountsComponent, SampleTestComponent,  {
-      providers: [ { provide: AuthenticationService, useValue: authMock },
+      imports: [ TooltipModule.forRoot() ],
+      providers: [
+        { provide: AuthenticationService, useValue: authMock },
         { provide: Contexts, useValue: contextsMock },
         { provide: UserService, useValue: userServiceMock },
         { provide: ProviderService, useValue: providersMock }]
@@ -60,6 +65,9 @@ describe('Connected Accounts Component', () => {
       expect(actualText).toMatch(new RegExp('OpenShift\\s+' + expectedOsoUser));
     });
 
+    it('should parse cluster name from cluster url', function(this: Context) {
+      expect(this.testedDirective.clusterName).toBe('cluster-name');
+    });
   });
 
   describe('User has both Github and OpenShift accounts connected', () => {
@@ -81,7 +89,9 @@ describe('Connected Accounts Component', () => {
     });
 
     const testContext = initContext(ConnectedAccountsComponent, SampleTestComponent,  {
-      providers: [ { provide: AuthenticationService, useValue: authMock },
+      imports: [ TooltipModule.forRoot() ],
+      providers: [
+        { provide: AuthenticationService, useValue: authMock },
         { provide: Contexts, useValue: contextsMock },
         { provide: UserService, useValue: userServiceMock },
         { provide: ProviderService, useValue: providersMock }]

--- a/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
@@ -76,7 +76,7 @@ describe('Connected Accounts Component', () => {
 
     it('should have OpenShift connection indicated', function() {
       const actualText = testContext.testedElement.textContent;
-      expect(actualText).toMatch(new RegExp('OpenShift\\s+' + expectedOsoUser));
+      expect(actualText).toMatch(new RegExp(expectedOsoUser));
     });
 
     it('should set cluster name and cluster url by calling tenant service', function(this: Context) {
@@ -116,7 +116,7 @@ describe('Connected Accounts Component', () => {
 
     it('should have OpenShift connection indicated', function() {
       const actualText = testContext.testedElement.textContent;
-      expect(actualText).toMatch(new RegExp('OpenShift\\s+' + expectedOsoUser));
+      expect(actualText).toMatch(new RegExp(expectedOsoUser));
     });
   });
 });

--- a/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
+++ b/src/app/profile/settings/connected-accounts/connected-accounts.spec.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { cluster } from 'd3';
-import { TooltipModule } from 'ngx-bootstrap';
 import { Contexts } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 import { UserService } from 'ngx-login-client';
 import { empty as observableEmpty, Observable,  of ,  throwError as observableThrowError } from 'rxjs';
 import { initContext, TestContext } from 'testing/test-context';
+
+import { TooltipModule } from 'ngx-bootstrap';
 import { ProviderService } from '../../../shared/account/provider.service';
 import { ConnectedAccountsComponent } from './connected-accounts.component';
 

--- a/src/app/profile/settings/settings.component.html
+++ b/src/app/profile/settings/settings.component.html
@@ -5,7 +5,7 @@
   <ul class="nav nav-tabs nav-tabs-pf">
     <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
       <a [routerLink]="['/' + loggedInUserName + '/_settings/']">
-        Connected Accounts
+        Connected Services
       </a>
     </li>
     <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4304
Fixes https://github.com/fabric8-services/fabric8-auth/issues/656

- Changes `Connected Accounts` -> `Connected Services`.
- Adds cluster URL to connected account section.