### PR TITLE
fix(api-url): add auth api url in openshift config map

### DIFF
--- a/openshift/fabric8-ui.app.yaml
+++ b/openshift/fabric8-ui.app.yaml
@@ -54,6 +54,11 @@ objects:
                 configMapKeyRef:
                   name: f8ui
                   key:  analytics.license.url
+            - name: FABRIC8_AUTH_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: f8ui
+                  key:  auth.api.url
             - name: FABRIC8_BUILD_TOOL_DETECTOR_API_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4757

- Adds a config map in the openshift deployment config for `FABRIC8_AUTH_API_URL`.
- Currently i have updated prod-preview config maps. So this issue is solved but before pushing new navigation to prod we need this issue - https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/2560 closed so that logout works from new navigation as well. 