### PR TITLE
 fix(collaborators): increase margin bottom and encapsulate css rule within parent component

### DIFF
--- a/src/app/space/settings/collaborators/collaborators.component.less
+++ b/src/app/space/settings/collaborators/collaborators.component.less
@@ -27,14 +27,12 @@
 .collaborator-list-scroll {
   max-height: 680px;
   overflow-y: auto;
-}
-
-.pfng-list-heading {
-  background-color: @color-pf-black-200 !important; /* stylelint-disable-line declaration-no-important */
-  display: block;
-  padding-left: 29px;
-}
-
-.list-pf-item:last-child {
-  margin-bottom: 50px;
+  .pfng-list-heading {
+    background-color: @color-pf-black-200 !important; /* stylelint-disable-line declaration-no-important */
+    display: block;
+    padding-left: 29px;
+  }
+  .list-pf-item:last-child {
+    margin-bottom: 60px;
+  }
 }


### PR DESCRIPTION
Based on the comment https://github.com/fabric8-ui/fabric8-ui/pull/3399#issuecomment-435052596.
- Increases the `margin-bottom` by 10px.
- Encapsulates the CSS rules within the parent component scope.