### PR TITLE
fix(header): fix header navbar colouring to be dark

### DIFF
--- a/src/app/layout/header/header.component.less
+++ b/src/app/layout/header/header.component.less
@@ -72,22 +72,21 @@
     > .active > a {
       background-color: @color-pf-black-900;
       background-image: linear-gradient(to top, @color-pf-black-700 0, @color-pf-black-900 100%);
+      border-bottom-color: @color-pf-black-900;
     }
     &.persistent-secondary {
-      //background-color: @color-pf-black-150;
+      background: none;
       > li {
         &.active {
           &.with-no-children { margin-bottom: 0; }
         }
         .navbar-persistent {
-          background-color: @color-pf-black-150;
-          > li:hover:before {
-            background: none;
-          }
+          border-bottom: 1px solid;
+          border-bottom-color: @color-pf-black;
+          background-color: @color-pf-black-900;
           > li a {
-            &:hover {
-              color: @color-pf-blue;
-            }
+            color: @color-pf-white;
+            &:hover { color: @color-pf-black-300; }
           }
         }
       }


### PR DESCRIPTION
This PR addresses https://github.com/openshiftio/openshift.io/issues/4375 and https://openshift.io/openshiftio/Openshift_io/plan/detail/783, where the header navbar should be made to be a darker colour.

It essentially just reverts an older commit [[0]](https://github.com/fabric8-ui/fabric8-ui/pull/2984) to make the navbar lighter, and here are some screenshots I took:

Base navbar:
![2018-10-10-131442_263x77_scrot](https://user-images.githubusercontent.com/10425301/46753921-25b7eb00-cc8f-11e8-92aa-95a786ce5f8f.png)

Base navbar with hover:
![2018-10-10-131458_1916x1033_scrot 1](https://user-images.githubusercontent.com/10425301/46754002-5730b680-cc8f-11e8-8a36-c9445ba45290.jpg)

Planner navbar:
![2018-10-10-131626_319x516_scrot](https://user-images.githubusercontent.com/10425301/46753923-25b7eb00-cc8f-11e8-9ded-b319167025f7.png)

[0] https://github.com/fabric8-ui/fabric8-ui/pull/2984