### PR TITLE
feat(deployments): allow scaling only if remaining quota is sufficient

### DIFF
--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.html
@@ -2,7 +2,7 @@
 </deployments-donut-chart>
 <div column class="deployments-donut-scale-controls fade-inline" *ngIf="!isIdled && !mini">
   <div>
-    <a id="scaleUp" title="Scale up" role="button" (click)="$event.preventDefault(); scaleUp()" *ngIf="!atQuota; else scaleUpDisabled">
+    <a id="scaleUp" title="Scale up" role="button" (click)="$event.preventDefault(); scaleUp()" *ngIf="!atQuota && !requestedScaleIsMaximum; else scaleUpDisabled">
       <i class="fa fa-chevron-up"></i>
       <span class="sr-only">Scale up</span>
     </a>

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -12,14 +12,8 @@ import {
   throwError as _throw
 } from 'rxjs';
 import { createMock } from 'testing/mock';
-import {
-  initContext,
-  TestContext
-} from 'testing/test-context';
+import { initContext } from 'testing/test-context';
 import { NotificationsService } from '../../../../shared/notifications.service';
-import { CpuStat } from '../models/cpu-stat';
-import { MemoryStat } from '../models/memory-stat';
-import { MemoryUnit } from '../models/memory-unit';
 import { PodPhase } from '../models/pod-phase';
 import { Pods } from '../models/pods';
 import { DeploymentsService } from '../services/deployments.service';

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.spec.ts
@@ -56,8 +56,7 @@ describe('DeploymentsDonutComponent', () => {
             svc.getPods.and.returnValue(
               of({ pods: [['Running' as PodPhase, 1], ['Terminating' as PodPhase, 1]], total: 2 })
             );
-            svc.getEnvironmentCpuStat.and.returnValue(new Subject<CpuStat>());
-            svc.getEnvironmentMemoryStat.and.returnValue(new Subject<MemoryStat>());
+            svc.canScale.and.returnValue(new Subject<boolean>());
             return svc;
           }
         },
@@ -174,31 +173,11 @@ describe('DeploymentsDonutComponent', () => {
       expect(testContext.testedDirective.atQuota).toBeFalsy();
     });
 
