### PR TITLE
fix(style): width of the elements

### DIFF
--- a/packages/planner/src/app/components_ngrx/label-selector/label-selector.component.less
+++ b/packages/planner/src/app/components_ngrx/label-selector/label-selector.component.less
@@ -34,7 +34,7 @@
 
 .create-label {
   .create-label-input {
-    width: ~'calc(e("100% - 90px"))';
+    width: ~'calc(100% - 90px)';
     height: 100%;
     display: inline-block;
     vertical-align: middle;

--- a/packages/planner/src/app/components_ngrx/planner-list/planner-list.component.less
+++ b/packages/planner/src/app/components_ngrx/planner-list/planner-list.component.less
@@ -24,10 +24,10 @@
       color: @color-pf-black;
       transform: translate(-50%, -50%);
       h2 {
-        margin-top: .5em;
+        margin-top: 0.5em;
       }
       .spinner {
-        &:before {
+        &::before {
           content: unset;
         }
         position: relative;
@@ -45,7 +45,7 @@
       width: 100%;
       overflow-y: auto;
       .f8-planner-list-title {
-        max-width: ~'calc(e("100% - 20px"))';
+        max-width: ~'calc(100% - 20px)';
       }
       //List entry tree view specific css
       .tree-node-level-2 .list-pf-item {
@@ -69,23 +69,23 @@
         }
         aside {
           float: right;
-          width: ~'calc(e("45% - 30px"))';
+          width: ~'calc(45% - 30px)';
           height: 100%;
-          padding-left: (@grid-gutter-width/6);
-          padding-right: (@grid-gutter-width/6);
+          padding-left: (@grid-gutter-width / 6);
+          padding-right: (@grid-gutter-width / 6);
           &:first-child,
           &:nth-child(3) {
             width: 10%;
-            padding: 0 (@grid-gutter-width/3);
+            padding: 0 (@grid-gutter-width / 3);
             span.fa {
               width: 100%;
               text-align: center;
-              padding: (@grid-gutter-width/6) 0;
-              margin: (@grid-gutter-width/6) 0;
+              padding: (@grid-gutter-width / 6) 0;
+              margin: (@grid-gutter-width / 6) 0;
               font-size: @pf-icon-2x;
             }
             &:nth-child(3) {
-              margin-top: ((@grid-gutter-width/3)*5);
+              margin-top: ((@grid-gutter-width / 3) * 5);
             }
           }
         }
@@ -94,7 +94,7 @@
         float: left;
         width: 100%;
         height: ~'calc(e("100% - 30px"))';
-        padding: (@grid-gutter-width/3);
+        padding: (@grid-gutter-width / 3);
         list-style: none;
         background-color: @color-pf-white;
         border: 1px solid;

--- a/packages/planner/src/app/components_ngrx/planner-query/planner-query.component.less
+++ b/packages/planner/src/app/components_ngrx/planner-query/planner-query.component.less
@@ -31,9 +31,9 @@
     right: 15px;
 
     &-menu {
+      right: 0 !important;
       min-width: 400px;
       min-height: 150px;
-      right: 0 !important;
     }
 
     &-close {
@@ -57,5 +57,5 @@
 }
 
 work-item-cell {
-  max-width: ~'calc(e("100% - 50px"))';
+  max-width: ~'calc(100% - 50px)';
 }

--- a/packages/planner/src/app/components_ngrx/work-item-cell/work-item-cell.component.less
+++ b/packages/planner/src/app/components_ngrx/work-item-cell/work-item-cell.component.less
@@ -3,7 +3,7 @@
 }
 .wi-detail-title {
   display: inline-flex;
-  width: ~'calc(e("100% - 20px"))';
+  width: ~'calc(100% - 20px)';
 }
 
 .wi-detail-icon {
@@ -30,7 +30,7 @@
     white-space: normal;
   }
 
-.click-disable {
-  cursor: not-allowed;
-}
+  .click-disable {
+    cursor: not-allowed;
+  }
 }

--- a/packages/planner/src/app/widgets/inlineinput/inlineinput.component.less
+++ b/packages/planner/src/app/widgets/inlineinput/inlineinput.component.less
@@ -3,7 +3,7 @@
 .inlineinput-container {
   width: 100%;
   .input-field {
-    width: ~'calc(e("100% - 30px"))';
+    width: ~'calc(100% - 30px)';
     height: 27px;
     min-height: 27px;
     padding: 0 (@grid-gutter-width/3);
@@ -54,7 +54,7 @@
     }
   }
   .active {
-    width: ~'calc(e("100% - 110px"))';
+    width: ~'calc(100% - 110px)';
     background-color: @color-pf-white;
     border: 1px solid;
     border-color: @color-pf-blue-400;


### PR DESCRIPTION
Fix: https://github.com/openshiftio/openshift.io/issues/4645

**Before:**
Long title is broken in planner
![screenshot from 2018-12-26 10-49-56](https://user-images.githubusercontent.com/2561818/50433086-0a5a9480-08fc-11e9-9fe6-19d4c827fdbc.png)

**After:**
Add truncate for long 
![screenshot from 2018-12-26 10-50-58](https://user-images.githubusercontent.com/2561818/50433158-3d9d2380-08fc-11e9-99ae-bf18b3ea76ca.png)

**Before:**
Input field width is not 100%
![screenshot from 2018-12-26 10-52-06](https://user-images.githubusercontent.com/2561818/50433182-5dcce280-08fc-11e9-9221-8b17e4bc12dd.png)

**After:**
Input field width is 100%
![screenshot from 2018-12-26 10-52-57](https://user-images.githubusercontent.com/2561818/50433193-70471c00-08fc-11e9-9165-d89cae47d5c7.png)
