### PR TITLE
fix(planner): Iteration labels not used consistently

### DIFF
--- a/packages/planner/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
+++ b/packages/planner/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
@@ -72,13 +72,13 @@
   id="table-iteration"
   *ngIf="col === 'iteration'"
   tooltip="{{
-    (row.iterationObs | async)?.parentPath === '/' ? 'NA' : (row.iterationObs | async)?.name
+    (row.iterationObs | async)?.parentPath === '/' ? '/' : (row.iterationObs | async)?.name
   }}"
   placement="left"
 >
   {{
     (row.iterationObs | async)?.parentPath === '/'
-      ? 'NA'
+      ? '/'
       : ((row.iterationObs | async)?.name | truncate: 12)
   }}
 </span>


### PR DESCRIPTION
- Added slash for root iteration
Issue: https://github.com/openshiftio/openshift.io/issues/2997
Issue: https://github.com/openshiftio/openshift.io/issues/4665
Issue: https://github.com/openshiftio/openshift.io/issues/4666
![screen shot 2018-12-26 at 17 39 14](https://user-images.githubusercontent.com/12659320/50450229-3b0af000-0935-11e9-82db-ff18e3a8a078.png)