-    it('should be "false" when both stats are below quota', function() {
-      const mockSvc: jasmine.SpyObj<DeploymentsService> = TestBed.get(DeploymentsService);
-      mockSvc.getEnvironmentCpuStat().next({ used: 0, quota: 2 });
-      mockSvc.getEnvironmentMemoryStat().next({ used: 0, quota: 2, units: MemoryUnit.GB });
+    it('should mirror inverted DeploymentsService#canScale()', function() {
+      TestBed.get(DeploymentsService).canScale().next(true);
       expect(testContext.testedDirective.atQuota).toBeFalsy();
-    });
 
-    it('should be "true" when CPU usage reaches quota', function() {
-      const mockSvc: jasmine.SpyObj<DeploymentsService> = TestBed.get(DeploymentsService);
-      mockSvc.getEnvironmentCpuStat().next({ used: 2, quota: 2 });
-      mockSvc.getEnvironmentMemoryStat().next({ used: 1, quota: 2, units: MemoryUnit.GB });
-      expect(testContext.testedDirective.atQuota).toBeTruthy();
-    });
-
-    it('should be "true" when Memory usage reaches quota', function() {
-      const mockSvc: jasmine.SpyObj<DeploymentsService> = TestBed.get(DeploymentsService);
-      mockSvc.getEnvironmentCpuStat().next({ used: 1, quota: 2 });
-      mockSvc.getEnvironmentMemoryStat().next({ used: 2, quota: 2, units: MemoryUnit.GB });
-      expect(testContext.testedDirective.atQuota).toBeTruthy();
-    });
-
-    it('should be "true" when both stats usage reaches quota', function() {
-      const mockSvc: jasmine.SpyObj<DeploymentsService> = TestBed.get(DeploymentsService);
-      mockSvc.getEnvironmentCpuStat().next({ used: 2, quota: 2 });
-      mockSvc.getEnvironmentMemoryStat().next({ used: 2, quota: 2, units: MemoryUnit.GB });
+      TestBed.get(DeploymentsService).canScale().next(false);
       expect(testContext.testedDirective.atQuota).toBeTruthy();
     });
   });

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -7,7 +7,6 @@ import {
 import { debounce } from 'lodash';
 import { NotificationType } from 'ngx-base';
 import {
-  combineLatest,
   Observable,
   Subscription
 } from 'rxjs';
@@ -15,7 +14,6 @@ import { first } from 'rxjs/operators';
 import { NotificationsService } from '../../../../shared/notifications.service';
 import { PodPhase } from '../models/pod-phase';
 import { Pods } from '../models/pods';
-import { Stat } from '../models/stat';
 import { DeploymentsService } from '../services/deployments.service';
 
 @Component({

--- a/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
+++ b/src/app/space/create/deployments/deployments-donut/deployments-donut.component.ts
@@ -73,12 +73,11 @@ export class DeploymentsDonutComponent implements OnInit {
     );
 
     this.subscriptions.push(
-      combineLatest(
-        this.deploymentsService.getEnvironmentCpuStat(this.spaceId, this.environment),
-        this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment)
-      ).subscribe((stats: Stat[]): void => {
-        this.atQuota = stats.some((stat: Stat): boolean => stat.used >= stat.quota);
-      })
+      this.deploymentsService
+        .canScale(this.spaceId, this.environment, this.applicationId)
+        .subscribe((canScale: boolean): void => {
+          this.atQuota = !canScale;
+        })
     );
   }
 

--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -349,7 +349,7 @@ describe('DeploymentApiService', () => {
 
   // TODO uncomment once backend is available and implementation is updated
   xdescribe('#getQuotaRequirementPerPod', () => {
-    it('should return result', function(this: TestContext, done: DoneFn): void {
+    it('should return result', function(done: DoneFn): void {
       const gb: number = Math.pow(1024, 3);
       const httpResponse: PodQuotaRequirementResponse = {
         data: {
@@ -359,7 +359,7 @@ describe('DeploymentApiService', () => {
           }
         }
       } as PodQuotaRequirementResponse;
-      this.service.getQuotaRequirementPerPod('foo spaceId', 'stage env', 'foo appId').pipe(
+      service.getQuotaRequirementPerPod('foo spaceId', 'stage env', 'foo appId').pipe(
         first()
       ).subscribe((data: PodQuotaRequirement): void => {
           expect(data).toEqual(httpResponse.data.limits);
@@ -373,8 +373,8 @@ describe('DeploymentApiService', () => {
       req.flush(httpResponse);
     });
 
-    it('should report errors', function(this: TestContext, done: DoneFn): void {
-      this.service.getQuotaRequirementPerPod('foo spaceId', 'stage env', 'foo appId').pipe(
+    it('should report errors', function(done: DoneFn): void {
+      service.getQuotaRequirementPerPod('foo spaceId', 'stage env', 'foo appId').pipe(
         first()
       ).subscribe(
           () => done.fail('should throw error'),

--- a/src/app/space/create/deployments/services/deployment-api.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.spec.ts
@@ -347,46 +347,47 @@ describe('DeploymentApiService', () => {
     });
   });
 
-  // TODO uncomment once backend is available and implementation is updated
-  xdescribe('#getQuotaRequirementPerPod', () => {
+  describe('#getQuotaRequirementPerPod', () => {
+    const gb: number = Math.pow(1024, 3);
+
     it('should return result', function(done: DoneFn): void {
-      const gb: number = Math.pow(1024, 3);
       const httpResponse: PodQuotaRequirementResponse = {
         data: {
           limits: {
-            cpucores: 1,
-            memory: 0.5 * gb
+            cpucores: 2,
+            memory: 1 * gb
           }
         }
       } as PodQuotaRequirementResponse;
       service.getQuotaRequirementPerPod('foo spaceId', 'stage env', 'foo appId').pipe(
         first()
       ).subscribe((data: PodQuotaRequirement): void => {
-          expect(data).toEqual(httpResponse.data.limits);
-          this.controller.verify();
-          done();
-        });
+        expect(data).toEqual(httpResponse.data.limits);
+        controller.verify();
+        done();
+      });
 
-      const req: TestRequest = this.controller.expectOne('http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/podlimits');
+      const req: TestRequest = controller.expectOne('http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/podlimits');
       expect(req.request.method).toEqual('GET');
       expect(req.request.headers.get('Authorization')).toEqual('Bearer mock-auth-token');
       req.flush(httpResponse);
     });
 
-    it('should report errors', function(done: DoneFn): void {
+    it('should report errors and return default', function(done: DoneFn): void {
       service.getQuotaRequirementPerPod('foo spaceId', 'stage env', 'foo appId').pipe(
         first()
-      ).subscribe(
-          () => done.fail('should throw error'),
-          () => {
-            expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
-            expect(TestBed.get(Logger).error).toHaveBeenCalled();
-            this.controller.verify();
-            done();
-          }
-        );
+      ).subscribe((data: PodQuotaRequirement): void => {
+        expect(TestBed.get(ErrorHandler).handleError).toHaveBeenCalled();
+        expect(TestBed.get(Logger).error).toHaveBeenCalled();
+        expect(data).toEqual({
+          cpucores: 1,
+          memory: 0.5 * gb
+        });
+        controller.verify();
+        done();
+      });
 
-      const req: TestRequest = this.controller.expectOne('http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/podlimits');
+      const req: TestRequest = controller.expectOne('http://example.com/deployments/spaces/foo%20spaceId/applications/foo%20appId/deployments/stage%20env/podlimits');
       req.error(new ErrorEvent('Mock HTTP error'));
     });
   });

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -223,20 +223,22 @@ export class DeploymentApiService {
   }
 
   getQuotaRequirementPerPod(spaceId: string, environmentName: string, applicationId: string): Observable<PodQuotaRequirement> {
-    // TODO replace mock below with this implementation once backend is available
-    // const encSpaceId: string = encodeURIComponent(spaceId);
-    // const encEnvironmentName: string = encodeURIComponent(environmentName);
-    // const encApplicationId: string = encodeURIComponent(applicationId);
-    // const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/podlimits`;
-    // return this.httpGet<PodQuotaRequirementResponse>(url).pipe(
-    //   map((response: PodQuotaRequirementResponse) => response.data.limits)
-    // );
-
-    const gb: number = Math.pow(1024, 3);
-    return of({
-      cpucores: 1,
-      memory: 0.5 * gb
-    });
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    const encEnvironmentName: string = encodeURIComponent(environmentName);
+    const encApplicationId: string = encodeURIComponent(applicationId);
+    const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/podlimits`;
+    return this.httpGet<PodQuotaRequirementResponse>(url).pipe(
+      map((response: PodQuotaRequirementResponse) => response.data.limits),
+      catchError((err: HttpErrorResponse): Observable<PodQuotaRequirement> => {
+        this.handleHttpError(err);
+        // 1 core/512MB is the default allocation on the backend
+        const gb: number = Math.pow(1024, 3);
+        return of({
+          cpucores: 1,
+          memory: 0.5 * gb
+        });
+      })
+    );
   }
 
   private httpGet<T>(url: string, params: HttpParams = new HttpParams()): Observable<T> {

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -133,6 +133,10 @@ export interface SeriesData {
 }
 
 export interface PodQuotaRequirementResponse {
+  data: PodQuotaLimits;
+}
+
+export interface PodQuotaLimits {
   limits: PodQuotaRequirement;
 }
 
@@ -219,6 +223,15 @@ export class DeploymentApiService {
   }
 
   getQuotaRequirementPerPod(spaceId: string, environmentName: string, applicationId: string): Observable<PodQuotaRequirement> {
+    // TODO replace mock below with this implementation once backend is available
+    // const encSpaceId: string = encodeURIComponent(spaceId);
+    // const encEnvironmentName: string = encodeURIComponent(environmentName);
+    // const encApplicationId: string = encodeURIComponent(applicationId);
+    // const url: string = `${this.apiUrl}${encSpaceId}/applications/${encApplicationId}/deployments/${encEnvironmentName}/podlimits`;
+    // return this.httpGet<PodQuotaRequirementResponse>(url).pipe(
+    //   map((response: PodQuotaRequirementResponse) => response.data.limits)
+    // );
+
     const gb: number = Math.pow(1024, 3);
     return of({
       cpucores: 1,

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -2,9 +2,9 @@ import {
   HttpClient,
   HttpErrorResponse,
   HttpHeaders,
-  HttpParams,
-  HttpResponse
+  HttpParams
 } from '@angular/common/http';
+
 import {
   ErrorHandler,
   Inject,
@@ -13,8 +13,8 @@ import {
 import { Logger } from 'ngx-base';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
-import { Observable ,  throwError as _throw } from 'rxjs';
-import { catchError ,  map } from 'rxjs/operators';
+import { Observable , of, throwError as _throw } from 'rxjs';
+import { catchError , map } from 'rxjs/operators';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
 
@@ -132,6 +132,15 @@ export interface SeriesData {
   value: number;
 }
 
+export interface PodQuotaRequirementResponse {
+  limits: PodQuotaRequirement;
+}
+
+export interface PodQuotaRequirement {
+  cpucores: number;
+  memory: number;
+}
+
 @Injectable()
 export class DeploymentApiService {
 
@@ -207,6 +216,14 @@ export class DeploymentApiService {
       catchError((err: HttpErrorResponse) => this.handleHttpError(err)),
       map(() => null)
     );
+  }
+
+  getQuotaRequirementPerPod(spaceId: string, environmentName: string, applicationId: string): Observable<PodQuotaRequirement> {
+    const gb: number = Math.pow(1024, 3);
+    return of({
+      cpucores: 1,
+      memory: 0.5 * gb
+    });
   }
 
   private httpGet<T>(url: string, params: HttpParams = new HttpParams()): Observable<T> {

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -8,7 +8,6 @@ import {
 } from 'ngx-base';
 import {
   empty as emptyObservable,
-  Observable,
   of,
   Subject,
   throwError as _throw,

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -560,8 +560,8 @@ describe('DeploymentsService', () => {
 
   describe('#canScale', () => {
     const GB: number = Math.pow(1024, 3);
-    it('should return true when remaining quota is sufficient', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(of([
+    it('should return true when remaining quota is sufficient', function(done: DoneFn): void {
+      apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -579,22 +579,22 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.apiService.getQuotaRequirementPerPod.and.returnValue(of({
+      apiService.getQuotaRequirementPerPod.and.returnValue(of({
         cpucores: 1,
         memory: 0.5 * GB
       }));
 
-      this.service.canScale('foo-spaceId', 'stage', 'vertx-hello')
+      service.canScale('foo-spaceId', 'stage', 'vertx-hello')
         .pipe(first())
         .subscribe((canScale: boolean): void => {
           expect(canScale).toBeTruthy();
           done();
         });
-      this.timer.next();
+      timerToken.next();
     });
 
-    it('should return false when remaining CPU quota is insufficient', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(of([
+    it('should return false when remaining CPU quota is insufficient', function(done: DoneFn): void {
+      apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -612,22 +612,22 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.apiService.getQuotaRequirementPerPod.and.returnValue(of({
+      apiService.getQuotaRequirementPerPod.and.returnValue(of({
         cpucores: 1,
         memory: 0.5 * GB
       }));
 
-      this.service.canScale('foo-spaceId', 'stage', 'vertx-hello')
+      service.canScale('foo-spaceId', 'stage', 'vertx-hello')
         .pipe(first())
         .subscribe((canScale: boolean): void => {
           expect(canScale).toBeFalsy();
           done();
         });
-      this.timer.next();
+      timerToken.next();
     });
 
-    it('should return false when remaining Memory quota is insufficient', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(of([
+    it('should return false when remaining Memory quota is insufficient', function(done: DoneFn): void {
+      apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -645,25 +645,25 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.apiService.getQuotaRequirementPerPod.and.returnValue(of({
+      apiService.getQuotaRequirementPerPod.and.returnValue(of({
         cpucores: 1,
         memory: 0.5 * GB
       }));
 
-      this.service.canScale('foo-spaceId', 'stage', 'vertx-hello')
+      service.canScale('foo-spaceId', 'stage', 'vertx-hello')
         .pipe(first())
         .subscribe((canScale: boolean): void => {
           expect(canScale).toBeFalsy();
           done();
         });
-      this.timer.next();
+      timerToken.next();
     });
   });
 
   describe('#getMaximumPods', () => {
     const GB: number = Math.pow(1024, 3);
-    it('should return appropriate number of maximum pods for typical scenario', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(of([
+    it('should return appropriate number of maximum pods for typical scenario', function(done: DoneFn): void {
+      apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -681,21 +681,21 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.apiService.getQuotaRequirementPerPod.and.returnValue(of({
+      apiService.getQuotaRequirementPerPod.and.returnValue(of({
         cpucores: 1,
         memory: 0.5 * GB
       }));
 
-      this.service.getMaximumPods('foo-spaceId', 'stage', 'vertx-hello')
+      service.getMaximumPods('foo-spaceId', 'stage', 'vertx-hello')
         .subscribe((maxPods: number): void => {
           expect(maxPods).toEqual(2);
           done();
         });
-      this.timer.next();
+      timerToken.next();
     });
 
-    it('should return maximum based on resource with least available quota', function(this: TestContext, done: DoneFn): void {
-      this.apiService.getEnvironments.and.returnValue(of([
+    it('should return maximum based on resource with least available quota', function(done: DoneFn): void {
+      apiService.getEnvironments.and.returnValue(of([
         {
           attributes: {
             name: 'stage',
@@ -713,17 +713,17 @@ describe('DeploymentsService', () => {
           }
         }
       ]));
-      this.apiService.getQuotaRequirementPerPod.and.returnValue(of({
+      apiService.getQuotaRequirementPerPod.and.returnValue(of({
         cpucores: 2,
         memory: 0.5 * GB
       }));
 
-      this.service.getMaximumPods('foo-spaceId', 'stage', 'vertx-hello')
+      service.getMaximumPods('foo-spaceId', 'stage', 'vertx-hello')
         .subscribe((maxPods: number): void => {
           expect(maxPods).toEqual(1); // only one CPU allocation will fit
           done();
         });
-      this.timer.next();
+      timerToken.next();
     });
   });
 


### PR DESCRIPTION
~~WIP: DeploymentApiService currently returns a mocked data structure. This needs to be replaced with an actual HTTP request once the backend support (https://github.com/fabric8-services/fabric8-wit/pull/2286) is merged and deployed. Additionally, there should be another piece of logic added on top to only allow a scale-up attempt for the maximum number of pods that can be supported in the remaining quota, so the user cannot over-request (ie attempt to scale 0->3 when there is only quota for 2).~~

Allow users to scale up deployments only if the remaining quota is sufficient to support an
additional pod. Previously, if any free quota remained a scale operation would always be permitted,
even if the amount of remaining quota was too small to support an additional pod.

related to https://github.com/openshiftio/openshift.io/issues/3389

