### PR TITLE
preparation for new nav

### DIFF
--- a/packages/fabric8-ui/src/app/app.module.ts
+++ b/packages/fabric8-ui/src/app/app.module.ts
@@ -98,6 +98,12 @@ import { HttpInterceptorProviders } from './shared/interceptors/index';
 import { RequestCache } from './shared/request-cache.service';
 import { togglesApiUrlProvider } from './shared/toggles.api.provider';
 
+/**
+ * Import application wide styles
+ */
+import '../assets/stylesheets/fabric8-ui-global-overrides.less';
+import '../assets/stylesheets/shared/osio.less';
+
 // Application wide providers
 const APP_PROVIDERS = [...APP_RESOLVER_PROVIDERS, AppState];
 

--- a/packages/fabric8-ui/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.html
+++ b/packages/fabric8-ui/src/app/profile/my-spaces/my-spaces-toolbar/my-spaces-toolbar.component.html
@@ -17,22 +17,11 @@
     >
       <ng-template #toolbarTemplate>
         <span class="vertical-separator padding-right-10">
-          <button
-            class="btn btn-default"
-            type="button"
-            tooltip="Search Spaces"
-            placement="top"
-            (click)="searchSpaces($event)"
-          >
+          <button class="btn btn-default" type="button" (click)="searchSpaces($event)">
             Find a Space to Join
           </button>
         </span>
-        <span
-          class="with-cursor-pointer padding-left-10"
-          placement="top"
-          tooltip="Create Space"
-          (click)="createSpace($event)"
-        >
+        <span class="with-cursor-pointer padding-left-10" (click)="createSpace($event)">
           <span class="add-space-tooltip">
             <i class="pficon pficon-add-circle-o margin-top-4"></i> Create Space
           </span>

--- a/packages/fabric8-ui/src/app/profile/overview/overview.component.less
+++ b/packages/fabric8-ui/src/app/profile/overview/overview.component.less
@@ -107,7 +107,6 @@
 
 .profile-overview-nav {
   padding: 4px 0 0;
-  margin-left: -48px;
   background-color: @color-pf-black-150;
   border-bottom: 1px solid @color-pf-black-300;
   .nav-tabs {

--- a/packages/fabric8-ui/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.html
+++ b/packages/fabric8-ui/src/app/space/create/codebases/codebases-toolbar/codebases-toolbar.component.html
@@ -6,12 +6,7 @@
     (onSortChange)="sortChange($event)"
   >
     <ng-template #addCodebaseTemplate>
-      <span
-        class="with-cursor-pointer"
-        placement="top"
-        tooltip="Add a Codebase"
-        (click)="addToSpace.emit()"
-      >
+      <span class="with-cursor-pointer" (click)="addToSpace.emit()">
         <span class="add-codebase-tooltip">
           <i class="pficon pficon-add-circle-o margin-top-4"></i> Add Codebase
         </span>

--- a/packages/fabric8-ui/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.html
+++ b/packages/fabric8-ui/src/app/space/settings/areas/areas-toolbar/areas-toolbar.component.html
@@ -6,13 +6,7 @@
     (onSortChange)="sortChange($event)"
   >
     <ng-template #addAreasTemplate>
-      <span
-        class="with-cursor-pointer"
-        placement="top"
-        tooltip="Add Areas"
-        *ngIf="userOwnsSpace"
-        (click)="addArea($event)"
-      >
+      <span class="with-cursor-pointer" *ngIf="userOwnsSpace" (click)="addArea($event)">
         <span class="add-codebase-tooltip">
           <i class="pficon pficon-add-circle-o margin-top-4"></i> Add Areas
         </span>

--- a/packages/fabric8-ui/src/main.browser.ts
+++ b/packages/fabric8-ui/src/main.browser.ts
@@ -18,12 +18,6 @@ import { decorateModuleRef } from './app/environment';
 import { AppModule } from './app/index';
 
 /**
- * Import application wide styles
- */
-import './assets/stylesheets/fabric8-ui-global-overrides.less';
-import './assets/stylesheets/shared/osio.less';
-
-/**
  * Bootstrap our Angular app with a top level NgModule
  */
 export function main(): Promise<any> {

--- a/packages/scripts/config/tsconfig/tsconfig.json
+++ b/packages/scripts/config/tsconfig/tsconfig.json
@@ -11,7 +11,7 @@
     "isolatedModules": false,
     "jsx": "react",
     "lib": ["dom", "es2015", "es2016", "es2017"],
-    "module": "es2015",
+    "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
The following changes were done while adding support for the new nav. Created a separate PR as these are the only files affected by the larger change that adds a new package for the react app.

* Support dynamic imports by setting `module` to `esnext` in tsconfig
* Moved style definitions in `fabric8-ui` from loader to `app.modules`
  * needed because the loader is not used with the react app, but the module is and we need the styles to load lazily with the module
* Removed tooltips which opened up, covering the nav bar. These tooltips had redundant text which added zero value.
* Fixed a cut off tab due to a bad margin style

Removed margin fix:
![image](https://user-images.githubusercontent.com/14068621/51080411-5c940780-16a9-11e9-9050-038ffb2fdb17.png)
![image](https://user-images.githubusercontent.com/14068621/51080418-69186000-16a9-11e9-974b-91277dfa86a2.png)

Removed these useless tooltips:
![image](https://user-images.githubusercontent.com/14068621/51080502-e42e4600-16aa-11e9-8fc2-a9b95472d991.png)
![image](https://user-images.githubusercontent.com/14068621/51080503-e8f2fa00-16aa-11e9-9594-2385ecb048e7.png)
![image](https://user-images.githubusercontent.com/14068621/51080446-ca403380-16a9-11e9-8f8b-6c5357d8c78e.png)
![image](https://user-images.githubusercontent.com/14068621/51080513-fdcf8d80-16aa-11e9-9820-741a73170688.png)



