### PR TITLE
fix(workspaces): removing retry calls from open / create workspace methods (#4416)

### DIFF
--- a/src/app/space/create/codebases/services/workspaces.service.ts
+++ b/src/app/space/create/codebases/services/workspaces.service.ts
@@ -44,8 +44,7 @@ export class WorkspacesService {
     const url: string = `${this.workspacesUrl}/${codebaseId}/create`;
     return this.http
       .post<WorkspaceLinks>(url, null, { headers: this.headers }).pipe(
-      catchError((error: HttpErrorResponse): Observable<WorkspaceLinks> => this.handleError(error)),
-      retry(8)); // che-starter timeout is 3 min -- 30 sec default request timeout is not enough
+      catchError((error: HttpErrorResponse): Observable<WorkspaceLinks> => this.handleError(error)));
   }
 
   /**
@@ -83,7 +82,6 @@ export class WorkspacesService {
   openWorkspace(url: string): Observable<WorkspaceLinks> {
     return this.http
       .post<WorkspaceLinks>(url, null, { headers: this.headers }).pipe(
-      retry(8), // che-starter timeout is 3 min -- 30 sec default request timeout is not enough
       catchError((error: HttpErrorResponse): Observable<WorkspaceLinks> => this.handleError(error)));
   }
 


### PR DESCRIPTION
openshift.io issue - https://github.com/openshiftio/openshift.io/issues/4416

`retry` calls should be removed completely from open / create workspace methods since those have been added back to the time when Che server used to be single-tenant and it was required to unidle it, which might caused timeouts. Currently, Che server is multi-tenant and is running on osd so those retries not needed anymore.

