### PR TITLE
feat(analyze-dashboard): display collaborators list in popover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11948,9 +11948,9 @@
       "integrity": "sha512-ni91yYtn8ldgf/pxrlwl9lkVcLURGzopSpJnEbbgG1v1EZWTobI8y7J3mx4Kxptkn0EeiQwnLel67G7XJSox4A=="
     },
     "ngx-fabric8-wit": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ngx-fabric8-wit/-/ngx-fabric8-wit-8.2.0.tgz",
-      "integrity": "sha512-6YKtfYNx59D12+8+q3Z9e3lKw5cAMQKFV+xpOvSx2oNB9HqJr1jRIEogQ+5dGfPCCF/SSGp7YTNNPc75hNQzvQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-fabric8-wit/-/ngx-fabric8-wit-8.2.1.tgz",
+      "integrity": "sha512-p+pMy9jnUqGcPiIMpUJAhPrfYJtZVdj7KZds+aZTnAIVLukFdbx6iG5uvD2HRFk937jDRBVzQEErQZykglMiMw==",
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "ng2-truncate": "1.3.17",
     "ngx-base": "3.3.1",
     "ngx-bootstrap": "3.0.1",
-    "ngx-fabric8-wit": "8.2.0",
+    "ngx-fabric8-wit": "8.2.1",
     "ngx-feature-flag": "1.0.0",
     "ngx-launcher": "2.0.9",
     "ngx-login-client": "2.5.1",

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -72,8 +72,21 @@
 
 <ng-template #popoverContent>
   <div class="popover-list-wrapper">
+  <form role="form" class="search-pf has-button margin-bottom-10">
+    <div class="form-group">
+      <div class="search-pf-input-group">
+        <label for="search1" class="sr-only">Search collaborators</label>
+        <input type="search" class="form-control" placeholder="Search collaborators" (input)="onCollaboratorSearchChange($event.target.value)">
+      </div>
+    </div>
+    <div class="form-group">
+      <button class="btn btn-default" type="button"><span class="fa fa-search"></span></button>
+    </div>
+  </form>
+    <!-- Hide the list entirely if there are no matching search terms in order to avoid displaying an empty state -->
     <pfng-list
-      [items]="collaborators"
+      *ngIf="filteredCollaborators.length > 0"
+      [items]="filteredCollaborators"
       [itemTemplate]="collaboratorItem">
       <ng-template #collaboratorItem let-item="item">
         <div class="list-pf-left">
@@ -84,7 +97,7 @@
           </ng-template>
         </div>
         <div class="list-pf-content-wrapper">
-          <div class="list-pf-title">
+          <div class="list-pf-title" [title]="item.attributes.username">
             {{item.attributes.fullName}}
           </div>
         </div>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -6,10 +6,10 @@
     <ng-container *ngIf="userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo">
       <span class="pointer"
             [popover]="popoverContent"
-            [popoverTitle]="collaborators?.length + ' Collaborator' + (collaborators?.length > 1 ? 's' : '')"
+            [popoverTitle]="collaboratorCount + ' Collaborator' + (collaboratorCount > 1 ? 's' : '')"
             [outsideClick]="true"
             placement="right">
-        <span class="pficon pficon-users fa-lg"></span> {{collaborators?.length}}
+        <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount}}
       </span>
       <span class="f8-space-masthead-vertical-divider-collab"></span>
       <a class="add-collaborators-link" (click)="launchAddCollaborators()">
@@ -19,11 +19,11 @@
     <ng-template #userDoesNotOwnSpaceHeaderInfo>
       <span class="pointer"
             [popover]="popoverContent"
-            [popoverTitle]="collaborators?.length + ' Collaborator' + (collaborators?.length > 1 ? 's' : '')"
+            [popoverTitle]="collaboratorCount + ' Collaborator' + (collaboratorCount > 1 ? 's' : '')"
             [outsideClick]="true"
             placement="right">
