### PR TITLE
feat(recent): introduce recent-utils to be extended by context and spaces service for "recent" logic

### DIFF
--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -140,7 +140,7 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
         .pipe(
           withLatestFrom(this._recent),
           map(([deletedSpace, recentContexts]: [Space, Context[]]): RecentData<Context> =>
-            this.onBroadcastDeleted(deletedSpace, recentContexts)
+            this.onBroadcastSpaceDeleted(deletedSpace, recentContexts, this.compareContextToSpace)
           ),
           filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired)
         )
@@ -148,7 +148,20 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
           this.saveRecentContexts(recentData.data)
         )
     );
+  }
 
+  // implements recent-utils compareElements()
+  compareElements(c1: Context, c2: Context): boolean {
+    return c1.name === c2.name;
+  }
+
+  // comparator function for space deletion events
+  compareContextToSpace(c: Context, s: Space): boolean {
+    if (c.space) {
+      return c.space.id === s.id;
+    } else {
+      return false;
+    }
   }
 
   get current(): Observable<Context> {

--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -131,7 +131,7 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
           filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired)
         )
         .subscribe((recentData: RecentData<Context>): void =>
-          this.saveRecentContexts(recentData.data)
+          this.saveRecentContexts(recentData.recent)
         )
     );
 
@@ -145,7 +145,7 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
           filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired)
         )
         .subscribe((recentData: RecentData<Context>): void =>
-          this.saveRecentContexts(recentData.data)
+          this.saveRecentContexts(recentData.recent)
         )
     );
   }

--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -116,37 +116,37 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
 
   private initRecent(): void {
     this.subscriptions.push(
-      this.loadRecentContexts().subscribe((contexts: Context[]): void => {
-        this._recent.next(contexts);
-      })
+      this.loadRecentContexts().subscribe((contexts: Context[]): void =>
+        this._recent.next(contexts)
+      )
     );
 
     this.subscriptions.push(
       this.broadcaster.on<Context>('contextChanged')
         .pipe(
           withLatestFrom(this.recent),
-          map(([changedContext, recentContexts]: [Context, Context[]]): RecentData<Context> => {
-            return this.onBroadcastChanged(changedContext, recentContexts);
-          }),
-          filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired === true)
-          )
-        .subscribe((recentData: RecentData<Context>): void => {
-          this.saveRecentContexts(recentData.data);
-        })
+          map(([changedContext, recentContexts]: [Context, Context[]]): RecentData<Context> =>
+            this.onBroadcastChanged(changedContext, recentContexts)
+          ),
+          filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired)
+        )
+        .subscribe((recentData: RecentData<Context>): void =>
+          this.saveRecentContexts(recentData.data)
+        )
     );
 
     this.subscriptions.push(
       this.broadcaster.on<Space>('spaceDeleted')
         .pipe(
           withLatestFrom(this._recent),
-          map(([deletedSpace, recentContexts]: [Space, Context[]]): RecentData<Context> => {
-            return this.onBroadcastDeleted(deletedSpace, recentContexts);
-          }),
-          filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired === true)
+          map(([deletedSpace, recentContexts]: [Space, Context[]]): RecentData<Context> =>
+            this.onBroadcastDeleted(deletedSpace, recentContexts)
+          ),
+          filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired)
         )
-        .subscribe((recentData: RecentData<Context>): void => {
-          this.saveRecentContexts(recentData.data);
-        })
+        .subscribe((recentData: RecentData<Context>): void =>
+          this.saveRecentContexts(recentData.data)
+        )
     );
 
   }
@@ -359,7 +359,7 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
     });
   }
 
