### PR TITLE
fix(spaces): improve the spaces page to display owned and shared spaces

### DIFF
--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -18,17 +18,13 @@ import { MockFeatureToggleComponent } from 'testing/mock-feature-toggle.componen
 import { initContext, TestContext } from 'testing/test-context';
 
 import {
-  Space,
-  SpaceService
-} from 'ngx-fabric8-wit';
-import {
   User,
   UserService
 } from 'ngx-login-client';
 import { LoadingWidgetComponent } from '../dashboard-widgets/loading-widget/loading-widget.component';
 import { LoadingWidgetModule } from '../dashboard-widgets/loading-widget/loading-widget.module';
+import { UserSpacesService } from '../shared/user-spaces.service';
 import { HomeComponent } from './home.component';
-import { UserSpacesService } from './user-spaces.service';
 
 @Component({
   template: '<alm-home></alm-home>'

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { User, UserService } from 'ngx-login-client';
 import { first } from 'rxjs/operators';
-import { UserSpacesService } from './user-spaces.service';
+import { UserSpacesService } from '../shared/user-spaces.service';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.html
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.html
@@ -5,6 +5,7 @@
   <div class="toolbar-header">
     <pfng-toolbar class="padding-top-10"
         [config]="toolbarConfig"
+        [actionTemplate]="actionTemplate"
         [viewTemplate]="toolbarTemplate"
         (onFilterChange)="filterChange($event)"
         (onSortChange)="sortChange($event)">
@@ -27,6 +28,7 @@
   <div class="toolbar-header">
     <pfng-toolbar class="padding-top-10"
         [config]="toolbarConfig"
+        [actionTemplate]="actionTemplate"
         [viewTemplate]="toolbarTemplate"
         (onFilterChange)="filterChange($event)"
         (onSortChange)="sortChange($event)">
@@ -40,5 +42,17 @@
         </span>
       </ng-template>
     </pfng-toolbar>
+  </div>
+</ng-template>
+
+ <!-- toggle button implementation -->
+<ng-template #actionTemplate>
+  <div class="btn-group">
+    <button class="btn btn-default btn-left" [ngClass]="{'active': activeButton === SpacesType.MYSPACES}" type="button" (click)="showMySpaces()">
+      My Spaces
+    </button>
+    <button class="btn btn-default btn-right" [ngClass]="{'active': activeButton === SpacesType.SHAREDSPACES}" type="button" (click)="showSharedSpaces()">
+      Shared Spaces
+    </button>
   </div>
 </ng-template>

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.less
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.less
@@ -10,6 +10,16 @@
     padding-right: 20px;
     .toolbar-pf {
       padding-top: 14px;
+      .btn-group {
+        .active {
+          background-color: @color-pf-blue-400;
+          color: @color-pf-white;
+        }
+        .btn-right {
+          border-left-width: 0;
+          margin: 0;
+        }
+      }
     }
   }
   .toolbar-pf-action-right {

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.spec.ts
@@ -4,8 +4,10 @@ import {
   Input,
   Output
 } from '@angular/core';
+import { Broadcaster } from 'ngx-base';
 import { FilterEvent } from 'patternfly-ng/filter';
 import { SortEvent } from 'patternfly-ng/sort';
+import { createMock } from 'testing/mock';
 import { MockFeatureToggleComponent } from 'testing/mock-feature-toggle.component';
 import { initContext } from 'testing/test-context';
 import { MySpacesToolbarComponent } from './my-spaces-toolbar.component';
@@ -31,6 +33,7 @@ class TestHostComponent {
 })
 class FakePfngToolbarComponent {
   @Input() config: any;
+  @Input() actionTemplate: any;
   @Input() viewTemplate: any;
   @Output() onFilterChange = new EventEmitter<FilterEvent>();
   @Output() onSortChange = new EventEmitter<SortEvent>();
@@ -41,6 +44,14 @@ describe('MySpacesToolbarComponent', () => {
     declarations: [
       FakePfngToolbarComponent,
       MockFeatureToggleComponent
+    ],
+    providers: [
+      {
+        provide: Broadcaster,
+        useFactory: (): jasmine.SpyObj<Broadcaster> => {
+          return createMock(Broadcaster);
+        }
+      }
     ]
   });
 

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.spec.ts
@@ -4,10 +4,8 @@ import {
   Input,
   Output
 } from '@angular/core';
-import { Broadcaster } from 'ngx-base';
 import { FilterEvent } from 'patternfly-ng/filter';
 import { SortEvent } from 'patternfly-ng/sort';
-import { createMock } from 'testing/mock';
 import { MockFeatureToggleComponent } from 'testing/mock-feature-toggle.component';
 import { initContext } from 'testing/test-context';
 import { MySpacesToolbarComponent } from './my-spaces-toolbar.component';
@@ -44,14 +42,6 @@ describe('MySpacesToolbarComponent', () => {
     declarations: [
       FakePfngToolbarComponent,
       MockFeatureToggleComponent
-    ],
-    providers: [
-      {
-        provide: Broadcaster,
-        useFactory: (): jasmine.SpyObj<Broadcaster> => {
-          return createMock(Broadcaster);
-        }
-      }
     ]
   });
 

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
@@ -10,12 +10,11 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { Broadcaster } from 'ngx-base';
 import { FilterConfig, FilterEvent, FilterField } from 'patternfly-ng/filter';
 import { SortConfig, SortEvent } from 'patternfly-ng/sort';
 import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
-enum SpacesType {
+export enum SpacesType {
   MYSPACES = 'mySpaces',
   SHAREDSPACES = 'sharedSpaces'
 }
@@ -33,6 +32,7 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
   @Output('onSearchSpaces') onSearchSpaces = new EventEmitter();
   @Output('onFilterChange') onFilterChange = new EventEmitter();
   @Output('onSortChange') onSortChange = new EventEmitter();
+  @Output('onToggleChange') onToggleChange: EventEmitter<SpacesType> = new EventEmitter<SpacesType>();
 
   @ViewChild('addCodebaseTemplate') addCodebaseTemplate: TemplateRef<any>;
 
@@ -43,8 +43,7 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
   activeButton: string = SpacesType.MYSPACES;
   SpacesType: typeof SpacesType = SpacesType;
 
-  constructor(private broadcaster: Broadcaster) {
-  }
+  constructor() { }
 
   // Initialization
 
@@ -83,16 +82,6 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
     }
   }
 
-  showMySpaces(): void {
-    this.activeButton = SpacesType.MYSPACES;
-    this.broadcaster.broadcast('displayMySpaces');
-  }
-
-  showSharedSpaces(): void {
-    this.activeButton = SpacesType.SHAREDSPACES;
-    this.broadcaster.broadcast('displaySharedSpaces');
-  }
-
   // Actions
 
   createSpace($event: MouseEvent): void {
@@ -109,5 +98,15 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
 
   sortChange($event: SortEvent): void {
     this.onSortChange.emit($event);
+  }
+
+  showMySpaces(): void {
+    this.activeButton = SpacesType.MYSPACES;
+    this.onToggleChange.emit(SpacesType.MYSPACES);
+  }
+
+  showSharedSpaces(): void {
+    this.activeButton = SpacesType.SHAREDSPACES;
+    this.onToggleChange.emit(SpacesType.SHAREDSPACES);
   }
 }

--- a/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
+++ b/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.ts
@@ -10,9 +10,15 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
+import { Broadcaster } from 'ngx-base';
 import { FilterConfig, FilterEvent, FilterField } from 'patternfly-ng/filter';
 import { SortConfig, SortEvent } from 'patternfly-ng/sort';
 import { ToolbarConfig } from 'patternfly-ng/toolbar';
+
+enum SpacesType {
+  MYSPACES = 'mySpaces',
+  SHAREDSPACES = 'sharedSpaces'
+}
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -34,8 +40,10 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
   isAscendingSort: boolean = true;
   sortConfig: SortConfig;
   toolbarConfig: ToolbarConfig;
+  activeButton: string = SpacesType.MYSPACES;
+  SpacesType: typeof SpacesType = SpacesType;
 
-  constructor() {
+  constructor(private broadcaster: Broadcaster) {
   }
 
   // Initialization
@@ -73,6 +81,16 @@ export class MySpacesToolbarComponent implements OnInit, OnChanges {
     if (changes.resultsCount && this.filterConfig) {
       this.filterConfig.resultsCount = changes.resultsCount.currentValue;
     }
+  }
+
+  showMySpaces(): void {
+    this.activeButton = SpacesType.MYSPACES;
+    this.broadcaster.broadcast('displayMySpaces');
+  }
+
+  showSharedSpaces(): void {
+    this.activeButton = SpacesType.SHAREDSPACES;
+    this.broadcaster.broadcast('displaySharedSpaces');
   }
 
   // Actions

--- a/src/app/profile/my-spaces/my-spaces.component.html
+++ b/src/app/profile/my-spaces/my-spaces.component.html
@@ -4,6 +4,7 @@
     (onSearchSpaces)="showSearchSpacesOverlay()"
     (onFilterChange)="filterChange($event)"
     (onSortChange)="sortChange($event)"
+    (onToggleChange)="toggleChange($event)"
     [resultsCount]="resultsCount">
   </my-spaces-toolbar>
   <div class="container-fluid margin-bottom-20">

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -21,6 +21,7 @@ import { ExtProfile, GettingStartedService } from '../../getting-started/service
 import { spaceMock } from '../../shared/context.service.mock';
 import { UserSpacesService } from '../../shared/user-spaces.service';
 import { MySpacesComponent } from './my-spaces.component';
+import { SpacesType } from './my-spaces-toolbar/my-spaces-toolbar.component';
 
 @Component({
   template: '<alm-my-spaces></alm-my-spaces>'
@@ -185,6 +186,12 @@ describe('MySpacesComponent', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
       const result: Space[] = component.spaces;
       expect(result).toEqual([spaceMock1, spaceMock2]);
+    });
+
+    it('should toggle to show Shared Spaces', (): void => {
+      const component: MySpacesComponent = testContext.testedDirective;
+      component.toggleChange(SpacesType.SHAREDSPACES);
+      expect(component.spaces).toEqual([spaceMock3]);
     });
   });
 

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -221,7 +221,7 @@ describe('MySpacesComponent', (): void => {
 
     it('should toggle the pin state', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      spyOn(component, 'savePins').and.callFake((): void => {});
+      spyOn(component, 'savePins').and.callThrough();
       spyOn(component, 'updateSpaces');
       component.handlePinChange(spaceMock1);
       expect((component.spaces[0] as any).showPin).toBe(false);

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -19,7 +19,7 @@ import { createMock } from 'testing/mock';
 import { initContext, TestContext } from 'testing/test-context';
 import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { spaceMock } from '../../shared/context.service.mock';
-import { UserSpacesService, SpaceInformation } from '../../shared/user-spaces.service';
+import { UserSpacesService } from '../../shared/user-spaces.service';
 import { MySpacesComponent } from './my-spaces.component';
 
 @Component({
@@ -155,7 +155,7 @@ describe('MySpacesComponent', (): void => {
           const mockSpaceService: any = createMock(SpaceService);
           mockSpaceService.getSpacesByUser.and.returnValue(of([spaceMock1, spaceMock2]));
           mockSpaceService.getSpaceById.and.returnValue(of([spaceMock3]));
-          mockSpaceService.deleteSpace = () => {};
+          mockSpaceService.deleteSpace.and.stub();
           return mockSpaceService;
         }
       },
@@ -179,17 +179,7 @@ describe('MySpacesComponent', (): void => {
         provide: UserSpacesService,
         useFactory: (): jasmine.SpyObj<UserSpacesService> => {
           const mockUserSpacesService: jasmine.SpyObj<UserSpacesService> = createMock(UserSpacesService);
-          const mockSpaceInformation: SpaceInformation[] = [{
-            attributes: {
-              name: 'spaceMock3-name'
-            },
-            id: '3',
-            links: {
-              self: 'mock-link'
-            },
-            type: 'mock-type'
-          }];
-          mockUserSpacesService.getInvolvedSpaces.and.returnValue(of(mockSpaceInformation));
+          mockUserSpacesService.getSharedSpaces.and.returnValue(of([spaceMock3]));
           return mockUserSpacesService;
         }
       }
@@ -200,7 +190,7 @@ describe('MySpacesComponent', (): void => {
   describe('#spaces', (): void => {
     it('should return the contents of _spaces', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: Space[] = component.spaces;
+      const result: Space[] = component.spaces;
       expect(result).toEqual([spaceMock1, spaceMock2]);
     });
   });
@@ -208,7 +198,7 @@ describe('MySpacesComponent', (): void => {
   describe('#handlePinChange', (): void => {
     it('should delegate to savePins and updateSpaces if the selected space exists in the user\'s spaces', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      spyOn(component, 'savePins').and.callFake((): void => {});
+      spyOn(component, 'savePins').and.callThrough();
       spyOn(component, 'updateSpaces');
       component.handlePinChange(spaceMock1);
       expect(component.savePins).toHaveBeenCalled();
@@ -222,7 +212,7 @@ describe('MySpacesComponent', (): void => {
   describe('#handlePinChange', (): void => {
     it('should delegate to savePins and updateSpaces if the selected space exists in the user\'s spaces', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      spyOn(component, 'savePins').and.callFake((): void => {});
+      spyOn(component, 'savePins').and.callThrough();
       spyOn(component, 'updateSpaces');
       component.handlePinChange(spaceMock1);
       expect(component.savePins).toHaveBeenCalled();
@@ -278,19 +268,19 @@ describe('MySpacesComponent', (): void => {
   describe('#matchesFilter', (): void => {
     it('should return true if there is a space that matches the filter value', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: boolean = component.matchesFilter(spaceMock1, mockFilter1);
+      const result: boolean = component.matchesFilter(spaceMock1, mockFilter1);
       expect(result).toBe(true);
     });
 
     it('should return false if there is no space that matches the filter value', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: boolean = component.matchesFilter(spaceMock1, mockFilter2);
+      const result: boolean = component.matchesFilter(spaceMock1, mockFilter2);
       expect(result).toBe(false);
     });
 
     it('should simply return true if the filter id isn\'t name, because this is not supported functionality', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: boolean = component.matchesFilter(spaceMock1, mockFilter3);
+      const result: boolean = component.matchesFilter(spaceMock1, mockFilter3);
       expect(result).toBe(true);
     });
 
@@ -298,7 +288,7 @@ describe('MySpacesComponent', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
       const mockFilterCaseInsensitive: Filter = cloneDeep(mockFilter1);
       mockFilterCaseInsensitive.value = mockFilter1.value.toUpperCase();
-      let result: boolean = component.matchesFilter(spaceMock1, mockFilterCaseInsensitive);
+      const result: boolean = component.matchesFilter(spaceMock1, mockFilterCaseInsensitive);
       expect(result).toBe(true);
     });
   });
@@ -315,14 +305,14 @@ describe('MySpacesComponent', (): void => {
     it('should return true if all of the filters are satisfied', () => {
       const component: MySpacesComponent = testContext.testedDirective;
       let mockFilters: Filter[] = [mockFilter1, mockFilter3];
-      let result: boolean = component.matchesFilters(spaceMock2, mockFilters);
+      const result: boolean = component.matchesFilters(spaceMock2, mockFilters);
       expect(result).toBe(true);
     });
 
     it('should return false if at least one of the filters results in zero matches', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
       let mockFilters: Filter[] = [mockFilter1, mockFilter2, mockFilter3];
-      let result: boolean = component.matchesFilters(spaceMock1, mockFilters);
+      const result: boolean = component.matchesFilters(spaceMock1, mockFilters);
       expect(result).toBe(false);
     });
   });
@@ -334,13 +324,13 @@ describe('MySpacesComponent', (): void => {
   describe('#canDeleteSpace', (): void => {
     it('should be true if the creator and user are the same people', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: boolean = component.canDeleteSpace('mock-id');
+      const result: boolean = component.canDeleteSpace('mock-id');
       expect(result).toBe(true);
     });
 
     it('should be false if the creator and user are different people', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: boolean = component.canDeleteSpace('not-mock-id');
+      const result: boolean = component.canDeleteSpace('not-mock-id');
       expect(result).toBe(false);
     });
   });
@@ -373,7 +363,7 @@ describe('MySpacesComponent', (): void => {
     });
 
     it('should remove the selected space out of _spaces', (): void => {
-      let component: MySpacesComponent = testContext.testedDirective;
+      const component: MySpacesComponent = testContext.testedDirective;
       const mockSpaceService: jasmine.SpyObj<SpaceService> = TestBed.get(SpaceService);
       spyOn(mockSpaceService, 'deleteSpace').and.returnValue(of(spaceMock1));
       spyOn(component, 'savePins').and.callThrough();
@@ -427,7 +417,7 @@ describe('MySpacesComponent', (): void => {
         isAscending: true
       };
       component.sortChange(mockSortEvent);
-      let result: number = component.compare(spaceMock1, spaceMock1);
+      const result: number = component.compare(spaceMock1, spaceMock1);
       expect(result).toBe(0);
     });
 
@@ -441,13 +431,13 @@ describe('MySpacesComponent', (): void => {
         isAscending: false
       };
       component.sortChange(mockSortEvent);
-      let result: number = component.compare(spaceMock1, spaceMock1);
+      const result: number = component.compare(spaceMock1, spaceMock1);
       expect(result).toBe(0);
     });
 
     it('should return -1 if the first space is first alphabetically, sorted ascending', (): void => {
       const component: MySpacesComponent = testContext.testedDirective;
-      let result: number = component.compare(spaceMock1, spaceMock2);
+      const result: number = component.compare(spaceMock1, spaceMock2);
       expect(result).toBe(-1);
     });
 
@@ -461,7 +451,7 @@ describe('MySpacesComponent', (): void => {
         isAscending: false
       };
       component.sortChange(mockSortEvent);
-      let result: number = component.compare(spaceMock1, spaceMock2);
+      const result: number = component.compare(spaceMock1, spaceMock2);
       expect(result).toBe(1);
     });
 
@@ -472,7 +462,7 @@ describe('MySpacesComponent', (): void => {
         isAscending: false
       };
       component.sortChange(mockSortEvent);
-      let result: number = component.compare(spaceMock1, spaceMock2);
+      const result: number = component.compare(spaceMock1, spaceMock2);
       expect(result).toBe(0);
     });
   });

--- a/src/app/profile/my-spaces/my-spaces.component.spec.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.spec.ts
@@ -129,14 +129,7 @@ describe('MySpacesComponent', (): void => {
         provide: Broadcaster,
         useFactory: (): jasmine.SpyObj<Broadcaster> => {
           const mockBroadcaster: jasmine.SpyObj<Broadcaster> = createMock(Broadcaster);
-          mockBroadcaster.on.and.callFake((key: string): Observable<any> => {
-            if (key === 'displayMySpaces') {
-              return of([spaceMock1, spaceMock2]);
-            }
-            if (key === 'displaySharedSpaces') {
-              return of([spaceMock3]);
-            }
-          });
+          mockBroadcaster.on.and.stub();
           mockBroadcaster.broadcast.and.callThrough();
           return mockBroadcaster;
         }

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -24,6 +24,7 @@ import {
 import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
 import { UserSpacesService } from '../../shared/user-spaces.service';
 import { MySpacesSearchSpacesDialog } from './my-spaces-search-dialog/my-spaces-search-spaces-dialog.component';
+import { SpacesType } from './my-spaces-toolbar/my-spaces-toolbar.component';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -78,22 +79,6 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     this.subscriptions.push(
       this.userService.loggedInUser.subscribe((user: User): void => {
         this.loggedInUser = user;
-      })
-    );
-
-    this.subscriptions.push(
-      this.broadcaster.on('displayMySpaces').subscribe((): void => {
-        this.listConfig.emptyStateConfig = this.mySpacesEmptyStateConfig;
-        this._spaces = this.mySpaces;
-        this.updateSpaces();
-      })
-    );
-
-    this.subscriptions.push(
-      this.broadcaster.on('displaySharedSpaces').subscribe((): void => {
-        this.listConfig.emptyStateConfig = this.sharedSpacesEmptyStateConfig;
-        this._spaces = this.sharedSpaces;
-        this.updateSpaces();
       })
     );
 
@@ -169,6 +154,18 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   // returns an Observable containing the list of spaces the user owns
   getMySpaces(): Observable<Space[]> {
     return this.spaceService.getSpacesByUser(this.context.user.attributes.username);
+  }
+
+  toggleChange(event: SpacesType): void {
+    if (event === SpacesType.MYSPACES) {
+      this.listConfig.emptyStateConfig = this.mySpacesEmptyStateConfig;
+      this._spaces = this.mySpaces;
+      this.updateSpaces();
+    } else if (event === SpacesType.SHAREDSPACES) {
+      this.listConfig.emptyStateConfig = this.sharedSpacesEmptyStateConfig;
+      this._spaces = this.sharedSpaces;
+      this.updateSpaces();
+    }
   }
 
   // Accessors

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -78,11 +78,15 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     this.initPfListConfigs();
 
     this.subscriptions.push(
-      this.contexts.current.subscribe(val => this.context = val)
+      this.contexts.current.subscribe((val: Context): void => {
+        this.context = val;
+      })
     );
 
     this.subscriptions.push(
-      this.userService.loggedInUser.subscribe(user => { this.loggedInUser = user; })
+      this.userService.loggedInUser.subscribe((user: User): void => {
+        this.loggedInUser = user;
+      })
     );
 
     this.subscriptions.push(
@@ -90,7 +94,8 @@ export class MySpacesComponent implements OnDestroy, OnInit {
         this.listConfig.emptyStateConfig = this.mySpacesEmptyStateConfig;
         this._spaces = this.mySpaces;
         this.updateSpaces();
-    }));
+      })
+    );
 
     this.subscriptions.push(
       this.broadcaster.on('displaySharedSpaces').subscribe((): void => {
@@ -193,7 +198,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   // Events
 
   handlePinChange($event: any): void {
-    let index: any = findIndex(this._spaces, (obj) => {
+    let index: any = findIndex(this._spaces, (obj: Space): boolean => {
       return obj.id === $event.id;
     });
     if (index > -1) {
@@ -210,7 +215,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     let filters = this.appliedFilters;
     this.displayedSpaces = [];
     if (filters && filters.length > 0) {
-      this._spaces.forEach((space) => {
+      this._spaces.forEach((space: Space): void => {
         if (this.matchesFilters(space, filters)) {
           this.displayedSpaces.push(space);
         }
@@ -233,7 +238,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   matchesFilters(space: Space, filters: Filter[]): boolean {
     let matches = true;
 
-    filters.forEach((filter) => {
+    filters.forEach((filter: Filter) => {
       if (!this.matchesFilter(space, filter)) {
         matches = false;
         return false;
@@ -262,8 +267,8 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     if (this.context && this.context.user && this.spaceToDelete) {
       let space = this.spaceToDelete;
       this.spaceService.deleteSpace(space)
-        .subscribe(spaces => {
-          let index: any = findIndex(this._spaces, (obj) => {
+        .subscribe((): void => {
+          let index: any = findIndex(this._spaces, (obj: Space): boolean => {
             return obj.id === space.id;
           });
           if (has(this._spaces[index], 'showPin')) {
@@ -275,7 +280,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
           this.spaceToDelete = undefined;
           this.modalRef.hide();
         },
-        err => {
+        (err: any): void => {
           this.logger.error(err);
           this.spaceToDelete = undefined;
           this.modalRef.hide();
@@ -294,7 +299,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   // Sort
 
   compare(space1: Space, space2: Space): number {
-    var compValue = 0;
+    let compValue: number = 0;
     if (this.currentSortField && this.currentSortField.id === 'name') {
       compValue = space1.attributes.name.localeCompare(space2.attributes.name);
     }
@@ -320,28 +325,28 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     this.modalRef.hide();
   }
 
-  showAddSpaceOverlay() {
+  showAddSpaceOverlay(): void {
     this.broadcaster.broadcast('showAddSpaceOverlay', true);
   }
 
-  showSearchSpacesOverlay() {
+  showSearchSpacesOverlay(): void {
     this.searchSpacesDialog.show();
   }
 
   // Pinned items
 
-  restorePins() {
+  restorePins(): void {
     if (this.loggedInUser.attributes === undefined) {
       return;
     }
-    let contextInformation = this.loggedInUser.attributes['contextInformation'];
-    let pins = (contextInformation !== undefined && contextInformation.pins !== undefined)
+    let contextInformation: any = this.loggedInUser.attributes['contextInformation'];
+    let pins: any[] = (contextInformation !== undefined && contextInformation.pins !== undefined)
       ? contextInformation.pins[this.pageName] : undefined;
 
-    this._spaces.forEach((space: any) => {
+    this._spaces.forEach((space: any): void => {
       space.showPin = false; // Must set default boolean to properly sort pins
       if (pins !== undefined && pins.length > 0) {
-        pins.forEach((id) => {
+        pins.forEach((id: string): void => {
           if (space.id === id) {
             space.showPin = true;
           }
@@ -358,19 +363,22 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     if (profile.contextInformation.pins === undefined) {
       profile.contextInformation.pins = {};
     }
-    let pins = [];
-    this._spaces.forEach((space: any) => {
+    let pins: any[] = [];
+    this._spaces.forEach((space: any): void => {
       if (space.showPin === true) {
         pins.push(space.id);
       }
     });
     profile.contextInformation.pins[this.pageName] = pins;
 
-    this.subscriptions.push(this.gettingStartedService.update(profile).subscribe(user => {
-      // Do nothing
-    }, error => {
-      this.logger.error('Failed to save pinned items');
-    }));
+    this.subscriptions.push(this.gettingStartedService.update(profile)
+      .subscribe((user: User): void => {
+        // Do nothing
+      },
+      (error: string): void => {
+        this.logger.error('Failed to save pinned items');
+      })
+    );
   }
 
   handleAction($event: Action): void {
@@ -385,9 +393,8 @@ export class MySpacesComponent implements OnDestroy, OnInit {
    * @returns {ExtProfile} The updated transient profile
    */
   private getTransientProfile(): ExtProfile {
-    let profile = this.gettingStartedService.createTransientProfile();
+    let profile: ExtProfile = this.gettingStartedService.createTransientProfile();
     delete profile.username;
-
     return profile;
   }
 }

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -68,8 +68,6 @@ export class MySpacesComponent implements OnDestroy, OnInit {
   ) { }
 
   ngOnInit() {
-    this.initPfListConfigs();
-
     this.subscriptions.push(
       this.contexts.current.subscribe((val: Context): void => {
         this.context = val;
@@ -82,6 +80,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
       })
     );
 
+    this.initPfListConfigs();
     this.initSpaces();
   }
 
@@ -149,11 +148,6 @@ export class MySpacesComponent implements OnDestroy, OnInit {
     } else {
       this.errorHandler.handleError('Failed to retrieve list of spaces owned by user');
     }
-  }
-
-  // returns an Observable containing the list of spaces the user owns
-  getMySpaces(): Observable<Space[]> {
-    return this.spaceService.getSpacesByUser(this.context.user.attributes.username);
   }
 
   toggleChange(event: SpacesType): void {

--- a/src/app/profile/my-spaces/my-spaces.component.ts
+++ b/src/app/profile/my-spaces/my-spaces.component.ts
@@ -18,7 +18,6 @@ import { Filter, FilterEvent } from 'patternfly-ng/filter';
 import { ListConfig } from 'patternfly-ng/list';
 import { SortEvent, SortField } from 'patternfly-ng/sort';
 import {
-  Observable,
   Subscription
 } from 'rxjs';
 import { ExtProfile, GettingStartedService } from '../../getting-started/services/getting-started.service';
@@ -175,7 +174,7 @@ export class MySpacesComponent implements OnDestroy, OnInit {
       return obj.id === $event.id;
     });
     if (index > -1) {
-      let space: any = this._spaces[index];
+      let space: any = this.displayedSpaces[index];
       space.showPin = (space.showPin === undefined) ? true : !space.showPin;
       this.savePins();
       this.updateSpaces();

--- a/src/app/profile/my-spaces/my-spaces.module.ts
+++ b/src/app/profile/my-spaces/my-spaces.module.ts
@@ -4,6 +4,7 @@ import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { InfiniteScrollModule } from 'ngx-widgets';
 import { ListModule } from 'patternfly-ng/list';
+import { UserSpacesService } from '../../shared/user-spaces.service';
 import { MySpacesItemActionsModule } from './my-spaces-item-actions/my-spaces-item-actions.module';
 import { MySpacesItemHeadingModule } from './my-spaces-item-heading/my-spaces-item-heading.module';
 import { MySpacesItemModule } from './my-spaces-item/my-spaces-item.module';
@@ -26,6 +27,7 @@ import { MySpacesComponent }     from './my-spaces.component';
     MySpacesRoutingModule,
     MySpacesSearchSpacesDialogModule
   ],
-  declarations: [ MySpacesComponent ]
+  declarations: [ MySpacesComponent ],
+  providers: [ UserSpacesService ]
 })
 export class MySpacesModule {}

--- a/src/app/shared/user-spaces.service.spec.ts
+++ b/src/app/shared/user-spaces.service.spec.ts
@@ -132,7 +132,7 @@ describe('UserSpacesService', () => {
     });
   });
 
-  describe('#getInvovledSpaces', (): void => {
+  describe('#getInvolvedSpaces', (): void => {
     it('should return the data portion of the response', (done: DoneFn): void => {
       const mockSpaceInformation: SpaceInformation[] = [{
         attributes: {

--- a/src/app/shared/user-spaces.service.ts
+++ b/src/app/shared/user-spaces.service.ts
@@ -18,14 +18,25 @@ import {
 } from 'rxjs/operators';
 
 import { Logger } from 'ngx-base';
-import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { Space, WIT_API_URL } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 
 export interface UserSpacesResponse {
-  data: Object[];
+  data: SpaceInformation[];
   meta: {
     totalCount: number
   };
+}
+
+export class SpaceInformation {
+  attributes: {
+    name: string
+  };
+  id: string;
+  links: {
+    self: string
+  };
+  type: string;
 }
 
 @Injectable()
@@ -57,4 +68,20 @@ export class UserSpacesService {
       );
   }
 
+    // Currently the backend returns values that look like Space[], but isn't
+    getInvolvedSpaces(): Observable<SpaceInformation[]> {
+      let headers: HttpHeaders = this.headers;
+      if (this.auth.getToken() != null) {
+        headers = this.headers.set('Authorization', `Bearer ${this.auth.getToken()}`);
+      }
+      return this.http.get(`${this.witUrl}user/spaces`, { headers })
+        .pipe(
+          map((response: UserSpacesResponse): SpaceInformation[] => response.data),
+          catchError((err: HttpErrorResponse): Observable<Space[]> => {
+            this.errorHandler.handleError(err);
+            this.logger.error(err);
+            return of([]);
+          })
+        );
+    }
 }


### PR DESCRIPTION
This PR addresses OSIO task [Add filter button/ability to Spaces page header](https://openshift.io/openshiftio/Openshift_io/plan/detail/844) [0], which is a sub-task of [Improve the My Spaces page](https://openshift.io/openshiftio/Openshift_io/plan/detail/786) on OSIO [1] and [Improve the My Spaces page](https://github.com/openshiftio/openshift.io/issues/4326) on GitHub [2].

~~I'll be waiting to rebase this on top of https://github.com/fabric8-ui/fabric8-ui/pull/3378, so the function that requests information from `/api/user/spaces` can be included in the new `user-spaces.service.ts`.~~

Additionally, there were a couple of unit tests in the `my-spaces.component.spec.ts` that weren't performing as expected, so I'll be continuing to update the unit tests and add more tests for the new functionality as well.

Here's a gif of what the toggling looks like in action.
![demo](https://user-images.githubusercontent.com/10425301/47164375-efe5b880-d2c5-11e8-8cda-56de567447e0.gif)

These changes required a new empty-state page for the case where the user owns spaces, but not collaborate on any [[3]](https://github.com/openshiftio/openshift.io/issues/4326#issuecomment-430471985).
![empty-state](https://user-images.githubusercontent.com/10425301/47164393-f70cc680-d2c5-11e8-841a-47d35d5bbc1e.png)

[0] https://openshift.io/openshiftio/Openshift_io/plan/detail/844
[1] https://openshift.io/openshiftio/Openshift_io/plan/detail/786
[2] https://github.com/openshiftio/openshift.io/issues/4326
[3] https://github.com/openshiftio/openshift.io/issues/4326#issuecomment-430471985