### PR TITLE
Update OSIO page titles to CodeReady Toolchain

### DIFF
--- a/src/app/shared/branding.service.ts
+++ b/src/app/shared/branding.service.ts
@@ -29,7 +29,7 @@ export class BrandingService {
       this._logo = openshiftLogo;
       this._backgroundClass = 'home-header-background-image';
       this._description = 'A free, end-to-end, cloud-native development experience.';
-      this._name = 'OpenShift.io';
+      this._name = 'CodeReady Toolchain';
       this._moreInfoLink = 'https://openshift.io';
     }
   }


### PR DESCRIPTION
Update all OSIO page titles to CodeReady Toolchain - [OSIO-1118](https://openshift.io/openshiftio/Openshift_io/plan/detail/1118)

![allpagetitles](https://user-images.githubusercontent.com/1892722/49206802-3a844580-f3d9-11e8-85b7-1b6cc606dcc7.png)

Reference: https://github.com/openshiftio/openshift.io/issues/4364
