### PR TITLE
fix(build): run semantic-release from root and only include build dir

### DIFF
--- a/packages/fabric8-ui/package.json
+++ b/packages/fabric8-ui/package.json
@@ -7,6 +7,9 @@
     "typescript"
   ],
   "license": "Apache-2.0",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "analyze": "osio-scripts analyze",
     "build": "CI=false STATIC_DIR=_static osio-scripts build",
@@ -27,7 +30,7 @@
     "test:e2e": "npm run e2e"
   },
   "dependencies": {
-    "@osio/scripts": "^0.0.1",
+    "@osio/scripts": "0.0.1",
     "@angularclass/hmr": "2.1.3",
     "@angularclass/hmr-loader": "3.0.4",
     "@ng-select/ng-select": "2.12.1",
@@ -73,7 +76,7 @@
     "ngx-widgets": "3.2.0",
     "patternfly": "3.54.8",
     "patternfly-ng": "4.5.1",
-    "patternfly-sandbox-ng": "^0.1.0",
+    "patternfly-sandbox-ng": "0.1.0",
     "pluralize": "7.0.0",
     "raven-js": "3.27.0",
     "uuid": "3.3.2"
@@ -85,7 +88,7 @@
     "gulp-clean": "0.4.0",
     "gulp-rename": "1.4.0",
     "gulp-replace": "1.0.0",
-    "readline-sync": "^1.4.0",
+    "readline-sync": "1.4.9",
     "rxjs-tslint": "0.1.5",
     "semantic-release": "15.12.0",
     "stylelint": "9.5.0",
@@ -94,6 +97,6 @@
   "release": {
     "branch": "master",
     "debug": "true",
-    "pkgRoot": "build"
+    "pkgRoot": "."
   }
 }


### PR DESCRIPTION
semantic-release was failing on the build because it was set to run in the build dir which did not include a package.json file. Updated package.json to specify `pkgRoot` to be the root dir and set the `files` array to include the `build` dir.

dry run:
```
21:30:52] [semantic-release] › ℹ  Running semantic-release version 15.12.0
[21:30:53] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/npm"
[21:30:53] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[21:30:53] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[21:30:53] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[21:30:53] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/npm"
[21:30:53] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/npm"
[21:30:53] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
[21:30:53] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
[21:30:53] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
[21:30:53] [semantic-release] › ⚠  This run was not triggered in a known CI environment, running in dry-run mode.
[21:30:53] [semantic-release] › ℹ  This test run was triggered on the branch move, while semantic-release is configured to only publish from origin/master, therefore a new version won’t be published.
```