### PR TITLE
fix(deployment): Use Build Tool Detector URL from config map

### DIFF
--- a/openshift/fabric8-ui.app.yaml
+++ b/openshift/fabric8-ui.app.yaml
@@ -54,6 +54,11 @@ objects:
                 configMapKeyRef:
                   name: f8ui
                   key:  analytics.license.url
+            - name: FABRIC8_BUILD_TOOL_DETECTOR_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: f8ui
+                  key: fabric8.build.tool.detector.api.url
             - name: WS_K8S_API_SERVER
               value: ${ws_k8s_api_server}
             - name: K8S_API_SERVER_PROTOCOL
@@ -67,8 +72,6 @@ objects:
               value: ${fabric8_feature_toggles_api_url}
             - name: FABRIC8_JENKINS_API_URL
               value: ${fabric8_jenkins_api_url}
-            - name: FABRIC8_BUILD_TOOL_DETECTOR_API_URL
-              value: ${fabric8_build_tool_detector_api_url}
             - name: OAUTH_ISSUER
               valueFrom:
                 configMapKeyRef:

--- a/openshift/fabric8-ui.app.yaml
+++ b/openshift/fabric8-ui.app.yaml
@@ -181,5 +181,3 @@ parameters:
   value: ''
 - name: fabric8_jenkins_api_url
   value: ''
-- name: fabric8_build_tool_detector_api_url
-  value: ''

--- a/openshift/fabric8-ui.config.yaml
+++ b/openshift/fabric8-ui.config.yaml
@@ -18,3 +18,4 @@ data:
   oauth.issuer: ""
   oauth.authorize.uri: ""
   oauth.logout.uri: ""
+  fabric8.build.tool.detector.api.url: ""


### PR DESCRIPTION
Use `BUILD_TOOL_DETECTOR` env value from config map instead of template params.