### PR TITLE
fix(nav): set feature toggle api url in env to wit url

### DIFF
--- a/packages/toolchain/env.js
+++ b/packages/toolchain/env.js
@@ -43,8 +43,8 @@ function getProductionEnv() {
 function getDevelopmentEnv() {
   const {
     FABRIC8_FORGE_API_URL = 'https://forge.api.prod-preview.openshift.io',
-    FABRIC8_FEATURE_TOGGLES_API_URL,
     FABRIC8_WIT_API_URL = 'https://prod-preview.openshift.io/api/',
+    FABRIC8_FEATURE_TOGGLES_API_URL = FABRIC8_WIT_API_URL,
     FABRIC8_REALM,
     FABRIC8_SSO_API_URL = 'https://sso.prod-preview.openshift.io/',
     FABRIC8_AUTH_API_URL = 'https://auth.prod-preview.openshift.io/api/',


### PR DESCRIPTION
After this PR - https://github.com/fabric8-ui/fabric8-ui/pull/3492, `getFeaturesUrl` was referencing to `FEATURE_TOGGLES_API_URL` which comes as undefined in dev environment since it was not set in env.js.
This is why in local env `getFeaturesUrl()` was returning `localhost:3000/api/features?strategy=enableByLevel`
