### PR TITLE
feat(roles): add feature flags on settings icon and collaborators page

### DIFF
--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -23,6 +23,7 @@ import {
 } from 'testing/test-context';
 import { LoginService } from '../../shared/login.service';
 import { HeaderComponent } from './header.component';
+import { MenusService } from './menus.service';
 
 @Component({
   template: '<alm-app-header></alm-app-header>'
@@ -68,6 +69,7 @@ describe('HeaderComponent', () => {
     declarations: [ MockRoutedComponent ],
     providers: [
       { provide: UserService, useValue: { loggedInUser: observableNever() } },
+      { provide: MenusService, useValue: jasmine.createSpyObj('MenusService', ['isFeatureUserEnabled']) },
       { provide: PermissionService, useValue:  jasmine.createSpyObj('PermissionService', ['hasScope']) },
       { provide: LoginService, useValue: jasmine.createSpyObj('LoginService', ['login']) },
       { provide: Broadcaster, useValue: mockBroadcaster },

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -44,7 +44,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       'settings', function(headerComponent, menuItem) {
         const subFeature = menuItem['subFeature'];
         const allFeatures = headerComponent.context.user['features'];
-        if (headerComponent.menusService.isFeatureUserEnabled(subFeature, allFeatures)) {
+        if (subFeature && allFeatures && headerComponent.menusService.isFeatureUserEnabled(subFeature, allFeatures)) {
           return headerComponent.loggedInUserNotSpaceAdmin();
         }
         return headerComponent.checkContextUserEqualsLoggedInUser();

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -9,9 +9,10 @@ import { MenuItem } from '../../models/menu-item';
 import { Navigation } from '../../models/navigation';
 import { LoginService } from '../../shared/login.service';
 import { MenuedContextType } from './menued-context-type';
+import { MenusService } from './menus.service';
 
 interface MenuHiddenCallback {
-  (headerComponent: HeaderComponent): Observable<boolean>;
+  (headerComponent: HeaderComponent, menuItem: MenuItem): Observable<boolean>;
 }
 
 @Component({
@@ -30,18 +31,23 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   menuCallbacks: Map<String, MenuHiddenCallback> = new Map<String, MenuHiddenCallback>([
     [
-      '_settings', function(headerComponent) {
+      '_settings', function(headerComponent, menuItem) {
         return headerComponent.checkContextUserEqualsLoggedInUser();
       }
     ],
     [
-      '_resources', function(headerComponent) {
+      '_resources', function(headerComponent, menuItem) {
         return headerComponent.checkContextUserEqualsLoggedInUser();
       }
     ],
     [
-      'settings', function(headerComponent) {
-        return headerComponent.loggedInUserNotSpaceAdmin();
+      'settings', function(headerComponent, menuItem) {
+        const subFeature = menuItem['subFeature'];
+        const allFeatures = headerComponent.context.user['features'];
+        if (headerComponent.menusService.isFeatureUserEnabled(subFeature, allFeatures)) {
+          return headerComponent.loggedInUserNotSpaceAdmin();
+        }
+        return headerComponent.checkContextUserEqualsLoggedInUser();
       }
     ]
   ]);
@@ -61,7 +67,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     public loginService: LoginService,
     private broadcaster: Broadcaster,
     private contexts: Contexts,
-    private permissionService: PermissionService
+    private permissionService: PermissionService,
+    private menusService: MenusService
   ) {
     router.events.subscribe((val: Event): void => {
       if (val instanceof NavigationEnd) {
@@ -169,7 +176,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
         // Clear the menu's active state
         n.active = false;
         if (this.menuCallbacks.has(n.path)) {
-          this.menuCallbacks.get(n.path)(this).subscribe(val => n.hide = val);
+          this.menuCallbacks.get(n.path)(this, n).subscribe(val => n.hide = val);
         }
         // lets go in reverse order to avoid matching
         // /namespace/space/create instead of /namespace/space/create/pipelines
@@ -185,7 +192,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
               n.active = true;
             }
             if (this.menuCallbacks.has(o.path)) {
-              this.menuCallbacks.get(o.path)(this).subscribe(val => o.hide = val);
+              this.menuCallbacks.get(o.path)(this, o).subscribe(val => o.hide = val);
             }
           }
           if (!foundPath) {
@@ -197,7 +204,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
                 n.active = true;
               }
               if (this.menuCallbacks.has(o.path)) {
-                this.menuCallbacks.get(o.path)(this).subscribe(val => o.hide = val);
+                this.menuCallbacks.get(o.path)(this, o).subscribe(val => o.hide = val);
               }
             }
           }
@@ -211,7 +218,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
                 n.active = true;
               }
               if (this.menuCallbacks.has(o.path)) {
-                this.menuCallbacks.get(o.path)(this).subscribe(val => o.hide = val);
+                this.menuCallbacks.get(o.path)(this, o).subscribe(val => o.hide = val);
               }
             }
           }

--- a/src/app/layout/header/menus.service.ts
+++ b/src/app/layout/header/menus.service.ts
@@ -17,6 +17,7 @@ export class MenusService {
         [
           {
             name: '',
+            subFeature: 'SpaceSettings',
             path: 'settings',
             icon: 'pficon pficon-settings',
             menus: [
@@ -77,7 +78,7 @@ export class MenusService {
     ]);
   }
 
-  private isFeatureEnabled(feature: string, features: Feature[]): boolean {
+  public isFeatureEnabled(feature: string, features: Feature[]): boolean {
     for (let f of features) {
       if (f.id === feature) {
         return f.attributes.enabled;
@@ -86,8 +87,17 @@ export class MenusService {
     return true;
   }
 
+  public isFeatureUserEnabled(feature: string, features: Feature[]): boolean {
+    for (let f of features) {
+      if (f.id === feature) {
+        return f.attributes['user-enabled'];
+      }
+    }
+    return true;
+  }
+
   // if a user is non-internal, she should not see internal feature in menu (feature is unapplicable)
-  private isFeatureNonApplicable(feature: string, features: Feature[]): boolean {
+  public isFeatureNonApplicable(feature: string, features: Feature[]): boolean {
     for (let f of features) {
       if (f.id === feature && !f.attributes['enablement-level']) {
         return true;

--- a/src/app/models/menu-item.ts
+++ b/src/app/models/menu-item.ts
@@ -1,6 +1,7 @@
 export interface MenuItem {
     name?: string;
     feature?: string;
+    subFeature?: string;
     path: string;
     fullPath?: string;
     icon?: string;

--- a/src/app/space/settings/collaborators/collaborators.component.html
+++ b/src/app/space/settings/collaborators/collaborators.component.html
@@ -1,99 +1,185 @@
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-xs-8 col-sm-8 col-md-9">
-      <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name}} Space:</h3>
-    </div>
-    <div class="col-xs-4 col-sm-4 col-md-3">
-      <div class="table-action-heading" (click)="launchAddCollaborators()">
-        <a><i class="pficon pficon-add-circle-o"></i> Add Collaborators</a>
+<f8-feature-toggle featureName="SpaceSettings.Collaborators" [userLevel]="user" [defaultLevel]="default"></f8-feature-toggle>
+<ng-template #user>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-8 col-sm-8 col-md-9">
+        <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name}} Space:</h3>
+      </div>
+      <div class="col-xs-4 col-sm-4 col-md-3">
+        <div class="table-action-heading" (click)="launchAddCollaborators()">
+          <a><i class="pficon pficon-add-circle-o"></i> Add Collaborators</a>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="collaborator-list-scroll" almInfiniteScroll (eachElementHeightInPx)='54' (initItems)='initCollaborators($event)' (fetchMore)='fetchMoreCollaborators($event)'>
-        <pfng-list
-          [config]="listConfig"
-          [itemHeadingTemplate]="itemHeadingTemplate"
-          [itemTemplate]="itemTemplate"
-          [actionTemplate]="actionTemplate"
-          [items]="collaborators" >
-          <ng-template #itemHeadingTemplate let-item="item">
-            <div class="list-pf-left">
-              <!-- Place holder to user avatar width below -->
-              <span class="icon-user"></span>
-            </div>
-            <div class="list-pf-content-wrapper">
-              <div class="list-pf-main-content">
-                <div class="list-pf-title">NAME (ID)</div>
-                <div class="list-pf-description">EMAIL</div>
-                <div class="list-pf-description">ROLE</div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="collaborator-list-scroll" almInfiniteScroll (eachElementHeightInPx)='54' (initItems)='initCollaborators($event)' (fetchMore)='fetchMoreCollaborators($event)'>
+          <pfng-list
+            [config]="listConfig"
+            [itemHeadingTemplate]="itemHeadingTemplate"
+            [itemTemplate]="itemTemplate"
+            [actionTemplate]="actionTemplate"
+            [items]="collaborators" >
+            <ng-template #itemHeadingTemplate let-item="item">
+              <div class="list-pf-left">
+                <!-- Place holder to user avatar width below -->
+                <span class="icon-user"></span>
               </div>
-            </div>
-          </ng-template>
-          <ng-template #itemTemplate let-item="item" let-index="index">
-            <div class="list-pf-left">
-              <span *ngIf="(item.attributes.imageURL !== undefined && item.attributes.imageURL.length !== 0); then showImageUrl else defaultImageUrl"></span>
-              <ng-template #showImageUrl>
-                <img [src]="item.attributes.imageURL" class="icon-user" height="40">
-              </ng-template>
-              <ng-template #defaultImageUrl>
-                <img src="../../../../assets/images/profile-user.png" class="icon-user" height="40">
-              </ng-template>
-            </div>
-            <div class="list-pf-content-wrapper">
-              <div class="list-pf-main-content">
-                <div class="list-pf-title">
-                  <span>{{item.attributes.fullName}}</span>
-                  <span class="collab-username">({{item.attributes.username}})</span>
-                </div>
-                <div class="list-pf-description">
-                  {{item.attributes.email}}
-                </div>
-                <div class="list-pf-description">
-                  {{ adminCollaborators.includes(item.id) ? 'Admin' : 'Contributor' }}
+              <div class="list-pf-content-wrapper">
+                <div class="list-pf-main-content">
+                  <div class="list-pf-title">NAME (ID)</div>
+                  <div class="list-pf-description">EMAIL</div>
+                  <div class="list-pf-description">ROLE</div>
                 </div>
               </div>
-            </div>
-          </ng-template>
-          <ng-template #actionTemplate let-item="item" let-index="index">
-            <span class="dropdown-kebab-pf dropdown" dropdown>
-              <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
-                <span class="fa fa-ellipsis-v"></span>
-              </button>
-              <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
-                <li role="menuitem">
-                  <a [routerLink]="['/', item.attributes.username]" class="secondary-action">View user</a>
-                </li>
-                <li *ngIf="!adminCollaborators.includes(item.id) else removeAdmin" role="menuitem">
-                  <a (click)="assignUserRole(item.id, 'admin')" class="secondary-action menu-item">Make admin</a>
-                </li>
-                <ng-template #removeAdmin>
-                  <li *ngIf="!isSpaceOwner(item.id); else cannotRemoveAdmin" role="menuitem">
-                    <a (click)="assignUserRole(item.id, 'contributor')" class="secondary-action menu-item">Remove as admin</a>
+            </ng-template>
+            <ng-template #itemTemplate let-item="item" let-index="index">
+              <div class="list-pf-left">
+                <span *ngIf="(item.attributes.imageURL !== undefined && item.attributes.imageURL.length !== 0); then showImageUrl else defaultImageUrl"></span>
+                <ng-template #showImageUrl>
+                  <img [src]="item.attributes.imageURL" class="icon-user" height="40">
+                </ng-template>
+                <ng-template #defaultImageUrl>
+                  <img src="../../../../assets/images/profile-user.png" class="icon-user" height="40">
+                </ng-template>
+              </div>
+              <div class="list-pf-content-wrapper">
+                <div class="list-pf-main-content">
+                  <div class="list-pf-title">
+                    <span>{{item.attributes.fullName}}</span>
+                    <span class="collab-username">({{item.attributes.username}})</span>
+                  </div>
+                  <div class="list-pf-description">
+                    {{item.attributes.email}}
+                  </div>
+                  <div class="list-pf-description">
+                    {{ adminCollaborators.includes(item.id) ? 'Admin' : 'Contributor' }}
+                  </div>
+                </div>
+              </div>
+            </ng-template>
+            <ng-template #actionTemplate let-item="item" let-index="index">
+              <span class="dropdown-kebab-pf dropdown" dropdown>
+                <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
+                  <span class="fa fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
+                  <li role="menuitem">
+                    <a [routerLink]="['/', item.attributes.username]" class="secondary-action">View user</a>
                   </li>
-                  <ng-template #cannotRemoveAdmin>
-                    <li class="disabled" title="Cannot remove owner of space as admin">
-                      <a class="secondary-action menu-item">Remove as admin</a>
+                  <li *ngIf="!adminCollaborators.includes(item.id) else removeAdmin" role="menuitem">
+                    <a (click)="assignUserRole(item.id, 'admin')" class="secondary-action menu-item">Make admin</a>
+                  </li>
+                  <ng-template #removeAdmin>
+                    <li *ngIf="!isSpaceOwner(item.id); else cannotRemoveAdmin" role="menuitem">
+                      <a (click)="assignUserRole(item.id, 'contributor')" class="secondary-action menu-item">Remove as admin</a>
+                    </li>
+                    <ng-template #cannotRemoveAdmin>
+                      <li class="disabled" title="Cannot remove owner of space as admin">
+                        <a class="secondary-action menu-item">Remove as admin</a>
+                      </li>
+                    </ng-template>
+                  </ng-template>
+                  <li *ngIf="!isSpaceOwner(item.id); else cannotRemoveUser" role="menuitem">
+                    <a class="secondary-action menu-item" (click)="confirmUserRemove(item)">Remove user</a>
+                  </li>
+                  <ng-template #cannotRemoveUser>
+                    <li class="disabled" title="Cannot remove owner of space">
+                      <a class="secondary-action">Remove user</a>
                     </li>
                   </ng-template>
-                </ng-template>
-                <li *ngIf="!isSpaceOwner(item.id); else cannotRemoveUser" role="menuitem">
-                  <a class="secondary-action menu-item" (click)="confirmUserRemove(item)">Remove from space</a>
-                </li>
-                <ng-template #cannotRemoveUser>
-                  <li class="disabled" title="Cannot remove owner of space">
-                    <a class="secondary-action">Remove from space</a>
-                  </li>
-                </ng-template>
-              </ul>
-            </span>
-          </ng-template>
-        </pfng-list>
+                </ul>
+              </span>
+            </ng-template>
+          </pfng-list>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</ng-template>
+<ng-template #default>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-8 col-sm-8 col-md-9">
+        <h3 class="collaborators-header">Collaborators of {{context.space.attributes.name}} Space:</h3>
+      </div>
+      <div class="col-xs-4 col-sm-4 col-md-3">
+        <div class="table-action-heading" (click)="launchAddCollaborators()">
+          <a><i class="pficon pficon-add-circle-o"></i> Add Collaborators</a>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="collaborator-list-scroll" almInfiniteScroll (eachElementHeightInPx)='54' (initItems)='initCollaborators($event)' (fetchMore)='fetchMoreCollaborators($event)'>
+          <pfng-list
+            [config]="listConfig"
+            [itemHeadingTemplate]="itemHeadingTemplate"
+            [itemTemplate]="itemTemplate"
+            [actionTemplate]="actionTemplate"
+            [items]="collaborators" >
+            <ng-template #itemHeadingTemplate let-item="item">
+              <div class="list-pf-left">
+                <!-- Place holder to user avatar width below -->
+                <span class="icon-user"></span>
+              </div>
+              <div class="list-pf-content-wrapper">
+                <div class="list-pf-main-content">
+                  <div class="list-pf-title">NAME (ID)</div>
+                  <div class="list-pf-description">EMAIL</div>
+                </div>
+              </div>
+            </ng-template>
+            <ng-template #itemTemplate let-item="item" let-index="index">
+              <div class="list-pf-left">
+                <span *ngIf="(item.attributes.imageURL !== undefined && item.attributes.imageURL.length !== 0); then showImageUrl else defaultImageUrl"></span>
+                <ng-template #showImageUrl>
+                  <img [src]="item.attributes.imageURL" class="icon-user" height="40">
+                </ng-template>
+                <ng-template #defaultImageUrl>
+                  <img src="../../../../assets/images/profile-user.png" class="icon-user" height="40">
+                </ng-template>
+              </div>
+              <div class="list-pf-content-wrapper">
+                <div class="list-pf-main-content">
+                  <div class="list-pf-title">
+                    <span>{{item.attributes.fullName}}</span>
+                    <span class="collab-username">({{item.attributes.username}})</span>
+                  </div>
+                  <div class="list-pf-description">
+                    {{item.attributes.email}}
+                  </div>
+                </div>
+              </div>
+            </ng-template>
+            <ng-template #actionTemplate let-item="item" let-index="index">
+              <span class="dropdown-kebab-pf dropdown" dropdown>
+                <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
+                  <span class="fa fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebab" *dropdownMenu>
+                  <li role="menuitem">
+                    <a [routerLink]="['/', item.attributes.username]" class="secondary-action">View user</a>
+                  </li>
+                  <li *ngIf="item.id !== context.space.relationships['owned-by'].data.id; else cannotRemove" role="menuitem">
+                    <a class="secondary-action menu-item" (click)="confirmUserRemove(item)">Remove user</a>
+                  </li>
+                  <ng-template #cannotRemove>
+                    <li class="disabled" title="Cannot remove owner of space">
+                      <a class="secondary-action">Remove user</a>
+                    </li>
+                  </ng-template>
+                </ul>
+              </span>
+            </ng-template>
+          </pfng-list>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-template>
+
+
 
 <div class="modal fade" bsModal #modalAdd="bs-modal" tabindex="-1" role="dialog" aria-hidden="true" (onShown)="onShowHandler()">
   <div class="modal-dialog">

--- a/src/app/space/settings/collaborators/collaborators.module.ts
+++ b/src/app/space/settings/collaborators/collaborators.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { Fabric8WitModule } from 'ngx-fabric8-wit';
+import { FeatureFlagModule } from 'ngx-feature-flag';
 import { InfiniteScrollModule } from 'ngx-widgets';
 import { ListModule } from 'patternfly-ng/list';
 import { AddCollaboratorsDialogModule } from './add-collaborators-dialog/add-collaborators-dialog.module';
@@ -18,7 +19,8 @@ import { CollaboratorsComponent } from './collaborators.component';
     InfiniteScrollModule,
     AddCollaboratorsDialogModule,
     ModalModule.forRoot(),
-    Fabric8WitModule
+    Fabric8WitModule,
+    FeatureFlagModule
   ],
   declarations: [
     CollaboratorsComponent


### PR DESCRIPTION
Planner Story - https://openshift.io/openshiftio/Openshift_io/plan/detail/1211

This PR adds feature flag to the logic to hiding settings icon in the header and on the collaborators page inside settings.

- The header component is rendered by using `MenusService` to determine if the menu item needs to be rendered or not.
- `MenusService` checks for feature enabled menu items and send it to component level where the logic to hide something based on user is owner or admin is decided.
- This is why its tricky to introduce feature flag at the header level based on the user permission as well as the feature enablement.
- For achieving this we had to introduce on more property called `subFeature` in the `MenuItem` type interface. Based on the `feature` property menu item is deleted from the list using menu.service. After that the component uses `subFeature` to further decide which logic to use based on faeture flag along with user permission.
- Add collaborators page under feature flag.
- Feature flag for both the pages are set to `beta` as planner is also set at same level.