-        <span class="pficon pficon-users fa-lg"></span> {{collaborators?.length}}
-        <span id="space-description-collaborators-placeholder">Collaborator{{collaborators?.length > 1 ? 's' : ''}}</span>
+        <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount}}
+        <span id="space-description-collaborators-placeholder">Collaborator{{collaboratorCount > 1 ? 's' : ''}}</span>
       </span>
     </ng-template>
   </div>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -6,7 +6,7 @@
     <ng-container *ngIf="userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo">
       <span class="pointer"
             [popover]="popoverContent"
-            [popoverTitle]="collaboratorCount + ' Collaborator' + (collaboratorCount > 1 ? 's' : '')"
+            [popoverTitle]="collaboratorCount + ' Collaborator' + (collaboratorCount === 1 ? '' : 's')"
             [outsideClick]="true"
             placement="right">
         <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount}}
@@ -19,11 +19,11 @@
     <ng-template #userDoesNotOwnSpaceHeaderInfo>
       <span class="pointer"
             [popover]="popoverContent"
-            [popoverTitle]="collaboratorCount + ' Collaborator' + (collaboratorCount > 1 ? 's' : '')"
+            [popoverTitle]="collaboratorCount + ' Collaborator' + (collaboratorCount === 1 ? '' : 's')"
             [outsideClick]="true"
             placement="right">
         <span class="pficon pficon-users fa-lg"></span> {{collaboratorCount}}
-        <span id="space-description-collaborators-placeholder">Collaborator{{collaboratorCount > 1 ? 's' : ''}}</span>
+        <span id="space-description-collaborators-placeholder">Collaborator{{collaboratorCount === 1 ? '' : 's'}}</span>
       </span>
     </ng-template>
   </div>
@@ -65,43 +65,38 @@
 <div class="modal fade" bsModal #modalAdd="bs-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <add-collaborators-dialog #addCollabDialog [host]="modalAdd" [spaceId]="space.id" (onAdded)="addCollaboratorsToParent($event)"></add-collaborators-dialog>
+      <add-collaborators-dialog #addCollabDialog [host]="modalAdd" [spaceId]="space.id" (onAdded)="refreshCollaboratorCount(); addCollaboratorsToParent($event)"></add-collaborators-dialog>
     </div>
   </div>
 </div>
 
 <ng-template #popoverContent>
-  <div class="popover-list-wrapper">
-  <form role="form" class="search-pf has-button margin-bottom-10">
-    <div class="form-group">
-      <div class="search-pf-input-group">
-        <label for="search1" class="sr-only">Search collaborators</label>
-        <input type="search" class="form-control" placeholder="Search collaborators" (input)="onCollaboratorSearchChange($event.target.value)">
+  <div class="popover-list-wrapper no-vertical-scroll">
+    <!-- Re-enable when collaborator query can include sorting parameter -->
+    <!-- <form role="form" class="search-pf has-button margin-bottom-10">
+      <div class="form-group">
+        <div class="search-pf-input-group">
+          <label for="search1" class="sr-only">Search collaborators</label>
+          <input type="search" class="form-control" placeholder="Search collaborators" (input)="onCollaboratorSearchChange($event.target.value)">
+        </div>
       </div>
-    </div>
-    <div class="form-group">
-      <button class="btn btn-default" type="button"><span class="fa fa-search"></span></button>
-    </div>
-  </form>
-    <!-- Hide the list entirely if there are no matching search terms in order to avoid displaying an empty state -->
-    <pfng-list
-      *ngIf="filteredCollaborators.length > 0"
-      [items]="filteredCollaborators"
-      [itemTemplate]="collaboratorItem">
-      <ng-template #collaboratorItem let-item="item">
-        <div class="list-pf-left">
+      <div class="form-group">
+        <button class="btn btn-default" type="button"><span class="fa fa-search"></span></button>
+      </div>
+    </form> -->
+    <div almInfiniteScroll class="collaborator-list-scroll" (initItems)="popoverInit($event.pageSize)" (fetchMore)="fetchMoreCollaborators()">
+      <div class="collaborator-item" *ngFor="let item of filteredCollaborators">
+        <span class="collaborator-avatar">
           <img *ngIf="(item.attributes.imageURL !== undefined && item.attributes.imageURL.length !== 0); else defaultImageUrl"
               [src]="item.attributes.imageURL" class="icon-user" width="24px" height="24px">
           <ng-template #defaultImageUrl>
             <img src="../../../assets/images/profile-user.png" class="icon-user" width="24px" height="24px">
           </ng-template>
