### PR TITLE
Fix(recent-utils): fix signature of recent-utils#compareElements

### DIFF
--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -147,7 +147,7 @@ export class ContextService extends RecentUtils<Context> implements Contexts {
         .pipe(
           withLatestFrom(this._recent),
           map(([deletedSpace, recentContexts]: [Space, Context[]]): RecentData<Context> =>
-            this.onBroadcastSpaceDeleted(deletedSpace, recentContexts, this.compareContextToSpace)
+            this.onBroadcastDeleted(deletedSpace, recentContexts, this.compareContextToSpace)
           ),
           filter((recentData: RecentData<Context>): boolean => recentData.isSaveRequired)
         )

--- a/src/app/shared/recent-utils.spec.ts
+++ b/src/app/shared/recent-utils.spec.ts
@@ -1,0 +1,100 @@
+
+import { ErrorHandler } from '@angular/core';
+import { EMPTY, throwError } from 'rxjs';
+import { ExtProfile, ProfileService } from '../profile/profile.service';
+import { RecentUtils } from './recent-utils';
+
+class RecentImpl extends RecentUtils<string> {
+  compareElements(a: string, b: string) {
+    return a === b;
+  }
+}
+
+const MockProfileService = jest.fn<ProfileService>().mockImplementation(() => {
+  return { silentSave: jest.fn().mockReturnValue(EMPTY) };
+});
+
+const MockErrorHandler = jest.fn<ErrorHandler>().mockImplementation(() => {
+  return { handleError: jest.fn() };
+});
+
+describe('recent-utils', () => {
+
+  let errorHandlerMock: ErrorHandler;
+  let profileServiceMock: ProfileService;
+  let subject: RecentUtils<string>;
+
+  beforeEach(() => {
+    errorHandlerMock = new MockErrorHandler();
+    profileServiceMock = new MockProfileService();
+    subject = new RecentImpl(errorHandlerMock, profileServiceMock);
+  });
+
+  describe('onBroadcastChanged', () => {
+    it('should not require saving if item already at start of list', () => {
+      expect(subject.onBroadcastChanged('a', ['a', 'b'])).toEqual({
+        recent: ['a', 'b'],
+        isSaveRequired: false
+      });
+    });
+
+    it('should bump existing item to front of list', () => {
+      expect(subject.onBroadcastChanged('a', ['b', 'a'])).toEqual({
+        recent: ['a', 'b'],
+        isSaveRequired: true
+      });
+    });
+
+    it('should add new items to the start of the list', () => {
+      expect(subject.onBroadcastChanged('b', ['a', 'c'])).toEqual({
+        recent: ['b', 'a', 'c'],
+        isSaveRequired: true
+      });
+    });
+
+    it('should limit list to 8 entries', () => {
+      expect(subject.onBroadcastChanged('z', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])).toEqual({
+        recent: ['z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+        isSaveRequired: true
+      });
+    });
+  });
+
+  describe('onBroadcastDeleted', () => {
+    it('should should not requiring saving if item is missing', () => {
+      expect(subject.onBroadcastDeleted('a', [])).toEqual({
+        recent: [],
+        isSaveRequired: false
+      });
+    });
+
+    it('should remove items from the list', () => {
+      expect(subject.onBroadcastDeleted('b', ['a', 'b', 'c'])).toEqual({
+        recent: ['a', 'c'],
+        isSaveRequired: true
+      });
+    });
+
+    it('should support custom comparator', () => {
+      const comparator = (a: string, b: any) => a === b.value;
+      expect(subject.onBroadcastDeleted({ value: 'b'}, ['a', 'b', 'c'], comparator)).toEqual({
+        recent: ['a', 'c'],
+        isSaveRequired: true
+      });
+    });
+  });
+
+  it('save profile success', () => {
+    subject.saveProfile({} as ExtProfile);
+    expect(profileServiceMock.silentSave).toHaveBeenCalled();
+    expect(errorHandlerMock.handleError).not.toHaveBeenCalled();
+  });
+
+  it('save profile error', () => {
+    const error = new Error();
+    profileServiceMock.silentSave = jest.fn().mockReturnValue(throwError(error));
+    subject.saveProfile({} as ExtProfile);
+    expect(profileServiceMock.silentSave).toHaveBeenCalled();
+    expect(errorHandlerMock.handleError).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/app/shared/recent-utils.ts
+++ b/src/app/shared/recent-utils.ts
@@ -25,9 +25,9 @@ export abstract class RecentUtils<T> {
     return this._recent;
   }
 
-  abstract compareElements<T>(t1: T, t2: T);
+  abstract compareElements<K = T>(t1: T, t2: K): boolean;
 
-  onBroadcastChanged(changed: T, recent: T[], compareFn: Function = this.compareElements): RecentData<T> {
+  onBroadcastChanged(changed: T, recent: T[], compareFn: ((a: T, b: T) => boolean) = this.compareElements): RecentData<T> {
     let index: number = recent.findIndex((t: T) => compareFn(t, changed));
     if (index === 0) { // continue only if changed is new, or requires a move within recent
       return { recent: recent, isSaveRequired: false };
@@ -44,8 +44,8 @@ export abstract class RecentUtils<T> {
     return { recent: recent, isSaveRequired: true };
   }
 
-  onBroadcastSpaceDeleted(deletedSpace: Space, recent: T[], compareFn: Function = this.compareElements): RecentData<T> {
-    let index: number = recent.findIndex((t: T) => compareFn(t, deletedSpace));
+  onBroadcastDeleted<K>(deleted: K, recent: T[], compareFn: ((a: T, b: K) => boolean) = this.compareElements): RecentData<T> {
+    let index: number = recent.findIndex((t: T) => compareFn(t, deleted));
     if (index === -1) {
       return { recent: recent, isSaveRequired: false };
     }

--- a/src/app/shared/spaces.service.ts
+++ b/src/app/shared/spaces.service.ts
@@ -67,7 +67,7 @@ export class SpacesService extends RecentUtils<Space> implements Spaces {
         .pipe(
           withLatestFrom(this.recent),
           map(([deletedSpace, recentSpaces]): RecentData<Space> =>
-            this.onBroadcastSpaceDeleted(deletedSpace, recentSpaces)
+            this.onBroadcastDeleted(deletedSpace, recentSpaces)
           ),
           filter((recentData: RecentData<Space>) => recentData.isSaveRequired)
         )


### PR DESCRIPTION
Fixes the signature of `recent-utils#compareElements` which causes test failures in the monorepo. The abstract function should not be typed as the generic comes from the class and not should not come from the function.

This function is implemented in `spaces.service` and `context.service` as follows:
```
  compareElements(s1: Space, s2: Space): boolean {
    return s1.id === s2.id;
  }
```
```
  compareElements(c1: Context, c2: Context): boolean {
    return c1.name === c2.name;
  }
```