### PR TITLE
fix(tests): run tests with CI=1 to ensure exit code is properly reported

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:html": "htmlhint **/*.html",
     "reinstall": "npm run clean && npm install",
     "start": "npm run tmp_e2e_workaround",
-    "test": "lerna run test --stream",
+    "test": "CI=1 lerna run test --stream",
     "tmp_e2e_workaround": "npm run bootstrap && npm start --prefix packages/fabric8-ui"
   },
   "engines": {


### PR DESCRIPTION
Unit tests weren't reporting the error code and therefore builds could still pass with failed unit tests.

Need to set `CI=1` to run tests in order to report a proper exit code which the build will use to check for failures.