-        </div>
-        <div class="list-pf-content-wrapper">
-          <div class="list-pf-title" [title]="item.attributes.username">
-            {{item.attributes.fullName}}
-          </div>
-        </div>
-      </ng-template>
-    </pfng-list>
+        </span>
+        <span class="collaborator-name" [title]="item.attributes.username">
+          {{item.attributes.fullName}}
+        </span>
+      </div>
+    </div>
   </div>
 </ng-template>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.html
@@ -3,15 +3,28 @@
     <div>
       <span class="f8-space-masthead-name">{{space?.attributes.name}}</span> <span class="f8-space-masthead-owner">{{spaceOwner | async}}</span>
     </div>
-    <span class="pficon pficon-users fa-lg"></span> {{collaborators?.length}}
-    <ng-container *ngIf='userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo'>
+    <ng-container *ngIf="userOwnsSpace; else userDoesNotOwnSpaceHeaderInfo">
+      <span class="pointer"
+            [popover]="popoverContent"
+            [popoverTitle]="collaborators?.length + ' Collaborator' + (collaborators?.length > 1 ? 's' : '')"
+            [outsideClick]="true"
+            placement="right">
+        <span class="pficon pficon-users fa-lg"></span> {{collaborators?.length}}
+      </span>
       <span class="f8-space-masthead-vertical-divider-collab"></span>
       <a class="add-collaborators-link" (click)="launchAddCollaborators()">
         <span class="pficon pficon-add-circle-o fa-lg"></span> Add Collaborator
       </a>
     </ng-container>
     <ng-template #userDoesNotOwnSpaceHeaderInfo>
-      <span id="space-description-collaborators-placeholder">Collaborator{{collaborators?.length > 1 ? 's' : ''}}</span>
+      <span class="pointer"
+            [popover]="popoverContent"
+            [popoverTitle]="collaborators?.length + ' Collaborator' + (collaborators?.length > 1 ? 's' : '')"
+            [outsideClick]="true"
+            placement="right">
+        <span class="pficon pficon-users fa-lg"></span> {{collaborators?.length}}
+        <span id="space-description-collaborators-placeholder">Collaborator{{collaborators?.length > 1 ? 's' : ''}}</span>
+      </span>
     </ng-template>
   </div>
   <div *ngIf="userOwnsSpace || space?.attributes.description" class="f8-space-masthead-vertical-divider"></div>
@@ -56,3 +69,26 @@
     </div>
   </div>
 </div>
+
+<ng-template #popoverContent>
+  <div class="popover-list-wrapper">
+    <pfng-list
+      [items]="collaborators"
+      [itemTemplate]="collaboratorItem">
+      <ng-template #collaboratorItem let-item="item">
+        <div class="list-pf-left">
+          <img *ngIf="(item.attributes.imageURL !== undefined && item.attributes.imageURL.length !== 0); else defaultImageUrl"
+              [src]="item.attributes.imageURL" class="icon-user" width="24px" height="24px">
+          <ng-template #defaultImageUrl>
+            <img src="../../../assets/images/profile-user.png" class="icon-user" width="24px" height="24px">
+          </ng-template>
+        </div>
+        <div class="list-pf-content-wrapper">
+          <div class="list-pf-title">
+            {{item.attributes.fullName}}
+          </div>
+        </div>
+      </ng-template>
+    </pfng-list>
+  </div>
+</ng-template>

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -180,17 +180,28 @@
 
 .popover-list-wrapper {
   max-height: 160px;
-  overflow: auto;
 }
 
