### PR TITLE
fix(planner): Child work item inherits iteration

### DIFF
--- a/packages/planner/src/app/components_ngrx/planner-list/planner-list.component.html
+++ b/packages/planner/src/app/components_ngrx/planner-list/planner-list.component.html
@@ -117,6 +117,7 @@
                 [selectedType]="type?.childTypes?.length ? type.childTypes[0] : null"
                 [selectedIteration]="selectedIterationSource | async"
                 [parentWorkItemId]="row.id"
+                [parentWorkItemIterationId]="row.iterationId"
                 (onStartCreateWI)="onCreateStart($event)"
               >
               </alm-work-item-quick-add>

--- a/packages/planner/src/app/components_ngrx/work-item-quick-add/work-item-quick-add.component.ts
+++ b/packages/planner/src/app/components_ngrx/work-item-quick-add/work-item-quick-add.component.ts
@@ -44,6 +44,7 @@ export class WorkItemQuickAddComponent
   @ViewChild('inlinequickAddElement') inlinequickAddElement: ElementRef;
 
   @Input() parentWorkItemId: string = null;
+  @Input() parentWorkItemIterationId: string = null;
   @Input() workItemTypes: WorkItemTypeUI[] = [];
   @Input() selectedType: WorkItemTypeUI = null;
   @Input() selectedIteration: IterationUI = null;
@@ -192,6 +193,17 @@ export class WorkItemQuickAddComponent
         },
       };
     }
+
+    // Set the parent iteration for new child work item
+    if (this.parentWorkItemIterationId) {
+      this.workItem.relationships.iteration = {
+        data: {
+          id: this.parentWorkItemIterationId,
+          type: 'iterations',
+        },
+      };
+    }
+
     this.createId = new Date().getTime();
 
     if (this.workItem.attributes['system.title']) {


### PR DESCRIPTION
Fixes https://github.com/fabric8-ui/fabric8-ui/pull/3464
Added Inheritance of iteration from parent

![screen shot 2018-12-27 at 19 01 16](https://user-images.githubusercontent.com/12659320/50488237-23516b80-0a0a-11e9-95ca-d7bfa4b5eab5.png)
![screen shot 2018-12-27 at 19 02 59](https://user-images.githubusercontent.com/12659320/50488241-28161f80-0a0a-11e9-8eaf-af0b406d4d40.png)
