### PR TITLE
fix(webpack): remove sourcemap file mappings

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -103,7 +103,7 @@ module.exports = function (options) {
      * See: http://webpack.github.io/docs/configuration.html#devtool
      * See: https://github.com/webpack/docs/wiki/build-performance#sourcemaps
      */
-    devtool: 'inline-source-map',
+    devtool: 'source-map',
 
     /**
      * Options affecting the output of the compilation.
@@ -144,10 +144,6 @@ module.exports = function (options) {
        * See: http://webpack.github.io/docs/configuration.html#output-chunkfilename
        */
       chunkFilename: '[name].chunk.js',
-
-      // Point sourcemap entries to original disk location (format as URL on Windows)
-      devtoolModuleFilenameTemplate: (info) =>
-        path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
     },
 
     resolve: {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -155,11 +155,6 @@ module.exports = function (env) {
        * See: http://webpack.github.io/docs/configuration.html#output-chunkfilename
        */
       chunkFilename: '_assets/lib/[name].[chunkhash:8].chunk.js',
-
-      // Point sourcemap entries to original disk location (format as URL on Windows)
-      devtoolModuleFilenameTemplate: (info) =>
-        path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
-
     },
 
     optimization: {


### PR DESCRIPTION
The existing sourcemap file mappings remap paths to local file system although it can make browsing more difficult. Removing to return to webpack defaults.