-.list-pf-container {
-  padding: 6px;
+.collaborator-list-scroll {
+  max-height: inherit;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
-.list-pf {
-  border-style: none;
+.collaborator-item {
+  padding-top: 6px;
+  padding-right: 6px;
+  padding-bottom: 12px;
 }
 
-.list-pf-item {
-  border-style: none;
+.collaborator-item:hover {
+  background-color: @color-pf-blue-50;
+}
+
+.collaborator-avatar {
+  padding-right: 12px;
+}
+
+.collaborator-name {
+  font-size: 1.2em;
 }

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -190,8 +190,9 @@
 
 .collaborator-item {
   padding-top: 6px;
-  padding-right: 6px;
-  padding-bottom: 12px;
+  padding-bottom: 6px;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .collaborator-item:hover {

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -173,3 +173,24 @@
 .add-dialog {
   color: @color-pf-black-900;
 }
+
+.popover {
+  min-width: 100%;
+}
+
+.popover-list-wrapper {
+  max-height: 160px;
+  overflow: auto;
+}
+
+.list-pf-container {
+  padding: 6px;
+}
+
+.list-pf {
+  border-style: none;
+}
+
+.list-pf-item {
+  border-style: none;
+}

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.less
@@ -182,27 +182,25 @@
   max-height: 160px;
 }
 
-.collaborator-list-scroll {
-  max-height: inherit;
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-
-.collaborator-item {
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-
-.collaborator-item:hover {
-  background-color: @color-pf-blue-50;
-}
-
-.collaborator-avatar {
-  padding-right: 12px;
-}
-
-.collaborator-name {
-  font-size: 1.2em;
+.collaborator {
+  &-list-scroll {
+    max-height: inherit;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+  &-item {
+    padding-top: 6px;
+    padding-bottom: 6px;
+    padding-left: 12px;
+    padding-right: 12px;
+    &:hover {
+      background-color: @color-pf-blue-50;
+    }
+  }
+  &-avatar {
+    padding-right: 12px;
+  }
+  &-name {
+    font-size: 1.2em;
+  }
 }

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -87,6 +87,7 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
       { provide: CollaboratorService, useFactory: () => {
           let mockCollaboratorService: jasmine.SpyObj<CollaboratorService> = createMock(CollaboratorService);
           mockCollaboratorService.getInitialBySpaceId.and.returnValue(observableOf(mockUsers) as Observable<User[]>);
+          mockCollaboratorService.getTotalCount.and.returnValue(observableOf(mockUsers.length));
           return mockCollaboratorService;
         }
       }

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -1,6 +1,7 @@
 import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { sortBy } from 'lodash';
 import { Broadcaster } from 'ngx-base';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { CollaboratorService, Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
@@ -39,9 +40,9 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
     }
   };
   const mockUsers: any = [
-    { id: 'mock-id-1', attributes: { username: 'mock-username-1' } },
-    { id: 'mock-id-2', attributes: { username: 'mock-username-2' } },
-    { id: 'mock-id-3', attributes: { username: 'mock-username-3' } }
+    { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'D' } },
+    { id: 'mock-id-a', attributes: { username: 'mock-username-a', fullName: 'A' } },
+    { id: 'mock-id-c', attributes: { username: 'mock-username-c', fullName: 'C' } }
   ];
 
   const testContext = initContext(EditSpaceDescriptionWidgetComponent, HostComponent, {
@@ -117,6 +118,10 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
       let link: DebugElement = testContext.fixture.debugElement.query(By.css('a'));
       expect(link).toBeNull();
     });
+
+    it('should sort list of collaborators for display', function() {
+      expect(testContext.testedDirective.collaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
+    });
   });
 
   describe('#saveDescription', () => {
@@ -156,10 +161,21 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
       expect(testContext.testedDirective.collaborators.length).toEqual(3);
 
       testContext.testedDirective.addCollaboratorsToParent([
-        { id: 'mock-id-4', attributes: { username: 'mock-username-4' } }
+        { id: 'mock-id-b', attributes: { username: 'mock-username-b' } }
       ] as User[]);
 
       expect(testContext.testedDirective.collaborators.length).toBe(4);
+    });
+
+    it('should maintain sort', function() {
+      expect(testContext.testedDirective.collaborators.length).toEqual(3);
+
+      const newUser: User = {
+        id: 'mock-id-b', attributes: { username: 'mock-username-b', fullName: 'B' }
+      } as User;
+      testContext.testedDirective.addCollaboratorsToParent([ newUser ]);
+
+      expect(testContext.testedDirective.collaborators).toEqual(sortBy(mockUsers.concat(newUser), (user: User): string => user.attributes.fullName));
     });
   });
 

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -40,9 +40,9 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
     }
   };
   const mockUsers: any = [
-    { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'D' } },
-    { id: 'mock-id-a', attributes: { username: 'mock-username-a', fullName: 'A' } },
-    { id: 'mock-id-c', attributes: { username: 'mock-username-c', fullName: 'C' } }
+    { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'Dave' } },
+    { id: 'mock-id-a', attributes: { username: 'mock-username-a', fullName: 'Ava' } },
+    { id: 'mock-id-c', attributes: { username: 'mock-username-c', fullName: 'Charles' } }
   ];
 
   const testContext = initContext(EditSpaceDescriptionWidgetComponent, HostComponent, {
@@ -121,6 +121,21 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
 
     it('should sort list of collaborators for display', function() {
       expect(testContext.testedDirective.collaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
+      expect(testContext.testedDirective.filteredCollaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
+    });
+
+    it('should filter collaborators on search term change', function() {
+      testContext.testedDirective.onCollaboratorSearchChange('Dave');
+      expect(testContext.testedDirective.filteredCollaborators).toEqual([ { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'Dave' } } ]);
+
+      testContext.testedDirective.onCollaboratorSearchChange('av');
+      expect(testContext.testedDirective.filteredCollaborators).toEqual([
+        { id: 'mock-id-a', attributes: { username: 'mock-username-a', fullName: 'Ava' } },
+        { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'Dave' } }
+      ]);
+
+      testContext.testedDirective.onCollaboratorSearchChange('');
+      expect(testContext.testedDirective.filteredCollaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
     });
   });
 
@@ -171,11 +186,12 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
       expect(testContext.testedDirective.collaborators.length).toEqual(3);
 
       const newUser: User = {
-        id: 'mock-id-b', attributes: { username: 'mock-username-b', fullName: 'B' }
+        id: 'mock-id-b', attributes: { username: 'mock-username-b', fullName: 'Brenda' }
       } as User;
       testContext.testedDirective.addCollaboratorsToParent([ newUser ]);
 
       expect(testContext.testedDirective.collaborators).toEqual(sortBy(mockUsers.concat(newUser), (user: User): string => user.attributes.fullName));
+      expect(testContext.testedDirective.filteredCollaborators).toEqual(sortBy(mockUsers.concat(newUser), (user: User): string => user.attributes.fullName));
     });
   });
 

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { sortBy } from 'lodash';
 import { Broadcaster } from 'ngx-base';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { CollaboratorService, Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
@@ -120,23 +119,21 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
       expect(link).toBeNull();
     });
 
