### PR TITLE
Deployments utilization bar component can display "other spaces" utilization

### DIFF
--- a/src/app/space/create/deployments/models/resource-utilization.ts
+++ b/src/app/space/create/deployments/models/resource-utilization.ts
@@ -1,0 +1,18 @@
+import { CpuStat } from './cpu-stat';
+import { MemoryStat } from './memory-stat';
+import { Stat } from './stat';
+
+export interface ResourceUtilization {
+  currentSpaceUsage: Stat;
+  otherSpacesUsage: Stat;
+}
+
+export interface CpuResourceUtilization extends ResourceUtilization {
+  currentSpaceUsage: CpuStat;
+  otherSpacesUsage: CpuStat;
+}
+
+export interface MemoryResourceUtilization extends ResourceUtilization {
+  currentSpaceUsage: MemoryStat;
+  otherSpacesUsage: MemoryStat;
+}

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.html
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.html
@@ -3,13 +3,13 @@
     <utilization-bar
       [resourceTitle]="'CPU'"
       [resourceUnit]="'Cores'"
-      [stat]="deploymentsService.getEnvironmentCpuStat(spaceId, environment)"
+      [stat]="deploymentsService.getEnvironmentCpuUtilization(spaceId, environment)"
       [status]="deploymentStatusService.getEnvironmentCpuStatus(spaceId, environment)"
     ></utilization-bar>
     <utilization-bar
       [resourceTitle]="'Memory'"
       [resourceUnit]="memUnit | async"
-      [stat]="deploymentsService.getEnvironmentMemoryStat(spaceId, environment)"
+      [stat]="deploymentsService.getEnvironmentMemoryUtilization(spaceId, environment)"
       [status]="deploymentStatusService.getEnvironmentMemoryStatus(spaceId, environment)"
     ></utilization-bar>
   </div>

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.spec.ts
@@ -47,8 +47,28 @@ describe('ResourceCardComponent', () => {
             const svc: jasmine.SpyObj<DeploymentsService> = createMock(DeploymentsService);
             svc.getApplications.and.returnValue(of(['foo-app', 'bar-app']));
             svc.getEnvironments.and.returnValue(of(['stage', 'prod']));
-            svc.getEnvironmentCpuStat.and.returnValue(of({ used: 1, quota: 2 }));
-            svc.getEnvironmentMemoryStat.and.returnValue(of({ used: 3, quota: 4, units: MemoryUnit.GB }));
+            svc.getEnvironmentCpuUtilization.and.returnValue(of({
+              currentSpaceUsage: {
+                used: 1,
+                quota: 2
+              },
+              otherSpacesUsage: {
+                used: 0,
+                quota: 2
+              }
+            }));
+            svc.getEnvironmentMemoryUtilization.and.returnValue(of({
+              currentSpaceUsage: {
+                used: 3,
+                quota: 4,
+                units: MemoryUnit.GB
+              },
+              otherSpacesUsage: {
+                used: 0,
+                quota: 4,
+                units: MemoryUnit.GB
+              }
+            }));
             return svc;
           }
         },
