### PR TITLE
fix(version): update fabric8-planner to 0.55.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5196,9 +5196,9 @@
       }
     },
     "fabric8-planner": {
-      "version": "0.55.10",
-      "resolved": "https://registry.npmjs.org/fabric8-planner/-/fabric8-planner-0.55.10.tgz",
-      "integrity": "sha512-7zRGBalJ0kUAoz7jguLpKnmpne0bE4mfxm1/vhqIbN6Z+WCwwmHgDa1OhvqAiF2kH8YaDoFV2L01zSmewlcgfQ==",
+      "version": "0.55.11",
+      "resolved": "https://registry.npmjs.org/fabric8-planner/-/fabric8-planner-0.55.11.tgz",
+      "integrity": "sha512-Q6QjLfBx9gbBA4kQCpWuf73zJ9jZqp36KwHTN0ekTa/tZ0CTm5105X54vtUU6wvObnOVbptvS/f/cjOEozl3QQ==",
       "requires": {
         "lodash": "4.17.4",
         "moment": "2.22.2",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "angular2-websocket": "0.9.5",
     "chunk-manifest-webpack2-plugin": "1.0.1",
     "core-js": "2.5.1",
-    "fabric8-planner": "0.55.10",
+    "fabric8-planner": "0.55.11",
     "fabric8-stack-analysis-ui": "0.12.6",
     "http-server": "0.10.0",
     "ie-shim": "0.1.0",


### PR DESCRIPTION
This PR
 - Updates fabric8-planner to version 0.55.11 (https://github.com/fabric8-ui/fabric8-planner/releases/tag/v0.55.11)