-    it('should sort list of collaborators for display', function() {
-      expect(testContext.testedDirective.collaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
-      expect(testContext.testedDirective.filteredCollaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
-    });
-
     it('should filter collaborators on search term change', function() {
+      testContext.testedDirective.popoverInit(10);
+      expect(testContext.testedDirective.filteredCollaborators).toEqual(mockUsers);
+
       testContext.testedDirective.onCollaboratorSearchChange('Dave');
       expect(testContext.testedDirective.filteredCollaborators).toEqual([ { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'Dave' } } ]);
 
       testContext.testedDirective.onCollaboratorSearchChange('av');
       expect(testContext.testedDirective.filteredCollaborators).toEqual([
-        { id: 'mock-id-a', attributes: { username: 'mock-username-a', fullName: 'Ava' } },
-        { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'Dave' } }
+        { id: 'mock-id-d', attributes: { username: 'mock-username-d', fullName: 'Dave' } },
+        { id: 'mock-id-a', attributes: { username: 'mock-username-a', fullName: 'Ava' } }
       ]);
 
       testContext.testedDirective.onCollaboratorSearchChange('');
-      expect(testContext.testedDirective.filteredCollaborators).toEqual(sortBy(mockUsers, (user: User): string => user.attributes.fullName));
+      expect(testContext.testedDirective.filteredCollaborators).toEqual(mockUsers);
     });
   });
 
