### PR TITLE
fix(tree-view): Fix missing expand toggle in area components

### DIFF
--- a/src/vendor.browser.ts
+++ b/src/vendor.browser.ts
@@ -28,6 +28,7 @@ import 'rxjs';
 import '../node_modules/patternfly/dist/css/patternfly.fontless.min.css';
 import '../node_modules/patternfly/dist/css/patternfly-additions.min.css';
 import '../node_modules/patternfly-ng/dist/css/patternfly-ng.min.css';
+import '../node_modules/patternfly-sandbox-ng/dist/css/patternfly-sandbox-ng.min.css';
 
 if ('production' === ENV) {
   // Production


### PR DESCRIPTION
Fixes https://openshift.io/openshiftio/Openshift_io/plan/detail/548
In ng6 upgrade, we missed the css therefore the ability to expand the treelist was removed. 