@@ -71,8 +91,8 @@ describe('ResourceCardComponent', () => {
 
   it('should correctly request the deployed environment data', (): void => {
     const mockSvc: jasmine.SpyObj<DeploymentsService> = TestBed.get(DeploymentsService);
-    expect(mockSvc.getEnvironmentCpuStat).toHaveBeenCalledWith('spaceId', 'stage');
-    expect(mockSvc.getEnvironmentMemoryStat).toHaveBeenCalledWith('spaceId', 'stage');
+    expect(mockSvc.getEnvironmentCpuUtilization).toHaveBeenCalledWith('spaceId', 'stage');
+    expect(mockSvc.getEnvironmentMemoryUtilization).toHaveBeenCalledWith('spaceId', 'stage');
   });
 
   it('should have its children passed the proper values', (): void => {
@@ -83,11 +103,11 @@ describe('ResourceCardComponent', () => {
     const cpuUtilBar: FakeUtilizationBarComponent = arrayOfComponents[0].componentInstance;
     expect(cpuUtilBar.resourceTitle).toEqual('CPU');
     expect(cpuUtilBar.resourceUnit).toEqual('Cores');
-    expect(cpuUtilBar.stat).toEqual(mockSvc.getEnvironmentCpuStat());
+    expect(cpuUtilBar.stat).toEqual(mockSvc.getEnvironmentCpuUtilization());
 
     const memoryUtilBar: FakeUtilizationBarComponent = arrayOfComponents[1].componentInstance;
     expect(memoryUtilBar.resourceTitle).toEqual('Memory');
     expect(memoryUtilBar.resourceUnit).toEqual('GB');
-    expect(memoryUtilBar.stat).toEqual(mockSvc.getEnvironmentMemoryStat());
+    expect(memoryUtilBar.stat).toEqual(mockSvc.getEnvironmentMemoryUtilization());
   });
 });

--- a/src/app/space/create/deployments/resource-usage/resource-card.component.ts
+++ b/src/app/space/create/deployments/resource-usage/resource-card.component.ts
@@ -5,8 +5,8 @@ import {
 } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { MemoryStat } from '../models/memory-stat';
 import { MemoryUnit } from '../models/memory-unit';
+import { MemoryResourceUtilization } from '../models/resource-utilization';
 import { DeploymentStatusService } from '../services/deployment-status.service';
 import { DeploymentsService } from '../services/deployments.service';
 
@@ -29,9 +29,10 @@ export class ResourceCardComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.spaceId && this.environment) {
-      this.memUnit = this.deploymentsService.getEnvironmentMemoryStat(this.spaceId, this.environment).pipe(
-        map((stat: MemoryStat): MemoryUnit => stat.units)
+      this.memUnit = this.deploymentsService.getEnvironmentMemoryUtilization(this.spaceId, this.environment).pipe(
+        map((utilization: MemoryResourceUtilization): MemoryUnit => utilization.currentSpaceUsage.units)
       );
     }
   }
+
 }

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.html
@@ -3,10 +3,19 @@
     {{ resourceTitle }} ({{ resourceUnit }})
   </div>
   <div class="progress">
-    <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"
+    <div *ngIf="usedPercent == 0 && othersPercent == 0" class="progress-bar" role="progressbar" [attr.aria-valuenow]="0" aria-valuemin="0" aria-valuemax="100"
+      [style.width]="0">
+      <span><b id="unusedResourceCardLabel">0 of {{ total }}</b></span>
+    </div>
+    <div *ngIf="usedPercent > 0" class="progress-bar" role="progressbar" [attr.aria-valuenow]="usedPercent" aria-valuemin="0" aria-valuemax="100"
       [ngClass]="warn ? 'utilization-warning' : 'utilization-okay'"
-      [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% Used">
-      <span><b id="resourceCardLabel" [ngClass]="{ 'label-warn': warn }">{{ used }} of {{ total }}</b></span>
+      [style.width]="usedPercent + '%'" data-toggle="tooltip" title="{{ usedPercent }}% used by this Space">
+      <span><b id="resourceCardLabel" [ngClass]="{ 'label-warn': warn }">{{ used + otherSpacesUsed }} of {{ total }}</b></span>
+    </div>
+    <div *ngIf="othersPercent > 0" class="progress-bar" role="progressbar" [attr.aria-valuenow]="othersPercent" aria-valuemin="0" aria-valuemax="100"
+      [ngClass]="warn ? 'utilization-others-warning' : 'utilization-others'"
+      [style.width]="othersPercent + '%'" data-toggle="tooltip" title="{{ othersPercent }}% used by other Spaces">
+      <span><b *ngIf="usedPercent == 0" id="othersResourceCardLabel" [ngClass]="{ 'label-warn': warn }">{{ used + otherSpacesUsed }} of {{ total }}</b></span>
     </div>
     <div class="progress-bar progress-bar-remaining" role="progressbar" [attr.aria-valuenow]="unusedPercent" aria-valuemin="0" aria-valuemax="100"
       [style.width]="unusedPercent + '%'" data-toggle="tooltip" title="{{ unusedPercent }}% Available">

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.less
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.less
@@ -3,9 +3,19 @@
 .utilization {
   &-okay {
     background: @color-pf-blue-300;
+    border-right: 1px solid @color-pf-black-200;
   }
   &-warning {
     background: @color-pf-orange-300;
+    border-right: 1px solid @color-pf-black-200;
+  }
+  &-others {
+    background: @color-pf-blue-500;
+    border-right: 1px solid @color-pf-black-200;
+  }
+  &-others-warning {
+    background: @color-pf-orange-400;
+    border-right: 1px solid @color-pf-black-200;
   }
 }
 

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit
 } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
