### PR TITLE
fix(header): fix capitalization of 'Create Space' in the user dropdown

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -86,7 +86,7 @@
                   <span class="nav-item-icon">
                     <i class="pficon pficon-add-circle-o"></i>
                   </span>
-                    Create space
+                    Create Space
                 </a>
               </li>
               <li id="header_spaces">


### PR DESCRIPTION
This one-liner fixes https://github.com/openshiftio/openshift.io/issues/4420, in which the capitalization of `Create space` to `Create Space` in the user menu is fixed.

Before:
![before](https://user-images.githubusercontent.com/12504403/46918792-789de500-cfa4-11e8-936f-bb8a1a2f2167.png)

After:
![after](https://user-images.githubusercontent.com/10425301/46954880-a5fb9900-d05f-11e8-8224-9bb845c61ccb.png)
