### PR TITLE
update monorepo tsconfig and jest

### DIFF
--- a/talamer/packages/fabric8-ui/tsconfig.json
+++ b/talamer/packages/fabric8-ui/tsconfig.json
@@ -19,5 +19,8 @@
       "node",
       "segment-analytics"
     ]
-  }
+  },
+  "include": [
+    "src"
+  ]
 }

--- a/talamer/packages/scripts/config/jest/transforms/angularComponentTransform.js
+++ b/talamer/packages/scripts/config/jest/transforms/angularComponentTransform.js
@@ -1,0 +1,12 @@
+const {process} = require('./typescriptTransform');
+
+const TEMPLATE_URL_REGEX = /templateUrl\s*:\s*('|"|`)(\.\/){0,}(.*)('|"|`)/g;
+const STYLE_URLS_REGEX = /styleUrls\s*:\s*\[[^\]]*\]/g;
+
+/* eslint-disable no-param-reassign */
+module.exports.process = (src, path, config, transformOptions) => {
+  src = src
+    .replace(TEMPLATE_URL_REGEX, 'template: require($1./$3$4)')
+    .replace(STYLE_URLS_REGEX, 'styles: []');
+  return process(src, path, config, transformOptions);
+};

--- a/talamer/packages/scripts/config/jest/transforms/htmlTransform.js
+++ b/talamer/packages/scripts/config/jest/transforms/htmlTransform.js
@@ -1,0 +1,1 @@
+module.exports.process = (src) => `module.exports=${JSON.stringify(src)}`;

--- a/talamer/packages/scripts/config/jest/transforms/typescriptTransform.js
+++ b/talamer/packages/scripts/config/jest/transforms/typescriptTransform.js
@@ -1,18 +1,3 @@
 const {process} = require('ts-jest');
 
-const TEMPLATE_URL_REGEX = /templateUrl\s*:\s*('|"|`)(\.\/){0,}(.*)('|"|`)/g;
-const STYLE_URLS_REGEX = /styleUrls\s*:\s*\[[^\]]*\]/g;
-const ESCAPE_TEMPLATE_REGEX = /(\${|`)/g;
-
-/* eslint-disable no-param-reassign */
-module.exports.process = (src, path, config, transformOptions) => {
-  if (path.endsWith('.html')) {
-    src = src.replace(ESCAPE_TEMPLATE_REGEX, '\\$1');
-  }
-  if (path.endsWith('.component.ts')) {
-    src = src
-      .replace(TEMPLATE_URL_REGEX, 'template: require($1./$3$4)')
-      .replace(STYLE_URLS_REGEX, 'styles: []');
-  }
-  return process(src, path, config, transformOptions);
-};
+module.exports.process = process;

--- a/talamer/packages/scripts/config/tsconfig/tsconfig.json
+++ b/talamer/packages/scripts/config/tsconfig/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationDir": "types",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
+    "isolatedModules": true,
     "jsx": "react",
     "lib": ["dom", "es2015", "es2016", "es2017"],
     "module": "esnext",


### PR DESCRIPTION
While attempting to run babel typescript instead of ts-loader, I made the following changes.

Need to separate out HTML and angular component transforms for jest so that it is easier to switch out the typescript transform portion only later.

Also update tsconfigs as noted by suggestions while attempting to use create-react-app typescript support.

Added suppprt to jest to read a `.ts` test setup file.