-import { Stat } from '../models/stat';
+import { ResourceUtilization } from '../models/resource-utilization';
 import {
   Status,
   StatusType
@@ -20,26 +20,33 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
 
   @Input() resourceTitle: string;
   @Input() resourceUnit: string;
-  @Input() stat: Observable<Stat>;
+  @Input() stat: Observable<ResourceUtilization>;
   @Input() status: Observable<Status>;
 
   warn: boolean = false;
 
   used: number;
+  otherSpacesUsed: number;
+
   total: number;
+
   usedPercent: number;
+  othersPercent: number;
   unusedPercent: number;
 
   private readonly subscriptions: Subscription[] = [];
 
   ngOnInit(): void {
     this.subscriptions.push(
-      this.stat.subscribe((val: Stat): void => {
-        this.used = val.used;
-        this.total = val.quota;
+      this.stat.subscribe((val: ResourceUtilization): void => {
+        console.log('TAG', val);
+        this.used = val.currentSpaceUsage.used;
+        this.otherSpacesUsed = val.otherSpacesUsage.used;
+        this.total = val.currentSpaceUsage.quota;
 
         this.usedPercent = (this.total !== 0) ? Math.floor(this.used / this.total * 100) : 0;
-        this.unusedPercent = 100 - this.usedPercent;
+        this.othersPercent = (this.total !== 0) ? Math.floor(this.otherSpacesUsed / this.total * 100) : 0;
+        this.unusedPercent = 100 - (this.usedPercent + this.othersPercent);
       })
     );
 

--- a/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
+++ b/src/app/space/create/deployments/resource-usage/utilization-bar.component.ts
@@ -39,7 +39,6 @@ export class UtilizationBarComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.subscriptions.push(
       this.stat.subscribe((val: ResourceUtilization): void => {
-        console.log('TAG', val);
         this.used = val.currentSpaceUsage.used;
         this.otherSpacesUsed = val.otherSpacesUsage.used;
         this.total = val.currentSpaceUsage.quota;

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -17,6 +17,7 @@ import { Observable , of, throwError } from 'rxjs';
 import { catchError , map } from 'rxjs/operators';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
+import { Stat } from '../models/stat';
 
 export interface ApplicationsResponse {
   data: Space;
@@ -89,6 +90,36 @@ export interface Quota {
   memory: MemoryStat;
 }
 
+export interface EnvironmentQuotaResponse {
+  id: string;
+  type: string;
+  data: EnvironmentQuota[];
+}
+
+export interface EnvironmentQuota {
+  attributes: EnvironmentQuotaAttributes;
+}
+
+export interface EnvironmentQuotaAttributes {
+  name: string;
+  space_usage: EnvironmentResourceUsage;
+  other_usage: OtherUsage;
+}
+
+export interface EnvironmentResourceUsage {
+  cpucores: number;
+  memory: number;
+}
+
+export interface OtherUsage {
+  cpucores: CpuStat;
+  memory: MemoryStat;
+  persistent_volume_claims: Stat;
+  replication_controllers: Stat;
+  secrets: Stat;
+  services: Stat;
+}
+
 export interface TimeseriesResponse {
   data: DeploymentStats;
 }
@@ -153,7 +184,7 @@ export class DeploymentApiService {
 
   constructor(
     private readonly http: HttpClient,
-    @Inject(WIT_API_URL) witUrl: string,
+    @Inject(WIT_API_URL) private readonly witUrl: string,
     private readonly auth: AuthenticationService,
     private readonly logger: Logger,
     private readonly errorHandler: ErrorHandler
@@ -168,6 +199,13 @@ export class DeploymentApiService {
     const encSpaceId: string = encodeURIComponent(spaceId);
     return this.httpGet<EnvironmentsResponse>(`${this.apiUrl}${encSpaceId}/environments`).pipe(
       map((response: EnvironmentsResponse): EnvironmentStat[] => response.data)
+    );
+  }
+
+  getQuotas(spaceId: string): Observable<EnvironmentQuota[]> {
+    const encSpaceId: string = encodeURIComponent(spaceId);
+    return this.httpGet<{}>(`${this.witUrl}deployments/environments/spaces/${encSpaceId}`).pipe(
+      map((response: EnvironmentQuotaResponse): EnvironmentQuota[] => response.data)
     );
   }
 

--- a/src/app/space/create/deployments/services/deployment-api.service.ts
+++ b/src/app/space/create/deployments/services/deployment-api.service.ts
@@ -13,8 +13,8 @@ import {
 import { Logger } from 'ngx-base';
 import { WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
-import { Observable , of, throwError } from 'rxjs';
-import { catchError , map } from 'rxjs/operators';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { CpuStat } from '../models/cpu-stat';
 import { MemoryStat } from '../models/memory-stat';
 import { Stat } from '../models/stat';

--- a/src/app/space/create/deployments/services/deployments.service.spec.ts
+++ b/src/app/space/create/deployments/services/deployments.service.spec.ts
@@ -27,6 +27,10 @@ import { MemoryUnit } from '../models/memory-unit';
 import { NetworkStat } from '../models/network-stat';
 import { PodPhase } from '../models/pod-phase';
 import { Pods } from '../models/pods';
+import {
+  CpuResourceUtilization,
+  MemoryResourceUtilization
+} from '../models/resource-utilization';
 import { ScaledMemoryStat } from '../models/scaled-memory-stat';
 import { ScaledNetStat } from '../models/scaled-net-stat';
 import { DeploymentApiService } from './deployment-api.service';
@@ -36,7 +40,6 @@ import {
   TIMER_TOKEN,
   TIMESERIES_SAMPLES_TOKEN
 } from './deployments.service';
-import { CpuResourceUtilization, MemoryResourceUtilization } from '../models/resource-utilization';
 
 describe('DeploymentsService', (): void => {
 


### PR DESCRIPTION
~~~This PR is a basic rough prototype for https://github.com/openshiftio/openshift.io/issues/3128 . This requires backend support from https://github.com/openshiftio/openshift.io/issues/3129 . It looks unlikely that I will be following through with the final implementation of this feature, so I leave it here as a WIP so someone else can easily pick it up.~~~

![image](https://user-images.githubusercontent.com/3787464/46962798-098ec200-d072-11e8-81ff-2ca54cb5b383.png)

![image](https://user-images.githubusercontent.com/3787464/46962815-17444780-d072-11e8-9f54-2391b26cc1c5.png)

This PR implements https://github.com/openshiftio/openshift.io/issues/3128 , allowing the Deployments page resource cards to indicate how much of the taken quota is used in the currently viewed Space context and how much is taken elsewhere (by deployments in different spaces). See the above screenshots depicting a scenario where two spaces are splitting quota in the Stage environment, and only one has a deployment in the Run environment.