### PR TITLE
feat(header): add 'Create Issue' help menu item to open GitHub issues

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -131,6 +131,11 @@
                     Documentation
                   </a>
                 </li>
+                <li id="header_createIssue" class="list-group-item">
+                  <a href="https://github.com/openshiftio/openshift.io/issues" target="_blank">
+                    Create Issue
+                  </a>
+                </li>
                 <li id="header_loggedinChat" class="list-group-item">
                   <a href="https://chat.openshift.io/developers/channels/town-square" target="top" class="pointer">
                     Chat with us


### PR DESCRIPTION
This PR addresses https://github.com/openshiftio/openshift.io/issues/4188 & https://openshift.io/openshiftio/Openshift_io/plan/detail/784, which adds a link to the help menu to direct users to the OSIO issues page.

Here's a shot of the drop down:
![2018-10-10-164327_198x211_scrot](https://user-images.githubusercontent.com/10425301/46765003-f06dc600-ccab-11e8-8906-f6b19131bae3.png)

And here's what it looks like in action:
![create-issue-link](https://user-images.githubusercontent.com/10425301/46765073-172bfc80-ccac-11e8-9705-0984e6a6d37f.gif)
