### PR TITLE
add intellij settings to monorepo

### DIFF
--- a/talamer/.idea/inspectionProfiles/Project_Default.xml
+++ b/talamer/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/talamer/.idea/runConfigurations/Debug_All_Tests.xml
+++ b/talamer/.idea/runConfigurations/Debug_All_Tests.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug All Tests" type="JavaScriptTestRunnerJest" factoryName="Jest">
+    <node-interpreter value="project" />
+    <node-options value="--inspect-brk" />
+    <working-dir value="$PROJECT_DIR$" />
+    <jest-options value="--runInBand" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/talamer/package.json
+++ b/talamer/package.json
@@ -18,7 +18,7 @@
     "test:ci": "CI=true osio-scripts test",
     "test:watch": "osio-scripts test",
     "test:coverage": "osio-scripts test:coverage",
-    "test:debug": "osio-scripts test:debug",
+    "test:debug": "osio-scripts test:debug --watchAll=false",
     "test:update": "osio-scripts test:update"
   },
   "keywords": [

--- a/talamer/packages/eslint-plugin-osio/lib/config/react.js
+++ b/talamer/packages/eslint-plugin-osio/lib/config/react.js
@@ -3,6 +3,10 @@ const merge = require('merge');
 module.exports = {
   extends: ['plugin:osio/base', 'airbnb'],
 
+  env: {
+    browser: true,
+  },
+
   rules: merge(
     require('./rules/react'),
     require('./rules/jsx-a11y'),

--- a/talamer/packages/scripts/lib/rewire-scripts.js
+++ b/talamer/packages/scripts/lib/rewire-scripts.js
@@ -266,7 +266,6 @@ function rewireJest() {
 
     config = {
       ...config,
-
       transform: {
         '^.+\\.(js|jsx)$': isEjecting
           ? '<rootDir>/node_modules/babel-jest'
@@ -278,7 +277,12 @@ function rewireJest() {
         '^.+\\.css$': resolve('config/jest/cssTransform.js'),
         '^(?!.*\\.(js|jsx|css|json|ts|tsx|html)$)': resolve('config/jest/fileTransform.js'),
       },
-      collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
+      collectCoverageFrom: [
+        'src/**/*.{js,jsx,ts,tsx}',
+        '!src/**/*.d.ts',
+        'packages/**/src/**/*.{js,jsx,ts,tsx}',
+        '!packages/**/src/**/*.d.ts',
+      ],
       testMatch: [
         '<rootDir>/**/__tests__/**/*.{js,jsx,ts,tsx}',
         '<rootDir>/**/*.(spec|test).{js,jsx,ts,tsx}',


### PR DESCRIPTION
Part of https://openshift.io/openshiftio/Openshift_io/plan/detail/650

* add launch configuration for debugging jest tests
* add project settings to enable eslint
  * Cannot enable eslint fix on save since intellij auto saves frequently. Intellij users can use the context menu `Fix ESLint Problems`
* fix other setting issues found while testing intellij support