### PR TITLE
fix(deployment): `resources` user settings link returns 404 error page

### DIFF
--- a/packages/fabric8-ui/src/app/profile/settings/settings.component.html
+++ b/packages/fabric8-ui/src/app/profile/settings/settings.component.html
@@ -9,9 +9,6 @@
     <li routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
       <a [routerLink]="['/' + loggedInUserName + '/_settings/feature-opt-in']"> Features Opt-in </a>
     </li>
-    <li routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
-      <a [routerLink]="['/' + loggedInUserName + '/_settings/resources']"> Resources </a>
-    </li>
   </ul>
 </div>
 <router-outlet></router-outlet>


### PR DESCRIPTION
fixes issue https://github.com/openshiftio/openshift.io/issues/4748

Removed the sub-nav link to the `Resources` page which no longer exists.
![image](https://user-images.githubusercontent.com/14068621/52235729-f5760700-2892-11e9-8921-f7b876de46c7.png)
