### PR TITLE
feat(interceptors): add interceptor for `X-App` headers in launcher API calls

### DIFF
--- a/src/app/shared/interceptors/index.ts
+++ b/src/app/shared/interceptors/index.ts
@@ -3,10 +3,12 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { AuthInterceptor } from 'ngx-login-client';
 import { CacheInterceptor } from './cache.interceptor';
 import { RequestIdInterceptor } from './request-id.interceptor';
+import { XAppInterceptor } from './x-app.interceptor';
 
 /** Http interceptor providers in outside-in order */
 export const HttpInterceptorProviders = [
   { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
   { provide: HTTP_INTERCEPTORS, useClass: RequestIdInterceptor, multi: true },
+  { provide: HTTP_INTERCEPTORS, useClass: XAppInterceptor, multi: true },
   { provide: HTTP_INTERCEPTORS, useClass: CacheInterceptor, multi: true }
 ];

--- a/src/app/shared/interceptors/x-app.interceptor.spec.ts
+++ b/src/app/shared/interceptors/x-app.interceptor.spec.ts
@@ -1,0 +1,56 @@
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ANALYTICS_RECOMMENDER_URL } from '../../space/app-launcher/shared/analytics-url.service';
+import { FABRIC8_FORGE_API_URL } from '../runtime-console/fabric8-ui-forge-api';
+import { XAppInterceptor } from './x-app.interceptor';
+
+describe('XAppInterceptor', () => {
+  const testUrl: string = 'http://forge.example.com/test';
+
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        { provide: FABRIC8_FORGE_API_URL, useValue: 'http://forge.example.com' },
+        { provide: ANALYTICS_RECOMMENDER_URL, useValue: 'http://recommender.example.com' },
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: XAppInterceptor,
+          multi: true
+        }
+      ]
+    });
+    httpMock = TestBed.get(HttpTestingController);
+    httpClient = TestBed.get(HttpClient);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should add an X-App header', () => {
+    httpClient.get(testUrl).subscribe(() => {});
+
+    const req = httpMock.expectOne(testUrl);
+
+    expect(req.request.headers.has('X-App')).toBeTruthy();
+    expect(req.request.headers.get('X-App')).toBe('OSIO');
+  });
+
+  it('should not add an X-App header if URL is not forge or recommender', () => {
+    httpClient.get('http://example.com/test').subscribe(() => {});
+
+    const req = httpMock.expectOne('http://example.com/test');
+
+    expect(req.request.headers.has('X-App')).toBeFalsy();
+  });
+});

--- a/src/app/shared/interceptors/x-app.interceptor.spec.ts
+++ b/src/app/shared/interceptors/x-app.interceptor.spec.ts
@@ -9,7 +9,8 @@ import { FABRIC8_FORGE_API_URL } from '../runtime-console/fabric8-ui-forge-api';
 import { XAppInterceptor } from './x-app.interceptor';
 
 describe('XAppInterceptor', () => {
-  const testUrl: string = 'http://forge.example.com/test';
+  const forgeTestUrl: string = 'http://forge.example.com/test';
+  const recommendorTestUrl: string = 'http://recommender.example.com/test';
 
   let httpMock: HttpTestingController;
   let httpClient: HttpClient;
@@ -37,10 +38,19 @@ describe('XAppInterceptor', () => {
     httpMock.verify();
   });
 
-  it('should add an X-App header', () => {
-    httpClient.get(testUrl).subscribe(() => {});
+  it('should add an X-App header to forge URL', () => {
+    httpClient.get(forgeTestUrl).subscribe(() => {});
 
-    const req = httpMock.expectOne(testUrl);
+    const req = httpMock.expectOne(forgeTestUrl);
+
+    expect(req.request.headers.has('X-App')).toBeTruthy();
+    expect(req.request.headers.get('X-App')).toBe('OSIO');
+  });
+
+  it('should add an X-App header to recommender URL', () => {
+    httpClient.get(recommendorTestUrl).subscribe(() => {});
+
+    const req = httpMock.expectOne(recommendorTestUrl);
 
     expect(req.request.headers.has('X-App')).toBeTruthy();
     expect(req.request.headers.get('X-App')).toBe('OSIO');

--- a/src/app/shared/interceptors/x-app.interceptor.ts
+++ b/src/app/shared/interceptors/x-app.interceptor.ts
@@ -21,15 +21,13 @@ export class XAppInterceptor implements HttpInterceptor {
     const url = request.url;
 
     // Attach a X-App to all requests that don't have one
-    if (url.startsWith(this.forgeApiUrl) || url.startsWith(this.recommenderApiUrl)) {
-      if (!request.headers.has('X-App')) {
-        const newReq = request.clone({
-          setHeaders: {
-            'X-App': 'OSIO'
-          }
-        });
-        return next.handle(newReq);
-      }
+    if ((url.startsWith(this.forgeApiUrl) || url.startsWith(this.recommenderApiUrl)) && !request.headers.has('X-App')) {
+      const newReq = request.clone({
+        setHeaders: {
+          'X-App': 'OSIO'
+        }
+      });
+      return next.handle(newReq);
     }
 
     return next.handle(request);

--- a/src/app/shared/interceptors/x-app.interceptor.ts
+++ b/src/app/shared/interceptors/x-app.interceptor.ts
@@ -1,0 +1,37 @@
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ANALYTICS_RECOMMENDER_URL } from '../../space/app-launcher/shared/analytics-url.service';
+import { FABRIC8_FORGE_API_URL } from '../runtime-console/fabric8-ui-forge-api';
+
+@Injectable()
+export class XAppInterceptor implements HttpInterceptor {
+
+  constructor(
+    @Inject(FABRIC8_FORGE_API_URL) private forgeApiUrl: string,
+    @Inject(ANALYTICS_RECOMMENDER_URL) private recommenderApiUrl: string
+  ) {}
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const url = request.url;
+
+    // Attach a X-App to all requests that don't have one
+    if (url.startsWith(this.forgeApiUrl) || url.startsWith(this.recommenderApiUrl)) {
+      if (!request.headers.has('X-App')) {
+        const newReq = request.clone({
+          setHeaders: {
+            'X-App': 'OSIO'
+          }
+        });
+        return next.handle(newReq);
+      }
+    }
+
+    return next.handle(request);
+  }
+}


### PR DESCRIPTION
Planner Story - https://openshift.io/openshiftio/Openshift_io/plan/detail/884

- Adds an interceptor for `X-App` headers in launcher API calls