-  private saveRecentContexts(recent: Context[]) {
+  private saveRecentContexts(recent: Context[]): void {
     this._recent.next(recent);
     let patch = {
       store: {

--- a/src/app/shared/recent-utils.ts
+++ b/src/app/shared/recent-utils.ts
@@ -1,0 +1,88 @@
+import { ErrorHandler } from '@angular/core';
+import { Context, Space } from 'ngx-fabric8-wit';
+import { Observable, ReplaySubject, Subject } from 'rxjs';
+import { ExtProfile, ProfileService } from '../profile/profile.service';
+
+export const RECENT_LENGTH: number = 8;
+
+export interface RecentData <T extends Context | Space> {
+  data: T[];
+  isSaveRequired: boolean;
+}
+
+export function isContext(context: any): context is Context {
+  return (<Context> context.user !== undefined);
+}
+
+export function isSpace(space: any): space is Space {
+  return (<Space> space.id !== undefined);
+}
+
+export abstract class RecentUtils <T extends Context | Space> {
+
+  protected _recent: Subject<T[]>;
+
+  constructor(
+    protected errorHandler: ErrorHandler,
+    protected profileService: ProfileService
+  ) {
+    this._recent = new ReplaySubject<T[]>(1);
+  }
+
+  get recent(): Observable<T[]> {
+    return this._recent;
+  }
+
+  onBroadcastChanged(changed: T, recent: T[]): RecentData<T> {
+    let index: number = 0;
+    if (isContext(changed)) {
+      index = (recent as Context[]).findIndex((context: Context) => context.name === (changed as Context).name);
+    } else if (isSpace(changed)) {
+      index = (recent as Space[]).findIndex((space: Space): boolean => space.id === (changed as Space).id);
+    }
+
+    if (index === 0) { // continue only if changed is new, or requires a move within recent
+      return { data: recent, isSaveRequired: false } as RecentData<T>;
+    } else if (index > 0) { // if changed exists in recent, move it to the front
+      recent.splice(index, 1);
+      recent.unshift(changed);
+    } else { // if changed is new to recent
+      recent.unshift(changed);
+      // trim recent if required to ensure it is length =< 8
+      if (recent.length > RECENT_LENGTH) {
+        recent.pop();
+      }
+    }
+    return { data: recent, isSaveRequired: true } as RecentData<T>;
+  }
+
+  onBroadcastDeleted(deletedSpace: Space, recent: T[]): RecentData<T> {
+    let index: number = -1;
+    if (recent.length !== 0 && isContext(recent[0])) {
+      index = (recent as Context[]).findIndex((context: Context): boolean => {
+        if (context.space) {
+          return context.space.id === deletedSpace.id;
+        } else {
+          return false;
+        }
+      });
+    } else if (recent.length !== 0 && isSpace(recent[0])) {
+      index = (recent as Space[]).findIndex((space: Space): boolean => space.id === deletedSpace.id);
+    }
+
+    if (index === -1) {
+      return { data: recent, isSaveRequired: false } as RecentData<T>;
+    }
+    recent.splice(index, 1);
+    return { data: recent, isSaveRequired: true } as RecentData<T>;
+  }
+
+  saveProfile(patch: ExtProfile): void {
+    this.profileService.silentSave(patch).subscribe(
+      (): void => {},
+      (err: string): void => {
+        this.errorHandler.handleError(err);
+      });
+  }
+
+}

--- a/src/app/shared/recent-utils.ts
+++ b/src/app/shared/recent-utils.ts
@@ -6,7 +6,7 @@ import { ExtProfile, ProfileService } from '../profile/profile.service';
 export const RECENT_LENGTH: number = 8;
 
 export interface RecentData <T> {
-  data: T[];
+  recent: T[];
   isSaveRequired: boolean;
 }
 
@@ -30,7 +30,7 @@ export abstract class RecentUtils<T> {
   onBroadcastChanged(changed: T, recent: T[], compareFn: Function = this.compareElements): RecentData<T> {
     let index: number = recent.findIndex((t: T) => compareFn(t, changed));
     if (index === 0) { // continue only if changed is new, or requires a move within recent
-      return { data: recent, isSaveRequired: false };
+      return { recent: recent, isSaveRequired: false };
     } else if (index > 0) { // if changed exists in recent, move it to the front
       recent.splice(index, 1);
       recent.unshift(changed);
@@ -41,16 +41,16 @@ export abstract class RecentUtils<T> {
         recent.pop();
       }
     }
-    return { data: recent, isSaveRequired: true };
+    return { recent: recent, isSaveRequired: true };
   }
 
   onBroadcastSpaceDeleted(deletedSpace: Space, recent: T[], compareFn: Function = this.compareElements): RecentData<T> {
     let index: number = recent.findIndex((t: T) => compareFn(t, deletedSpace));
     if (index === -1) {
-      return { data: recent, isSaveRequired: false };
+      return { recent: recent, isSaveRequired: false };
     }
     recent.splice(index, 1);
-    return { data: recent, isSaveRequired: true };
+    return { recent: recent, isSaveRequired: true };
   }
 
   saveProfile(patch: ExtProfile): void {

--- a/src/app/shared/spaces.service.spec.ts
+++ b/src/app/shared/spaces.service.spec.ts
@@ -1,3 +1,4 @@
+import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { cloneDeep } from 'lodash';
 import { Broadcaster } from 'ngx-base';
@@ -7,6 +8,7 @@ import { ConnectableObservable, Observable } from 'rxjs';
 import { of } from 'rxjs/observable/of';
 import { createMock } from 'testing/mock';
 import { ExtProfile, ProfileService } from '../profile/profile.service';
+import { RECENT_LENGTH } from './recent-utils';
 import { SpacesService } from './spaces.service';
 
 describe('SpacesService', () => {
@@ -92,6 +94,14 @@ describe('SpacesService', () => {
             const mockSpaceService: jasmine.SpyObj<SpaceService> = createMock(SpaceService);
             mockSpaceService.getSpaceById.and.returnValue(of(mockSpace));
             return mockSpaceService;
+          }
+        },
+        {
+          provide: ErrorHandler,
+          useFactory: () => {
+            const mockErrorHandler: jasmine.SpyObj<ErrorHandler> = createMock(ErrorHandler);
+            mockErrorHandler.handleError.and.stub();
+            return mockErrorHandler;
           }
         }
       ]
@@ -206,10 +216,10 @@ describe('SpacesService', () => {
           recentSpaces: [mockSpace2.id, mockSpace.id]
         }
       };
-      spyOn(console, 'log');
+      const errorHandler: jasmine.SpyObj<ErrorHandler> = TestBed.get(ErrorHandler);
       const spacesService: SpacesService = TestBed.get(SpacesService);
       expect(profileService.silentSave).toHaveBeenCalledWith(expectedPatch);
-      expect(console.log).toHaveBeenCalledTimes(0);
+      expect(errorHandler.handleError).toHaveBeenCalledTimes(0);
     });
 
     it('should log an error if silentSave failed', () => {
@@ -235,10 +245,10 @@ describe('SpacesService', () => {
           recentSpaces: [mockSpace2.id, mockSpace.id]
         }
       };
-      spyOn(console, 'log');
+      const errorHandler: jasmine.SpyObj<ErrorHandler> = TestBed.get(ErrorHandler);
       const spacesService: SpacesService = TestBed.get(SpacesService);
       expect(profileService.silentSave).toHaveBeenCalledWith(expectedPatch);
-      expect(console.log).toHaveBeenCalledWith('Error saving recent spaces:', 'error');
+      expect(errorHandler.handleError).toHaveBeenCalled();
     });
   });
 
@@ -359,7 +369,7 @@ describe('SpacesService', () => {
       });
       const spacesService: SpacesService = TestBed.get(SpacesService);
       spacesService.recent.subscribe(spaces => {
-        expect(spaces.length).toEqual(SpacesService.RECENT_SPACE_LENGTH);
+        expect(spaces.length).toEqual(RECENT_LENGTH);
         done();
       });
     });

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -70,7 +70,7 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
         .pipe(
           withLatestFrom(this.recent),
           map(([deletedSpace, recentSpaces]): RecentData<Space> =>
-            this.onBroadcastDeleted(deletedSpace, recentSpaces)
+            this.onBroadcastSpaceDeleted(deletedSpace, recentSpaces)
           ),
           filter((recentData: RecentData<Space>) => recentData.isSaveRequired)
         )
@@ -78,6 +78,11 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
           this.saveRecentSpaces(recentData.data)
         )
     );
