### PR TITLE
fix(build) expose port in dockerfile

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -93,6 +93,8 @@ WORKDIR $WORKSPACE/
 
 VOLUME /dist
 
+EXPOSE 3000
+
 ENTRYPOINT ["/home/fabric8/fabric8-ui/docker-entrypoint.sh"]
 
 #ENTRYPOINT ["scl"]


### PR DESCRIPTION
I want to create PR checks for this repository that would run e2e test. I need to expose port 3000 so that e2e test can access the locally-build app.