@@ -174,25 +171,28 @@ describe('EditSpaceDescriptionWidgetComponent', () => {
 
   describe('#addCollaboratorsToParent', () => {
     it('should add new collaborators', function() {
-      expect(testContext.testedDirective.collaborators.length).toEqual(3);
+      expect(testContext.testedDirective.collaborators).toEqual([]);
 
-      testContext.testedDirective.addCollaboratorsToParent([
-        { id: 'mock-id-b', attributes: { username: 'mock-username-b' } }
-      ] as User[]);
+      const newUsers: User[] = [
+        {
+          id: 'mock-id-e',
+          attributes: {
+            username: 'mock-username-e',
+            fullName: 'Edith'
+          }
+        },
+        {
+          id: 'mock-id-b',
+          attributes: {
+            username: 'mock-username-b',
+            fullName: 'Brenda'
+          }
+        }
+      ] as User[];
 
-      expect(testContext.testedDirective.collaborators.length).toBe(4);
-    });
+      testContext.testedDirective.addCollaboratorsToParent(newUsers);
 
-    it('should maintain sort', function() {
-      expect(testContext.testedDirective.collaborators.length).toEqual(3);
-
-      const newUser: User = {
-        id: 'mock-id-b', attributes: { username: 'mock-username-b', fullName: 'Brenda' }
-      } as User;
-      testContext.testedDirective.addCollaboratorsToParent([ newUser ]);
-
-      expect(testContext.testedDirective.collaborators).toEqual(sortBy(mockUsers.concat(newUser), (user: User): string => user.attributes.fullName));
-      expect(testContext.testedDirective.filteredCollaborators).toEqual(sortBy(mockUsers.concat(newUser), (user: User): string => user.attributes.fullName));
+      expect(testContext.testedDirective.collaborators).toEqual(newUsers);
     });
   });
 

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
@@ -5,7 +5,7 @@ import { ModalDirective } from 'ngx-bootstrap';
 import { CollaboratorService, Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
 import { User, UserService } from 'ngx-login-client';
 import { Observable,  of as observableOf, Subject, Subscription } from 'rxjs';
-import { debounceTime, map, switchMap, tap } from 'rxjs/operators';
+import { debounceTime, first, map, switchMap, tap } from 'rxjs/operators';
 import { SpaceNamespaceService } from '../../shared/runtime-console/space-namespace.service';
 
 @Component({
@@ -20,6 +20,7 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
   space: Space;
   spaceOwner: Observable<string>;
   filteredCollaborators: User[];
+  collaboratorCount: number;
 
   private subscriptions: Subscription[] = [];
   private _descriptionUpdater: Subject<string> = new Subject();
@@ -51,6 +52,11 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
             this.collaboratorService.getInitialBySpaceId(space.id).subscribe((users: User[]) => {
               this.collaborators = users;
               this.filteredCollaborators = this.collaborators;
+              this.collaboratorService.getTotalCount()
+                .pipe(first())
+                .subscribe((count: number): void => {
+                  this.collaboratorCount = count;
+                });
             })
           );
           this.spaceOwner = this.userService

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
@@ -19,6 +19,7 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
   @Input() userOwnsSpace: boolean;
   space: Space;
   spaceOwner: Observable<string>;
+  filteredCollaborators: User[];
 
   private subscriptions: Subscription[] = [];
   private _descriptionUpdater: Subject<string> = new Subject();
@@ -49,6 +50,7 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
           this.subscriptions.push(
             this.collaboratorService.getInitialBySpaceId(space.id).subscribe((users: User[]) => {
               this.collaborators = users;
+              this.filteredCollaborators = this.collaborators;
             })
           );
           this.spaceOwner = this.userService
@@ -125,6 +127,20 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
 
   addCollaboratorsToParent(addedUsers: User[]): void {
     this.collaborators = uniqBy(this.collaborators.concat(addedUsers), 'id');
+    this.filteredCollaborators = this.collaborators;
+  }
+
+  onCollaboratorSearchChange(searchTerm: string): void {
+    if (searchTerm === '') {
+      this.filteredCollaborators = this.collaborators;
+      return;
+    }
+    this.filteredCollaborators = this.collaborators
+      .filter(
+        (user: User): boolean =>
+          user.attributes.fullName.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
+          || user.attributes.username.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
+        );
   }
 
   ngOnDestroy(): void {

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
-import { find } from 'lodash';
+import { sortBy, uniqBy } from 'lodash';
 import { Broadcaster } from 'ngx-base';
 import { ModalDirective } from 'ngx-bootstrap';
 import { CollaboratorService, Contexts, Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
@@ -19,10 +19,10 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
   @Input() userOwnsSpace: boolean;
   space: Space;
   spaceOwner: Observable<string>;
-  collaborators: User[];
 
   private subscriptions: Subscription[] = [];
   private _descriptionUpdater: Subject<string> = new Subject();
+  private _collaborators: User[];
 
   private loggedInUser: User;
   @ViewChild('description') description: any;
@@ -87,6 +87,14 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
     );
   }
 
+  set collaborators(collaborators: User[]) {
+    this._collaborators = sortBy(collaborators, (user: User): string => user.attributes.fullName);
+  }
+
+  get collaborators(): User[] {
+    return this._collaborators;
+  }
+
   onUpdateDescription(description): void {
     this._descriptionUpdater.next(description);
   }
@@ -116,14 +124,7 @@ export class EditSpaceDescriptionWidgetComponent implements OnInit, OnDestroy {
   }
 
   addCollaboratorsToParent(addedUsers: User[]): void {
-    addedUsers.forEach((user: User) => {
-      let matchingUser = find(this.collaborators, (existing: User) => {
-        return existing.id === user.id;
-      });
-      if (!matchingUser) {
-        this.collaborators.push(user);
-      }
-    });
+    this.collaborators = uniqBy(this.collaborators.concat(addedUsers), 'id');
   }
 
   ngOnDestroy(): void {

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module.ts
@@ -6,11 +6,9 @@ import { ModalModule } from 'ngx-bootstrap/modal';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { FeatureFlagModule } from 'ngx-feature-flag';
-import { AlmEditableModule, AlmIconModule } from 'ngx-widgets';
-import { ListModule } from 'patternfly-ng';
+import { AlmEditableModule, AlmIconModule, InfiniteScrollModule } from 'ngx-widgets';
 import { AddCollaboratorsDialogModule } from '../../space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.module';
 import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-widget.component';
-
 
 @NgModule({
   imports: [
@@ -23,7 +21,7 @@ import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-wi
     FeatureFlagModule,
     ModalModule.forRoot(),
     PopoverModule.forRoot(),
-    ListModule,
+    InfiniteScrollModule,
     RouterModule
   ],
   declarations: [EditSpaceDescriptionWidgetComponent],

--- a/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module.ts
+++ b/src/app/dashboard-widgets/edit-space-description-widget/edit-space-description-widget.module.ts
@@ -3,9 +3,11 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { ModalModule } from 'ngx-bootstrap/modal';
+import { PopoverModule } from 'ngx-bootstrap/popover';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
 import { FeatureFlagModule } from 'ngx-feature-flag';
 import { AlmEditableModule, AlmIconModule } from 'ngx-widgets';
+import { ListModule } from 'patternfly-ng';
 import { AddCollaboratorsDialogModule } from '../../space/settings/collaborators/add-collaborators-dialog/add-collaborators-dialog.module';
 import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-widget.component';
 
@@ -20,6 +22,8 @@ import { EditSpaceDescriptionWidgetComponent } from './edit-space-description-wi
     Fabric8WitModule,
     FeatureFlagModule,
     ModalModule.forRoot(),
+    PopoverModule.forRoot(),
+    ListModule,
     RouterModule
   ],
   declarations: [EditSpaceDescriptionWidgetComponent],


### PR DESCRIPTION
Display the list of space collaborators in a popover component upon click of the collaborator count
label when viewing the Analyze Dashboard for any given space

related to https://openshift.io/openshiftio/Openshift_io/plan/detail/847

~~Still TODO: add search widget in popover~~

![image](https://user-images.githubusercontent.com/3787464/47575349-e8e72780-d90f-11e8-98c8-c29a4f242b93.png)

![image](https://user-images.githubusercontent.com/3787464/47575382-f7354380-d90f-11e8-8250-c8e6ab267190.png)
