### PR TITLE
fix(format): change all type casts to use `as`

### DIFF
--- a/src/a-runtime-console/kubernetes/store/build.store.ts
+++ b/src/a-runtime-console/kubernetes/store/build.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class BuildStore extends NamespacedResourceStore<Build, Builds, BuildService> {
   constructor(buildconfigBuild: BuildService, namespaceScope: DevNamespaceScope) {
-    super(buildconfigBuild, [], <Build> {}, namespaceScope, Build);
+    super(buildconfigBuild, [], {} as Build, namespaceScope, Build);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/buildconfig.store.ts
+++ b/src/a-runtime-console/kubernetes/store/buildconfig.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class BuildConfigStore extends NamespacedResourceStore<BuildConfig, BuildConfigs, BuildConfigService> {
   constructor(buildconfigBuildConfig: BuildConfigService, namespaceScope: DevNamespaceScope) {
-    super(buildconfigBuildConfig, [], <BuildConfig> {}, namespaceScope, BuildConfig);
+    super(buildconfigBuildConfig, [], {} as BuildConfig, namespaceScope, BuildConfig);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/configmap.store.ts
+++ b/src/a-runtime-console/kubernetes/store/configmap.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class ConfigMapStore extends NamespacedResourceStore<ConfigMap, ConfigMaps, ConfigMapService> {
   constructor(deploymentService: ConfigMapService, namespaceScope: NamespaceScope) {
-    super(deploymentService, [], <ConfigMap> {}, namespaceScope, ConfigMap);
+    super(deploymentService, [], {} as ConfigMap, namespaceScope, ConfigMap);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/deployment.store.ts
+++ b/src/a-runtime-console/kubernetes/store/deployment.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class DeploymentStore extends NamespacedResourceStore<Deployment, Deployments, DeploymentService> {
   constructor(deploymentService: DeploymentService, namespaceScope: NamespaceScope) {
-    super(deploymentService, [], <Deployment> {}, namespaceScope, Deployment);
+    super(deploymentService, [], {} as Deployment, namespaceScope, Deployment);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/deploymentconfig.store.ts
+++ b/src/a-runtime-console/kubernetes/store/deploymentconfig.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class DeploymentConfigStore extends NamespacedResourceStore<DeploymentConfig, DeploymentConfigs, DeploymentConfigService> {
   constructor(deploymentService: DeploymentConfigService, namespaceScope: NamespaceScope) {
-    super(deploymentService, [], <DeploymentConfig> {}, namespaceScope, DeploymentConfig);
+    super(deploymentService, [], {} as DeploymentConfig, namespaceScope, DeploymentConfig);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/event.store.ts
+++ b/src/a-runtime-console/kubernetes/store/event.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class EventStore extends NamespacedResourceStore<Event, Events, EventService> {
   constructor(eventEvent: EventService, namespaceScope: NamespaceScope) {
-    super(eventEvent, [], <Event> {}, namespaceScope, Event);
+    super(eventEvent, [], {} as Event, namespaceScope, Event);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/namespace.store.ts
+++ b/src/a-runtime-console/kubernetes/store/namespace.store.ts
@@ -6,7 +6,7 @@ import { KubernetesResourceStore } from './kuberentesresource.store';
 @Injectable()
 export class NamespaceStore extends KubernetesResourceStore<Namespace, Namespaces, NamespaceService> {
   constructor(namespaceNamespace: NamespaceService) {
-    super(namespaceNamespace, [], <Namespace> {}, Namespace);
+    super(namespaceNamespace, [], {} as Namespace, Namespace);
   }
 
 

--- a/src/a-runtime-console/kubernetes/store/pod.store.ts
+++ b/src/a-runtime-console/kubernetes/store/pod.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class PodStore extends NamespacedResourceStore<Pod, Pods, PodService> {
   constructor(podPod: PodService, namespaceScope: NamespaceScope) {
-    super(podPod, [], <Pod> {}, namespaceScope, Pod);
+    super(podPod, [], {} as Pod, namespaceScope, Pod);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/replicaset.store.ts
+++ b/src/a-runtime-console/kubernetes/store/replicaset.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class ReplicaSetStore extends NamespacedResourceStore<ReplicaSet, ReplicaSets, ReplicaSetService> {
   constructor(replicaSetReplicaSet: ReplicaSetService, namespaceScope: NamespaceScope) {
-    super(replicaSetReplicaSet, [], <ReplicaSet> {}, namespaceScope, ReplicaSet);
+    super(replicaSetReplicaSet, [], {} as ReplicaSet, namespaceScope, ReplicaSet);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/replicationcontroller.store.ts
+++ b/src/a-runtime-console/kubernetes/store/replicationcontroller.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class ReplicationControllerStore extends NamespacedResourceStore<ReplicationController, ReplicationControllers, ReplicationControllerService> {
   constructor(replicationControllerReplicationController: ReplicationControllerService, namespaceScope: NamespaceScope) {
-    super(replicationControllerReplicationController, [], <ReplicationController> {}, namespaceScope, ReplicationController);
+    super(replicationControllerReplicationController, [], {} as ReplicationController, namespaceScope, ReplicationController);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/route.store.ts
+++ b/src/a-runtime-console/kubernetes/store/route.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class RouteStore extends NamespacedResourceStore<Route, Routes, RouteService> {
   constructor(routeService: RouteService, namespaceScope: NamespaceScope) {
-    super(routeService, [], <Route> {}, namespaceScope, Route);
+    super(routeService, [], {} as Route, namespaceScope, Route);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/store/service.store.ts
+++ b/src/a-runtime-console/kubernetes/store/service.store.ts
@@ -7,7 +7,7 @@ import { NamespacedResourceStore } from './namespacedresource.store';
 @Injectable()
 export class ServiceStore extends NamespacedResourceStore<Service, Services, ServiceService> {
   constructor(serviceService: ServiceService, namespaceScope: NamespaceScope) {
-    super(serviceService, [], <Service> {}, namespaceScope, Service);
+    super(serviceService, [], {} as Service, namespaceScope, Service);
   }
 
   protected get kind() {

--- a/src/a-runtime-console/kubernetes/ui/pipeline/build-stage-view/build-stage-view.spec.ts
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/build-stage-view/build-stage-view.spec.ts
@@ -130,9 +130,9 @@ describe('BuildStageViewComponent', () => {
 
   let mockJenkinsService = {
     getJenkinsStatus(): Observable<any> {
-      let jenkinsStatus = observableOf([<any> {
+      let jenkinsStatus = observableOf([{
         'data': {'state': 'idled'}
-      }]);
+      } as any]);
       return jenkinsStatus;
     }
   };

--- a/src/a-runtime-console/kubernetes/ui/pipeline/input-action-dialog/input-action-dialog.spec.ts
+++ b/src/a-runtime-console/kubernetes/ui/pipeline/input-action-dialog/input-action-dialog.spec.ts
@@ -20,9 +20,9 @@ describe('InputActionDialog', () => {
 
   let mockJenkinsService = {
     getJenkinsStatus(): Observable<any> {
-      let jenkinsStatus = observableOf([<any> {
+      let jenkinsStatus = observableOf([{
         'data': {'state': 'idled'}
-      }]);
+      } as any]);
       return jenkinsStatus;
     }
   };

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -37,10 +37,10 @@ if ('production' === ENV) {
     const appRef = modRef.injector.get(ApplicationRef);
     const cmpRef = appRef.components[0];
 
-    let _ng = (<any> window).ng;
+    let _ng = (window as any).ng;
     enableDebugTools(cmpRef);
-    (<any> window).ng.probe = _ng.probe;
-    (<any> window).ng.coreTokens = _ng.coreTokens;
+    (window as any).ng.probe = _ng.probe;
+    (window as any).ng.coreTokens = _ng.coreTokens;
 
     /* Below line is needed to get the broadcaster instance from AppModule which is
     used in `ngx-launcher` to broadcast events for telemetry */

--- a/src/app/layout/header/menus.service.ts
+++ b/src/app/layout/header/menus.service.ts
@@ -97,7 +97,7 @@ export class MenusService {
   }
 
   public attach(context: Context) {
-    if (!(context.type instanceof MenuedContextType || (<MenuedContextType> context.type).menus)) {
+    if (!(context.type instanceof MenuedContextType || (context.type as MenuedContextType).menus)) {
       // Take a copy of the context to attach menus to (not sure we need to do this)
       let res = cloneDeep(context.type) as MenuedContextType;
       // Take a copy of the menus and attach them

--- a/src/app/space/add-app-overlay/add-app-overlay.component.spec.ts
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.spec.ts
@@ -27,7 +27,7 @@ export class BroadcasterTestProvider {
   on<T>(key: any): Observable<T> {
     return this._eventBus.asObservable()
       .pipe(filter(event => event.key === key),
-            map(event => <T> event.data)
+            map(event => event.data as T)
       );
   }
 }

--- a/src/app/space/add-space-overlay/add-space-overlay.component.ts
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.ts
@@ -88,10 +88,10 @@ export class AddSpaceOverlayComponent implements OnInit {
    */
   createSpace() {
     if (!this.userService.currentLoggedInUser && !this.userService.currentLoggedInUser.id) {
-      this.notifications.message(<Notification> {
+      this.notifications.message({
         message: `Failed to create "${this.space.name}". Invalid user: "${this.userService.currentLoggedInUser}"`,
         type: NotificationType.DANGER
-      });
+      } as Notification);
       return;
     }
 
@@ -128,10 +128,10 @@ export class AddSpaceOverlayComponent implements OnInit {
           this.hideAddSpaceOverlay();
         },
         err => {
-          this.notifications.message(<Notification> {
+          this.notifications.message({
             message: `Failed to create "${this.space.name}"`,
             type: NotificationType.DANGER
-        });
+        } as Notification);
     }));
   }
 

--- a/src/app/space/app-launcher/services/app-launcher-dependency-check.service.spec.ts
+++ b/src/app/space/app-launcher/services/app-launcher-dependency-check.service.spec.ts
@@ -30,7 +30,7 @@ function initTestBed() {
   });
 }
 
-let mockContext = <Context> {
+let mockContext = {
   name: 'my-space-apr24-4-43',
   path: '/user/my-space-apr24-4-43',
   space: {
@@ -43,7 +43,7 @@ let mockContext = <Context> {
       'version': 0
     }
   }
-};
+} as Context;
 
 class mockContextService {
   get current(): Observable<Context> { return observableOf(mockContext); }

--- a/src/app/space/wizard/common/utilities.ts
+++ b/src/app/space/wizard/common/utilities.ts
@@ -40,7 +40,7 @@ export function formatJson(obj: any, indent: number = 0): string {
 }
 
 export function clone<T>(value: any): T {
-  return <T> JSON.parse(JSON.stringify(value || {}));
+  return JSON.parse(JSON.stringify(value || {})) as T;
 }
 
 


### PR DESCRIPTION
Switched all usage of `<>` type casting to use `as` since `<>` is not supported alongside jsx in tsx files.

This is needed to support compiling react jsx going forward.