### PR TITLE
fix(collaborators): fix scrolling issue for last item in the list

### DIFF
--- a/src/app/space/settings/collaborators/collaborators.component.less
+++ b/src/app/space/settings/collaborators/collaborators.component.less
@@ -34,3 +34,7 @@
   display: block;
   padding-left: 29px;
 }
+
+.list-pf-item:last-child {
+  margin-bottom: 50px;
+}


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4437

- Adds a `margin-bottom: 50px` to the last item in the list so that the kebab menu is visible easily.

Screenshot - 
<img width="1680" alt="screenshot 2018-11-01 at 12 36 59 pm" src="https://user-images.githubusercontent.com/6041994/47837667-db7be280-ddd2-11e8-9187-a33a811d6d3d.png">
