### PR TITLE
fix(env): assign wit url to feature toggles and add fallback to /api/

### DIFF
--- a/packages/toolchain/src/app/api/internal/__tests__/api.config.spec.ts
+++ b/packages/toolchain/src/app/api/internal/__tests__/api.config.spec.ts
@@ -3,16 +3,28 @@ describe('api.config', () => {
     jest.resetModules();
   });
 
+  it('should fallback to api URLs default', () => {
+    const bak = process.env;
+    process.env = {};
+
+    // eslint-disable-next-line
+    const config = require('../api.config');
+    expect(config.AUTH_API_URL).toBe('/api/');
+    expect(config.FEATURE_TOGGLES_API_URL).toBe('/api/');
+    expect(config.WIT_API_URL).toBe('/api/');
+
+    process.env = bak;
+  });
+
   it('should fallback to api URLs from process.env', () => {
     const bak = process.env;
     process.env.FABRIC8_AUTH_API_URL = 'test-auth-url';
-    process.env.FABRIC8_FEATURE_TOGGLES_API_URL = 'test-ft-url';
     process.env.FABRIC8_WIT_API_URL = 'test-wit-url';
 
     // eslint-disable-next-line
     const config = require('../api.config');
     expect(config.AUTH_API_URL).toBe('test-auth-url');
-    expect(config.FEATURE_TOGGLES_API_URL).toBe('test-ft-url');
+    expect(config.FEATURE_TOGGLES_API_URL).toBe('test-wit-url');
     expect(config.WIT_API_URL).toBe('test-wit-url');
 
     process.env = bak;
@@ -23,13 +35,12 @@ describe('api.config', () => {
     (window as any).Fabric8UIEnv = {
       authApiUrl: 'test-auth-url',
       witApiUrl: 'test-wit-url',
-      featureTogglesApiUrl: 'test-ft-url',
     };
 
     // eslint-disable-next-line
     const config = require('../api.config');
     expect(config.AUTH_API_URL).toBe('test-auth-url');
-    expect(config.FEATURE_TOGGLES_API_URL).toBe('test-ft-url');
+    expect(config.FEATURE_TOGGLES_API_URL).toBe('test-wit-url');
     expect(config.WIT_API_URL).toBe('test-wit-url');
 
     (window as any).Fabric8UIEnv = bak;

--- a/packages/toolchain/src/app/api/internal/api.config.ts
+++ b/packages/toolchain/src/app/api/internal/api.config.ts
@@ -1,7 +1,7 @@
-const { FABRIC8_AUTH_API_URL, FABRIC8_FEATURE_TOGGLES_API_URL, FABRIC8_WIT_API_URL } = process.env;
+const { FABRIC8_AUTH_API_URL, FABRIC8_WIT_API_URL } = process.env;
 
+const DEFAULT_URL = '/api/';
 const config: { [key: string]: string } = (window as any).Fabric8UIEnv || {};
-export const AUTH_API_URL = config.authApiUrl || FABRIC8_AUTH_API_URL;
-export const FEATURE_TOGGLES_API_URL =
-  config.featureTogglesApiUrl || FABRIC8_FEATURE_TOGGLES_API_URL;
-export const WIT_API_URL = config.witApiUrl || FABRIC8_WIT_API_URL;
+export const AUTH_API_URL = config.authApiUrl || FABRIC8_AUTH_API_URL || DEFAULT_URL;
+export const WIT_API_URL = config.witApiUrl || FABRIC8_WIT_API_URL || DEFAULT_URL;
+export const FEATURE_TOGGLES_API_URL = WIT_API_URL;

--- a/packages/toolchain/webpack.config.js
+++ b/packages/toolchain/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = function() {
               transform(content) {
                 return content
                   .toString('utf-8')
-                  .replace(/{{ .Env.([a-zA-Z0-9_-]*) }}/g, (match, p1) => process.env[p1]);
+                  .replace(/{{ .Env.([a-zA-Z0-9_-]*) }}/g, (match, p1) => process.env[p1] || '');
               },
             },
           ]),


### PR DESCRIPTION
The `api-locator.service.ts` in the angular app does not expose any URL which uses the `FABRIC8_FEATURE_TOGGLES_API_URL` env variable. The `toggles.api.provider.ts` provides the wit api url for feature toggles.

Using `FABRIC8_FEATURE_TOGGLES_API_URL` breaks the react app in prod preview today because the URL is incorrect. Furthermore, in production, the `fabric8-ui.env.js` file doesn't even include a value for the feature toggles. Most URLs are empty. Which means we need to add a default fallback to `/api/` just like the `api-locator.service.ts` does.

The result of not having this fix is that on prod-preview, the react app queries for features at `https://api.prod-preview.openshift.io/api/features?strategy=enableByLevel` while the angular app queries `https://prod-preview.openshift.io/api/features?strategy=enableByLevel`. The value the react app gets is invalid and does not include the correct user enablement settings for whatever reason.

We should fix the URL in prod-proview env, but for now this change aligns the react and angular apps in how they provide api URLs.