+  }
+
+  // implements recent-utils compareElements()
+  compareElements(s1: Space, s2: Space): boolean {
+    return s1.id === s2.id;
   }
 
   get current(): Observable<Space> {

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -1,30 +1,37 @@
+import { ErrorHandler } from '@angular/core';
 import { Injectable } from '@angular/core';
 import { Broadcaster } from 'ngx-base';
 import { Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
-import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 import { merge } from 'rxjs/observable/merge';
 import { of } from 'rxjs/observable/of';
 import { filter, map, withLatestFrom } from 'rxjs/operators';
 import { ExtProfile, ProfileService } from '../profile/profile.service';
+import { RecentData, RecentUtils } from './recent-utils';
 
 @Injectable()
-export class SpacesService implements Spaces {
-
-  static readonly RECENT_SPACE_LENGTH = 8;
+export class SpacesService extends RecentUtils<Space> implements Spaces {
 
   private _current: Observable<Space>;
-  private _recent: Subject<Space[]>;
+  private subscriptions: Subscription[] = [];
 
   constructor(
-    private contexts: Contexts,
-    private spaceService: SpaceService,
+    protected errorHandler: ErrorHandler,
+    protected profileService: ProfileService,
     private broadcaster: Broadcaster,
-    private profileService: ProfileService
+    private spaceService: SpaceService,
+    private contexts: Contexts
   ) {
-    this._recent = new ReplaySubject<Space[]>(1);
+    super(errorHandler, profileService);
     this.initCurrent();
     this.initRecent();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((subscription: Subscription): void => {
+      subscription.unsubscribe();
+    });
   }
 
   private initCurrent(): void {
@@ -38,75 +45,46 @@ export class SpacesService implements Spaces {
 
   private initRecent(): void {
     // load existing recent spaces from profile.store.recentSpaces
-    this.loadRecent().subscribe((spaces: Space[]): void => {
-      this._recent.next(spaces);
-    });
+    this.subscriptions.push(
+      this.loadRecentSpaces().subscribe((spaces: Space[]): void => {
+        this._recent.next(spaces);
+      })
+    );
 
-    // update _recent with newly seen space when spaceChanged is emitted
-    this.broadcaster.on<Space>('spaceChanged')
-      .pipe(
-        withLatestFrom(this.recent),
-        map(([changedSpace, recentSpaces]: [Space, Space[]]): [Space, Space[], number] => {
-          let index: number = recentSpaces.findIndex((space: Space): boolean => space.id === changedSpace.id);
-          return [changedSpace, recentSpaces, index];
-        }),
-        filter(([changedSpace, recentSpaces, index]: [Space, Space[], number]): boolean => {
-          return index !== 0; // continue only if the changed space is new, or requires a move in _recent
-        }),
-        map(([changedSpace, recentSpaces, index]: [Space, Space[], number]): Space[] => {
-          // if changedSpace exists in recentSpaces
-          if (index !== -1) {
-            // move the space to the front of the list if it is already in _recent
-            if (recentSpaces[0].id !== changedSpace.id) {
-              recentSpaces.splice(index, 1);
-              recentSpaces.unshift(changedSpace);
-            }
-            // otherwise, no operation required; changedSpace is already index 0
-          // if changedSpace is new to the recent spaces
-          } else {
-            recentSpaces.unshift(changedSpace);
-            // trim recentSpaces if required to ensure it is length =< 8
-            if (recentSpaces.length > SpacesService.RECENT_SPACE_LENGTH) {
-              recentSpaces.pop();
-            }
-          }
-          return recentSpaces;
+    this.subscriptions.push(
+      this.broadcaster.on<Space>('spaceChanged')
+        .pipe(
+          withLatestFrom(this.recent),
+          map(([changedSpace, recentSpaces]: [Space, Space[]]): RecentData<Space> => {
+            return this.onBroadcastChanged(changedSpace, recentSpaces);
+          }),
+          filter((recentData: RecentData<Space>): boolean => recentData.isSaveRequired === true)
+        )
+        .subscribe((recentData: RecentData<Space>): void => {
+          this.saveRecentSpaces(recentData.data);
         })
-      )
-      .subscribe((recentSpaces: Space[]): void => {
-        this.saveRecent(recentSpaces);
-      });
+    );
 
-    // if a space is deleted, check to see if it should be removed from _recent
-    this.broadcaster.on<Space>('spaceDeleted')
-      .pipe(
-        withLatestFrom(this.recent),
-        map(([deletedSpace, recentSpaces]: [Space, Space[]]): [Space, Space[], number] => {
-          let index: number = recentSpaces.findIndex((space: Space): boolean => space.id === deletedSpace.id);
-          return [deletedSpace, recentSpaces, index];
-        }),
-        filter(([deletedSpace, recentSpaces, index]: [Space, Space[], number]): boolean => {
-          return index !== -1;
-        }),
-        map(([deletedSpace, recentSpaces, index]: [Space, Space[], number]): Space[] => {
-          recentSpaces.splice(index, 1);
-          return recentSpaces;
+    this.subscriptions.push(
+      this.broadcaster.on<Space>('spaceDeleted')
+        .pipe(
+          withLatestFrom(this.recent),
+          map(([deletedSpace, recentSpaces]): RecentData<Space> => {
+            return this.onBroadcastDeleted(deletedSpace, recentSpaces);
+          }),
+          filter((recentData: RecentData<Space>) => recentData.isSaveRequired === true)
+        )
+        .subscribe((recentData: RecentData<Space>): void => {
+          this.saveRecentSpaces(recentData.data);
         })
-      )
-      .subscribe((recentSpaces: Space[]): void => {
-        this.saveRecent(recentSpaces);
-      });
+    );
   }
 
   get current(): Observable<Space> {
     return this._current;
   }
 
-  get recent(): Observable<Space[]> {
-    return this._recent;
-  }
-
-  private loadRecent(): Observable<Space[]> {
+  private loadRecentSpaces(): Observable<Space[]> {
     return this.profileService.current.switchMap((profile: ExtProfile): Observable<Space[]> => {
       if (profile.store.recentSpaces && profile.store.recentSpaces.length > 0) {
         return forkJoin((profile.store.recentSpaces as string[]).map((id: string): Observable<Space> => {
@@ -122,15 +100,14 @@ export class SpacesService implements Spaces {
     });
   }
 
-  private saveRecent(recent: Space[]): Subscription {
-    this._recent.next(recent);
-    let patch = {
+  private saveRecentSpaces(recentSpaces: Space[]): void {
+    this._recent.next(recentSpaces);
+    let patch: ExtProfile = {
       store: {
-        recentSpaces: recent.map((val: Space): string => val.id)
+        recentSpaces: (recentSpaces as Space[]).map((val: Space): string => val.id)
       }
     } as ExtProfile;
-    return this.profileService.silentSave(patch)
-      .subscribe((): void => {}, (err: string): void => console.log('Error saving recent spaces:', err));
+    this.saveProfile(patch);
   }
 
 }

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -46,37 +46,37 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
   private initRecent(): void {
     // load existing recent spaces from profile.store.recentSpaces
     this.subscriptions.push(
-      this.loadRecentSpaces().subscribe((spaces: Space[]): void => {
-        this._recent.next(spaces);
-      })
+      this.loadRecentSpaces().subscribe((spaces: Space[]): void =>
+        this._recent.next(spaces)
+      )
     );
 
     this.subscriptions.push(
       this.broadcaster.on<Space>('spaceChanged')
         .pipe(
           withLatestFrom(this.recent),
-          map(([changedSpace, recentSpaces]: [Space, Space[]]): RecentData<Space> => {
-            return this.onBroadcastChanged(changedSpace, recentSpaces);
-          }),
-          filter((recentData: RecentData<Space>): boolean => recentData.isSaveRequired === true)
+          map(([changedSpace, recentSpaces]: [Space, Space[]]): RecentData<Space> =>
+            this.onBroadcastChanged(changedSpace, recentSpaces)
+          ),
+          filter((recentData: RecentData<Space>): boolean => recentData.isSaveRequired)
         )
-        .subscribe((recentData: RecentData<Space>): void => {
-          this.saveRecentSpaces(recentData.data);
-        })
+        .subscribe((recentData: RecentData<Space>): void =>
+          this.saveRecentSpaces(recentData.data)
+        )
     );
 
     this.subscriptions.push(
       this.broadcaster.on<Space>('spaceDeleted')
         .pipe(
           withLatestFrom(this.recent),
-          map(([deletedSpace, recentSpaces]): RecentData<Space> => {
-            return this.onBroadcastDeleted(deletedSpace, recentSpaces);
-          }),
-          filter((recentData: RecentData<Space>) => recentData.isSaveRequired === true)
+          map(([deletedSpace, recentSpaces]): RecentData<Space> =>
+            this.onBroadcastDeleted(deletedSpace, recentSpaces)
+          ),
+          filter((recentData: RecentData<Space>) => recentData.isSaveRequired)
         )
-        .subscribe((recentData: RecentData<Space>): void => {
-          this.saveRecentSpaces(recentData.data);
-        })
+        .subscribe((recentData: RecentData<Space>): void =>
+          this.saveRecentSpaces(recentData.data)
+        )
     );
   }
 
@@ -92,7 +92,7 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
           return this.spaceService.getSpaceById(id).catch((): Observable<Space> => Observable.of(null));
         }))
         .map((spaces: Space[]): Space[] => {
-          return spaces.filter(((space: Space): boolean => { return space !== null; }));
+          return spaces.filter((space: Space): boolean => space !== null);
         });
       } else {
         return of([]);

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -61,7 +61,7 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
           filter((recentData: RecentData<Space>): boolean => recentData.isSaveRequired)
         )
         .subscribe((recentData: RecentData<Space>): void =>
-          this.saveRecentSpaces(recentData.data)
+          this.saveRecentSpaces(recentData.recent)
         )
     );
 
@@ -75,7 +75,7 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
           filter((recentData: RecentData<Space>) => recentData.isSaveRequired)
         )
         .subscribe((recentData: RecentData<Space>): void =>
-          this.saveRecentSpaces(recentData.data)
+          this.saveRecentSpaces(recentData.recent)
         )
     );
   }


### PR DESCRIPTION
~~Note: this PR is meant to be on top of https://github.com/fabric8-ui/fabric8-ui/pull/3320 [[0]](https://github.com/fabric8-ui/fabric8-ui/pull/3320), so I'll keep it a WIP for the time being. Only the last commit in this PR is relevant here.~~

This PR addresses a comment [[1]](https://github.com/fabric8-ui/fabric8-ui/pull/3320#issuecomment-421436050) on [[0]](https://github.com/fabric8-ui/fabric8-ui/pull/3320) regarding extracting common "recent" logic to an extendable common class. Here, `recent-utils.ts` is introduced and takes care of the:
1. declaration and return of `_recent`
2. logic as a result of broadcaster events `'spaceChanged', 'contextChanged', 'spaceDeleted'`
3. saving the patch to the profile

The loading of recent contexts and spaces happen in similar functionality, but not similar enough that it makes sense to combine the two IMO. The recent spaces are just loaded by simply iterating through the `profile.store.recentSpaces` and getting the space by id from the `SpaceService` on each of them, where the context service needs to distinguish between user contexts and space contexts while loading, potentially building a context to contain spaces with after retreiving the space by id from `SpaceService`.

Additionally I made use of the error handler to remove a few instances of `console.log()`, and added a couple of functions that help out the `recent-utils` by determining if the object in question is a space or context. Also, adding a list of subscriptions in the `SpacesService` so they can be unsubscribed from when `ngOnDestroy` gets called, similar to the changes in the `ContextService`.

[0] https://github.com/fabric8-ui/fabric8-ui/pull/3320
[1] https://github.com/fabric8-ui/fabric8-ui/pull/3320#issuecomment-421436050