### PR TITLE
fix(rebranding): Update all static text references to CodeReady Toolchain

### DIFF
--- a/src/app/getting-started/getting-started.component.html
+++ b/src/app/getting-started/getting-started.component.html
@@ -6,8 +6,8 @@
     We're having trouble connecting your account.
   </h1>
   <p>
-    It looks like we're having trouble linking your OpenShift.io account to your OpenShift Online account.  This is preventing you from logging into your
-    OpenShift.io account.  Please log out and try to log in again.
+    It looks like we're having trouble linking your CodeReady Toolchain account to your OpenShift Online account.  This is preventing you from logging into your
+    CodeReady Toolchain account.  Please log out and try to log in again.
   </p>
   <div class="blank-slate-pf-main-action">
     <button class="btn btn-primary btn-lg" (click)="logOut()">Log Out</button>

--- a/src/app/layout/redirect-status/redirect-status.component.ts
+++ b/src/app/layout/redirect-status/redirect-status.component.ts
@@ -13,7 +13,7 @@ export class RedirectStatusComponent implements OnInit {
       '_verifyEmail', {
         success: {
           statusMessage: 'Your e-mail has been confirmed.',
-          secondaryStatusMessage: 'Thank you for validating your e-mail address. You can now continue to use Openshift.io',
+          secondaryStatusMessage: 'Thank you for validating your e-mail address. You can now continue to use CodeReady Toolchain.',
           callToActionUrl: '_home',
           callToActionLabel: 'home dashboard'
         },

--- a/src/app/layout/redirect-status/status/status.component.spec.ts
+++ b/src/app/layout/redirect-status/status/status.component.spec.ts
@@ -18,7 +18,7 @@ describe('StatusComponent', () => {
 
   const successData: RedirectStatusData = {
     statusMessage: 'Your e-mail has been confirmed.',
-    secondaryStatusMessage: 'Thank you for validating your e-mail address. You can now continue to use Openshift.io',
+    secondaryStatusMessage: 'Thank you for validating your e-mail address. You can now continue to use CodeReady Toolchain.',
     callToActionUrl: '_home',
     callToActionLabel: 'home dashboard'
   };

--- a/src/app/profile/cleanup/cleanup.component.html
+++ b/src/app/profile/cleanup/cleanup.component.html
@@ -6,8 +6,8 @@
         <strong>{{notificationTitle}}</strong> {{notificationText}}
       </div>
       <h3 *ngIf="cleanupStatus === 'notstarted'">
-        <strong>You are about to erase all of your OpenShift.io spaces</strong>, reverting your OpenShift.io environment to its default state.
-        This action will not affect your GitHub account or repositories associated with OpenShift.io.
+        <strong>You are about to erase all of your CodeReady Toolchain spaces</strong>, reverting your CodeReady Toolchain environment to its default state.
+        This action will not affect your GitHub account or repositories associated with CodeReady Toolchain.
       </h3>
       <h3 *ngIf="cleanupStatus === 'notstarted'">Your account will be reset and the following spaces will be removed.</h3>
       <h3 *ngIf="cleanupStatus !== 'notstarted'">Results</h3>
@@ -68,15 +68,15 @@
       </div>
       <div>
         <p class="cleanup-action-confirm" *ngIf="cleanupStatus !== 'completedwitherrors' && cleanupStatus !== 'completed'">
-          By clicking on 'Erase my OpenShift.io environment', you are telling us that you no longer wish to use your current environment, and that you wish to start all over again.  There is no going back - we cannot save what is lost.
+          By clicking on 'Erase my CodeReady Toolchain environment', you are telling us that you no longer wish to use your current environment, and that you wish to start all over again.  There is no going back - we cannot save what is lost.
         </p>
         <p class="cleanup-action-confirm" *ngIf="cleanupStatus === 'completedwitherrors'">
-          There was an error erasing some of your spaces from OpenShift.io.  You can either erase these manually, or try again using the button below.
+          There was an error erasing some of your spaces from CodeReady Toolchain.  You can either erase these manually, or try again using the button below.
         </p>
         <p class="cleanup-action-confirm" *ngIf="cleanupStatus === 'completed'">
-          You have successfully erased your OpenShift.io environment.  You can now return to your user dashboard.
+          You have successfully erased your CodeReady Toolchain environment.  You can now return to your user dashboard.
         </p>
-        <button class="btn btn-danger btn-lg" (click)="confirmErase()" *ngIf="cleanupStatus !== 'completed'">Erase My OpenShift.io Environment</button>
+        <button class="btn btn-danger btn-lg" (click)="confirmErase()" *ngIf="cleanupStatus !== 'completed'">Erase My CodeReady Toolchain Environment</button>
         <div *ngIf="cleanupStatus === 'completedwitherrors' || cleanupStatus === 'completed'" class="cleanup-home-action">
           <button class="btn btn-primary btn-lg" (click)="goHome()">Take me to my Dashboard</button>
         </div>
@@ -88,12 +88,12 @@
 <modal #confirmCleanup title="Are you sure?">
   <modal-content>
     <section>
-      <p class="clean-modal-warning">Erasing your OpenShift.io environment is an action that CANNOT be undone.</p>
+      <p class="clean-modal-warning">Erasing your CodeReady Toolchain environment is an action that CANNOT be undone.</p>
       <p>This will permanently erase all spaces, codebase links, applications, environments and pipelines.</p>
-      <p>Please verify this action by typing in your OpenShift.io username.</p>
+      <p>Please verify this action by typing in your CodeReady Toolchain username.</p>
       <form class="form-horizontal">
         <div class="form-group">
-          <label class="col-sm-4 control-label">OpenShift.io Username</label>
+          <label class="col-sm-4 control-label">CodeReady Toolchain Username</label>
           <div class="col-sm-8">
             <input
               #username

--- a/src/app/profile/cleanup/cleanup.component.ts
+++ b/src/app/profile/cleanup/cleanup.component.ts
@@ -155,7 +155,7 @@ export class CleanupComponent implements OnInit, OnDestroy {
     this.notificationClass = 'alert-success';
     this.notificationIcon = 'pficon-ok';
     this.notificationTitle = 'Success!';
-    this.notificationText = 'Your OpenShift.io environment has been erased!';
+    this.notificationText = 'Your CodeReady Toolchain environment has been erased!';
     this.cleanupStatus = 'completed';
   }
 

--- a/src/app/profile/settings/feature-opt-in/feature-opt-in.component.ts
+++ b/src/app/profile/settings/feature-opt-in/feature-opt-in.component.ts
@@ -103,7 +103,7 @@ export class FeatureOptInComponent implements OnInit {
         name: 'released',
         selected: this.featureLevel === 'released',
         title: 'Production-Only Features',
-        description: 'Use the generally available version of OpenShift.io.',
+        description: 'Use the generally available version of CodeReady Toolchain.',
         detailDescription: 'These features have been released and are part of the product release.',
         features: [],
         displayed: true

--- a/src/app/space/add-app-overlay/add-app-overlay.component.html
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.html
@@ -98,7 +98,7 @@
               </a>
             </p>
             <br/>
-            <h5>When I import a codebase?</h5>
+            <h5>When should I import a codebase?</h5>
             <p>
               If you have existing code in a GitHub repository, you can choose the import
               option and use that code as a foundation for an application in CodeReady Toolchain.

--- a/src/app/space/add-app-overlay/add-app-overlay.component.html
+++ b/src/app/space/add-app-overlay/add-app-overlay.component.html
@@ -73,8 +73,8 @@
           <section class="col-sm-6 f8-add-app-overlay__right-section">
             <h5>What happens when I create an application?</h5>
             <p>
-              When you create an application in CodeReady ToolChain, a new codebase
-              is created and stored in your git repository. CodeReady ToolChain also
+              When you create an application in CodeReady Toolchain, a new codebase
+              is created and stored in your git repository. CodeReady Toolchain also
               generates a new pipeline and pipeline environments for the application
               and starts an initial build.
             </p>
@@ -87,8 +87,8 @@
             <h5>What is a codebase?</h5>
             <p>
               A codebase is a generic representation of an application's code.
-              CodeReady ToolChain also stores application metadata for version control.
-              Since CodeReady ToolChain provides a hosted instance of Eclipse Che, you can
+              CodeReady Toolchain also stores application metadata for version control.
+              Since CodeReady Toolchain provides a hosted instance of Eclipse Che, you can
               create a workspace for any application and use the browser-based IDE
               and containerized development/testing environment to make updates to your codebase.
             </p>
@@ -101,7 +101,7 @@
             <h5>When I import a codebase?</h5>
             <p>
               If you have existing code in a GitHub repository, you can choose the import
-              option and use that code as a foundation for an application in CodeReady ToolChain.
+              option and use that code as a foundation for an application in CodeReady Toolchain.
             </p>
             <p>
               <a href="https://docs.openshift.io/getting-started-guide.html#importing-existing-project" target="_blank">

--- a/src/app/space/add-space-overlay/add-space-overlay.component.html
+++ b/src/app/space/add-space-overlay/add-space-overlay.component.html
@@ -52,7 +52,7 @@
             </p>
             <h5>What is a space?</h5>
             <p>
-              A space in Openshift.io is where a team works. Every application, codebase,
+              A space in CodeReady Toolchain is where a team works. Every application, codebase,
               iteration, work item and collaborator is attached to a space.
             </p>
             <p>

--- a/src/app/space/app-launcher/services/app-launcher-target-environment.service.ts
+++ b/src/app/space/app-launcher/services/app-launcher-target-environment.service.ts
@@ -12,7 +12,7 @@ export class AppLauncherTargetEnvironmentService implements TargetEnvironmentSer
   getTargetEnvironments(): Observable<TargetEnvironment[]> {
     return observableOf([{
       description: 'Here is a brief description of what OpenShift Online is. ' +
-        'There is a distinction between what OpenShift Online does compared to OpenShift.io.',
+        'There is a distinction between what OpenShift Online does compared to CodeReady Toolchain.',
       benefits: [
         'In your GitHub namespace, create repository containg your project\'s code.',
         'Configure OpenShift Online to build and deploy your code on each push to your repository\'s master branch.',

--- a/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.component.html
+++ b/src/app/space/create/codebases/codebases-delete/codebase-delete-dialog.component.html
@@ -6,7 +6,7 @@
 </div>
 <div class="modal-body">
   <p>Are you sure you want to remove <span class="codebase-name">{{ codebase.name }}</span>?
-    This will only remove the codebase from OpenShift.io, and will not delete your code from
+    This will only remove the codebase from CodeReady Toolchain, and will not delete your code from
     your git repository.</p>
 </div>
 <div class="modal-footer">


### PR DESCRIPTION
Update all static text references to CodeReady Toolchain on OSIO - [OSIO-1180](https://openshift.io/openshiftio/Openshift_io/plan/detail/1180)

Attaching screenshots for some of the code changes:

Feature Opt In
![featureoptin](https://user-images.githubusercontent.com/1892722/49517562-27062e00-f862-11e8-8bf1-12f7fa3d0465.png)

Context text during space creation
![context](https://user-images.githubusercontent.com/1892722/49517609-3be2c180-f862-11e8-8d4f-33f5bce9adce.png)

Context text during app creation
![app](https://user-images.githubusercontent.com/1892722/49517652-56b53600-f862-11e8-81a6-b33c6db5eba0.png)


Remove codebase modal
![removecodebase](https://user-images.githubusercontent.com/1892722/49517629-4c933780-f862-11e8-9be0-892e13f00112.png)




Reference: https://github.com/openshiftio/openshift.io/issues/4364
