### PR TITLE
fix(less): fix pfng list header text spacing

### DIFF
--- a/src/app/space/create/codebases/codebases.component.less
+++ b/src/app/space/create/codebases/codebases.component.less
@@ -19,6 +19,7 @@
 }
 
 .pfng-list-heading {
+  display: block;
   background-color: @color-pf-black-200 !important; /* stylelint-disable-line declaration-no-important */
 }
 


### PR DESCRIPTION
This one-liner addresses https://github.com/openshiftio/openshift.io/issues/4408.

After the f8-ui updates the spacing of the `pfng-list-heading` has been out of sync with the list itself. This is because the `pfng-list-heading` is now given a `display: flex` by the patternfly-ng stylesheets, whereas before it used to be `display: block`. Adding this display type to the `codebases.component.less` will amend the spacing.

Before:
![before](https://user-images.githubusercontent.com/10425301/46813583-f9f73c80-cd44-11e8-935f-50016a14adac.png)

After:
![after](https://user-images.githubusercontent.com/10425301/46813543-e6e46c80-cd44-11e8-95ea-aa4b25bb14b0.png)
